### PR TITLE
feat: add package and version command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.10"
+          - "3.14"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project and development tools
+        run: python -m pip install ".[dev]"
+
+      - name: Check lint
+        run: ruff check .
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Check types
+        run: mypy
+
+      - name: Run tests
+        run: python -m unittest discover -s tests -v
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Install built wheel
+        run: >-
+          python -c "import glob, subprocess, sys;
+          wheels = glob.glob('dist/*.whl');
+          assert len(wheels) == 1, wheels;
+          subprocess.run([sys.executable, '-m', 'pip', 'install', '--force-reinstall',
+          '--no-deps', wheels[0]], check=True)"
+
+      - name: Verify installed wheel
+        run: >-
+          python -m unittest discover -s tests -v
+          && sb --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Initial project contract and contribution workflow.
+- Installable `silobrief` package and `sb --version` command.

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,6 +9,19 @@ siloBrief는 Python 프로젝트에서 공개 가능한 맥락을 골라, 사람
 현재는 출시 전 개발 단계입니다. v0.1 동작은
 [`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md)에 고정되어 있습니다.
 
+현재 개발 빌드는 로컬 설치 후 버전 명령을 제공합니다.
+
+```console
+python -m pip install .
+sb --version
+```
+
+예상 출력:
+
+```text
+siloBrief 0.1.0
+```
+
 ## 범위와 한계
 
 - Python 3.10 이상, Windows와 Ubuntu

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ internet access are separated.
 The project is in pre-release development. Its frozen v0.1 behavior is documented in
 [`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md).
 
+The current development build exposes its version command after a local install:
+
+```console
+python -m pip install .
+sb --version
+```
+
+Expected output:
+
+```text
+siloBrief 0.1.0
+```
+
 ## Boundaries
 
 - Python 3.10 or newer on Windows and Ubuntu
@@ -27,4 +40,3 @@ The project accepts changes through an Issue and a pull request to `develop`. Re
 ## License
 
 Apache License 2.0. See [`LICENSE`](LICENSE).
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "silobrief"
+version = "0.1.0"
+description = "Create reviewed research briefs from Python project context"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [{ name = "d3vksy" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "build>=1.2",
+    "mypy>=1.15",
+    "ruff>=0.11",
+]
+
+[project.scripts]
+sb = "silobrief.cli:main"
+
+[project.urls]
+Repository = "https://github.com/d3vksy/silobrief"
+Issues = "https://github.com/d3vksy/silobrief/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+silobrief = ["py.typed"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+files = ["src", "tests"]

--- a/src/silobrief/__init__.py
+++ b/src/silobrief/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+
+__version__: str = version("silobrief")
+
+__all__ = ["__version__"]

--- a/src/silobrief/__main__.py
+++ b/src/silobrief/__main__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from silobrief.cli import main
+
+raise SystemExit(main())

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from silobrief import __version__
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sb",
+        description="Create a reviewed research brief from Python project context.",
+    )
+    parser.add_argument("--version", action="version", version=f"siloBrief {__version__}")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    _build_parser().parse_args(argv)
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import unittest
+from importlib.metadata import version
+
+from silobrief import __version__
+from silobrief.cli import main
+
+
+class VersionCommandTests(unittest.TestCase):
+    def test_version_uses_installed_package_metadata(self) -> None:
+        self.assertEqual(__version__, version("silobrief"))
+
+    def test_version_prints_public_product_name(self) -> None:
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), self.assertRaises(SystemExit) as caught:
+            main(["--version"])
+
+        self.assertEqual(caught.exception.code, 0)
+        self.assertEqual(stdout.getvalue(), "siloBrief 0.1.0\n")

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+from importlib.metadata import distribution
+from pathlib import Path
+
+import silobrief
+
+
+class PackageMetadataTests(unittest.TestCase):
+    def test_distribution_has_no_runtime_dependencies(self) -> None:
+        requirements = distribution("silobrief").requires or []
+
+        self.assertTrue(
+            all('extra == "dev"' in requirement for requirement in requirements),
+            requirements,
+        )
+
+    def test_distribution_includes_typing_marker(self) -> None:
+        package_file = silobrief.__file__
+        assert package_file is not None
+
+        self.assertTrue(Path(package_file).with_name("py.typed").is_file())


### PR DESCRIPTION
Refs #3

## 변경 이유

후속 기능이 공통으로 사용할 설치 가능한 Python 패키지와 최소 CLI 계약을 먼저 확정합니다.

## 변경 내용

- PEP 621·setuptools 기반 `pyproject.toml`을 추가했습니다.
- typed package와 `sb` console script를 추가했습니다.
- 배포 metadata에서 버전을 읽어 `siloBrief 0.1.0`을 출력합니다.
- wheel에 `py.typed`를 포함하고 런타임 의존성을 0개로 유지합니다.
- Ubuntu·Windows × Python 3.10·3.14 CI를 추가했습니다.
- 영문·한국어 README와 CHANGELOG를 갱신했습니다.

## 검증

- 테스트를 구현 전에 실행해 `ModuleNotFoundError` 실패를 확인했습니다.
- 로컬 `ruff check .`, format check, `mypy`, unittest 4개: 통과
- 로컬 wheel·sdist build 및 wheel 재설치: 통과
- 프로젝트 밖 임시 디렉터리에서 `sb --version`: `siloBrief 0.1.0`
- `py.typed` 포함 및 런타임 의존성 0개 검사: 통과
- GitHub Actions run 30758244433: Ubuntu·Windows × Python 3.10·3.14 네 job 모두 통과

## 제외 범위와 남은 제한

`setup`, `ignore`, `init`, `log`, `chat`, 배포 업로드와 릴리스 자동화는 포함하지 않습니다.