### PR TITLE
feat: initialize project state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial project contract and contribution workflow.
 - Installable `silobrief` package and `sb --version` command.
+- Deterministic and idempotent project initialization with `sb setup`.

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,6 +22,16 @@ sb --version
 siloBrief 0.1.0
 ```
 
+현재 디렉터리 또는 지정한 기존 프로젝트 디렉터리에 로컬 상태를 초기화합니다.
+
+```console
+sb setup [PATH]
+```
+
+이 명령은 `.silobrief/config.json`, `.silobrief/notes.json`, `.silobrief/exports/`를
+만듭니다. 다시 실행하면 기존 상태를 덮어쓰지 않고 호환 여부만 검사합니다. 인덱스는
+아직 구현되지 않은 `sb init`에서 생성합니다.
+
 ## 범위와 한계
 
 - Python 3.10 이상, Windows와 Ubuntu

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Expected output:
 siloBrief 0.1.0
 ```
 
+Initialize local state in the current directory or an existing project directory:
+
+```console
+sb setup [PATH]
+```
+
+This creates `.silobrief/config.json`, `.silobrief/notes.json`, and
+`.silobrief/exports/`. Running the command again validates compatible state without
+overwriting it. The index is created later by `sb init`, which is not implemented yet.
+
 ## Boundaries
 
 - Python 3.10 or newer on Windows and Ubuntu

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
+from pathlib import Path
 
 from silobrief import __version__
+from silobrief.state import SetupError, setup_project
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -12,9 +14,23 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Create a reviewed research brief from Python project context.",
     )
     parser.add_argument("--version", action="version", version=f"siloBrief {__version__}")
+    subcommands = parser.add_subparsers(dest="command")
+    setup = subcommands.add_parser("setup", help="Initialize local project state.")
+    setup.add_argument("path", nargs="?", type=Path, default=Path.cwd())
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    _build_parser().parse_args(argv)
+    parser = _build_parser()
+    arguments = parser.parse_args(argv)
+
+    if arguments.command == "setup":
+        project = arguments.path
+        if not isinstance(project, Path):
+            parser.error("setup path must be a filesystem path")
+        try:
+            setup_project(project)
+        except SetupError as error:
+            parser.error(str(error))
+
     return 0

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TypedDict
+
+STATE_DIRECTORY = ".silobrief"
+DEFAULT_EXCLUDES = (
+    ".git/",
+    ".silobrief/",
+    "__pycache__/",
+    ".venv/",
+    "venv/",
+    "build/",
+    "dist/",
+)
+
+
+class SetupError(Exception):
+    pass
+
+
+class _ConfigData(TypedDict):
+    boundaries: list[object]
+    default_excludes: list[str]
+    schema_version: int
+
+
+class _NotesData(TypedDict):
+    notes: list[object]
+    notes_version: int
+
+
+def setup_project(project: Path) -> None:
+    root = _project_root(project)
+    state = root / STATE_DIRECTORY
+
+    if state.exists() or state.is_symlink():
+        _validate_state(state)
+        return
+
+    try:
+        state.mkdir()
+    except FileExistsError:
+        _validate_state(state)
+        return
+    except OSError as error:
+        raise SetupError(f"cannot create {STATE_DIRECTORY}: {error}") from error
+
+    try:
+        (state / "exports").mkdir()
+        _write_json(
+            state / "config.json",
+            _ConfigData(
+                boundaries=[],
+                default_excludes=list(DEFAULT_EXCLUDES),
+                schema_version=1,
+            ),
+        )
+        _write_json(state / "notes.json", _NotesData(notes=[], notes_version=1))
+    except OSError as error:
+        shutil.rmtree(state, ignore_errors=True)
+        raise SetupError(f"cannot initialize {STATE_DIRECTORY}: {error}") from error
+
+
+def _project_root(project: Path) -> Path:
+    if project.is_symlink():
+        raise SetupError("project root must not be a symbolic link")
+    if not project.is_dir():
+        raise SetupError("project root must be an existing directory")
+
+    try:
+        return project.resolve(strict=True)
+    except OSError as error:
+        raise SetupError(f"cannot resolve project root: {error}") from error
+
+
+def _write_json(path: Path, value: _ConfigData | _NotesData) -> None:
+    content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def _validate_state(state: Path) -> None:
+    if state.is_symlink() or not state.is_dir():
+        raise SetupError(f"{STATE_DIRECTORY} must be a real directory")
+
+    config = _read_object(state / "config.json")
+    if set(config) != {"boundaries", "default_excludes", "schema_version"}:
+        raise SetupError("config.json has an incompatible schema")
+    if config["schema_version"] != 1:
+        raise SetupError("config.json has an unsupported schema version")
+    if not isinstance(config["boundaries"], list):
+        raise SetupError("config.json boundaries must be an array")
+    excludes = config["default_excludes"]
+    if not isinstance(excludes, list) or not all(isinstance(item, str) for item in excludes):
+        raise SetupError("config.json default_excludes must be a string array")
+    if tuple(excludes) != DEFAULT_EXCLUDES:
+        raise SetupError("config.json default exclusions do not match version 1")
+
+    notes = _read_object(state / "notes.json")
+    if set(notes) != {"notes", "notes_version"}:
+        raise SetupError("notes.json has an incompatible schema")
+    if notes["notes_version"] != 1 or not isinstance(notes["notes"], list):
+        raise SetupError("notes.json is not compatible with version 1")
+
+    exports = state / "exports"
+    if exports.is_symlink() or not exports.is_dir():
+        raise SetupError("exports must be a real directory")
+
+    index = state / "index.json"
+    if index.exists() or index.is_symlink():
+        index_data = _read_object(index)
+        if index_data.get("index_version") != 1:
+            raise SetupError("index.json is not compatible with version 1")
+
+
+def _read_object(path: Path) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise SetupError(f"{path.name} must be a real file")
+
+    try:
+        value: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SetupError(f"cannot read {path.name}: {error}") from error
+    if not isinstance(value, dict):
+        raise SetupError(f"{path.name} must contain a JSON object")
+
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise SetupError(f"{path.name} contains a non-string key")
+        result[key] = item
+    return result

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -88,7 +88,7 @@ def _validate_state(state: Path) -> None:
     config = _read_object(state / "config.json")
     if set(config) != {"boundaries", "default_excludes", "schema_version"}:
         raise SetupError("config.json has an incompatible schema")
-    if config["schema_version"] != 1:
+    if not _is_version_one(config["schema_version"]):
         raise SetupError("config.json has an unsupported schema version")
     if not isinstance(config["boundaries"], list):
         raise SetupError("config.json boundaries must be an array")
@@ -101,7 +101,7 @@ def _validate_state(state: Path) -> None:
     notes = _read_object(state / "notes.json")
     if set(notes) != {"notes", "notes_version"}:
         raise SetupError("notes.json has an incompatible schema")
-    if notes["notes_version"] != 1 or not isinstance(notes["notes"], list):
+    if not _is_version_one(notes["notes_version"]) or not isinstance(notes["notes"], list):
         raise SetupError("notes.json is not compatible with version 1")
 
     exports = state / "exports"
@@ -111,8 +111,12 @@ def _validate_state(state: Path) -> None:
     index = state / "index.json"
     if index.exists() or index.is_symlink():
         index_data = _read_object(index)
-        if index_data.get("index_version") != 1:
+        if not _is_version_one(index_data.get("index_version")):
             raise SetupError("index.json is not compatible with version 1")
+
+
+def _is_version_one(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value == 1
 
 
 def _read_object(path: Path) -> dict[str, object]:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+
+from silobrief.cli import main
+
+DEFAULT_EXCLUDES = [
+    ".git/",
+    ".silobrief/",
+    "__pycache__/",
+    ".venv/",
+    "venv/",
+    "build/",
+    "dist/",
+]
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+class SetupCommandTests(unittest.TestCase):
+    def test_setup_creates_initial_state_without_changing_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "service.py"
+            source.write_text("VALUE = 1\n", encoding="utf-8", newline="\n")
+            source_digest = hashlib.sha256(source.read_bytes()).digest()
+
+            result = main(["setup", str(project)])
+
+            state = project / ".silobrief"
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                json.loads((state / "config.json").read_text(encoding="utf-8")),
+                {
+                    "boundaries": [],
+                    "default_excludes": DEFAULT_EXCLUDES,
+                    "schema_version": 1,
+                },
+            )
+            self.assertEqual(
+                json.loads((state / "notes.json").read_text(encoding="utf-8")),
+                {"notes": [], "notes_version": 1},
+            )
+            self.assertTrue((state / "exports").is_dir())
+            self.assertFalse((state / "index.json").exists())
+            self.assertEqual(hashlib.sha256(source.read_bytes()).digest(), source_digest)
+            self.assertNotIn(b"\r\n", (state / "config.json").read_bytes())
+            self.assertTrue((state / "config.json").read_bytes().endswith(b"\n"))
+
+    def test_setup_defaults_to_current_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+
+            with working_directory(project):
+                result = main(["setup"])
+
+            self.assertEqual(result, 0)
+            self.assertTrue((project / ".silobrief" / "config.json").is_file())
+
+    def test_setup_keeps_valid_state_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(main(["setup", str(project)]), 0)
+            state = project / ".silobrief"
+            tracked = [state / "config.json", state / "notes.json", state / "exports"]
+            fixed_time = 1_700_000_000_000_000_000
+            for path in tracked:
+                os.utime(path, ns=(fixed_time, fixed_time))
+            before = [
+                (path.read_bytes() if path.is_file() else b"", path.stat().st_mtime_ns)
+                for path in tracked
+            ]
+
+            result = main(["setup", str(project)])
+
+            after = [
+                (path.read_bytes() if path.is_file() else b"", path.stat().st_mtime_ns)
+                for path in tracked
+            ]
+            self.assertEqual(result, 0)
+            self.assertEqual(after, before)
+
+    def test_setup_rejects_missing_path_and_regular_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            regular_file = root / "project.py"
+            regular_file.write_text("pass\n", encoding="utf-8", newline="\n")
+
+            for invalid_path in (root / "missing", regular_file):
+                with self.subTest(path=invalid_path), contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit) as caught:
+                        main(["setup", str(invalid_path)])
+
+                self.assertEqual(caught.exception.code, 2)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from collections.abc import Iterator
 from pathlib import Path
+from unittest import mock
 
 from silobrief.cli import main
 
@@ -34,6 +35,13 @@ def working_directory(path: Path) -> Iterator[None]:
 
 
 class SetupCommandTests(unittest.TestCase):
+    def assert_setup_error(self, project: Path) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main(["setup", str(project)])
+        self.assertEqual(caught.exception.code, 2)
+        return stderr.getvalue()
+
     def test_setup_creates_initial_state_without_changing_source(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             project = Path(directory)
@@ -60,8 +68,20 @@ class SetupCommandTests(unittest.TestCase):
             self.assertTrue((state / "exports").is_dir())
             self.assertFalse((state / "index.json").exists())
             self.assertEqual(hashlib.sha256(source.read_bytes()).digest(), source_digest)
-            self.assertNotIn(b"\r\n", (state / "config.json").read_bytes())
-            self.assertTrue((state / "config.json").read_bytes().endswith(b"\n"))
+            expected_config = (
+                json.dumps(
+                    {
+                        "boundaries": [],
+                        "default_excludes": DEFAULT_EXCLUDES,
+                        "schema_version": 1,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n"
+            ).encode()
+            self.assertEqual((state / "config.json").read_bytes(), expected_config)
 
     def test_setup_defaults_to_current_directory(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -103,8 +123,107 @@ class SetupCommandTests(unittest.TestCase):
             regular_file.write_text("pass\n", encoding="utf-8", newline="\n")
 
             for invalid_path in (root / "missing", regular_file):
-                with self.subTest(path=invalid_path), contextlib.redirect_stderr(io.StringIO()):
-                    with self.assertRaises(SystemExit) as caught:
-                        main(["setup", str(invalid_path)])
+                with self.subTest(path=invalid_path):
+                    self.assert_setup_error(invalid_path)
 
-                self.assertEqual(caught.exception.code, 2)
+    def test_setup_rejects_symbolic_link_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            project.mkdir()
+            link = root / "project-link"
+            try:
+                link.symlink_to(project, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"symbolic links unavailable: {error}")
+
+            message = self.assert_setup_error(link)
+
+            self.assertIn("symbolic link", message)
+            self.assertFalse((project / ".silobrief").exists())
+
+            state_link_project = root / "state-link-project"
+            state_link_project.mkdir()
+            state_link = state_link_project / ".silobrief"
+            state_link.symlink_to(project, target_is_directory=True)
+
+            message = self.assert_setup_error(state_link_project)
+
+            self.assertIn("real directory", message)
+            self.assertEqual(list(project.iterdir()), [])
+
+    def test_setup_rejects_state_file_and_partial_state_without_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_file_project = root / "state-file"
+            state_file_project.mkdir()
+            state_file = state_file_project / ".silobrief"
+            state_file.write_bytes(b"do not replace\n")
+
+            self.assert_setup_error(state_file_project)
+            self.assertEqual(state_file.read_bytes(), b"do not replace\n")
+
+            partial_project = root / "partial"
+            partial_project.mkdir()
+            self.assertEqual(main(["setup", str(partial_project)]), 0)
+            partial_state = partial_project / ".silobrief"
+            partial_config = partial_state / "config.json"
+            config_before = partial_config.read_bytes()
+            (partial_state / "notes.json").unlink()
+
+            self.assert_setup_error(partial_project)
+            self.assertEqual(partial_config.read_bytes(), config_before)
+            self.assertFalse((partial_state / "notes.json").exists())
+
+    def test_setup_rejects_corrupt_and_incompatible_config_without_changes(self) -> None:
+        valid_with_boolean_version = json.dumps(
+            {
+                "boundaries": [],
+                "default_excludes": DEFAULT_EXCLUDES,
+                "schema_version": True,
+            },
+            sort_keys=True,
+        ).encode()
+        cases = {
+            "corrupt": b"{\n",
+            "not-an-object": b"[]\n",
+            "boolean-version": valid_with_boolean_version,
+        }
+
+        for name, replacement in cases.items():
+            with self.subTest(case=name), tempfile.TemporaryDirectory() as directory:
+                project = Path(directory)
+                self.assertEqual(main(["setup", str(project)]), 0)
+                config = project / ".silobrief" / "config.json"
+                config.write_bytes(replacement)
+
+                self.assert_setup_error(project)
+
+                self.assertEqual(config.read_bytes(), replacement)
+
+    def test_setup_rejects_incompatible_notes_and_index_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(main(["setup", str(project)]), 0)
+            state = project / ".silobrief"
+            notes = state / "notes.json"
+            notes.write_text('{"notes": [], "notes_version": true}\n', encoding="utf-8")
+
+            self.assert_setup_error(project)
+
+            notes.write_text('{"notes": [], "notes_version": 1}\n', encoding="utf-8")
+            index = state / "index.json"
+            index.write_text('{"index_version": 2}\n', encoding="utf-8")
+
+            self.assert_setup_error(project)
+            self.assertEqual(index.read_text(encoding="utf-8"), '{"index_version": 2}\n')
+
+    def test_setup_removes_new_state_after_write_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+
+            with mock.patch("silobrief.state.Path.write_text", side_effect=OSError("disk full")):
+                message = self.assert_setup_error(project)
+
+            self.assertIn("cannot initialize", message)
+            self.assertFalse((project / ".silobrief").exists())


### PR DESCRIPTION
Refs #5

## 변경 이유

후속 명령이 사용할 로컬 상태를 기존 프로젝트 파일 변경 없이 결정적으로 초기화해야 합니다.

## 변경 내용

- `sb setup [PATH]`와 현재 디렉터리 기본값을 추가했습니다.
- schema version 1의 `config.json`, notes version 1의 `notes.json`, `exports/`를 생성합니다.
- 기본 제외 규칙 일곱 개를 고정된 순서로 기록합니다.
- 기존 유효 상태에서는 파일과 mtime을 바꾸지 않습니다.
- symlink 루트·상태, 일반 파일 충돌, 부분·손상 상태와 호환되지 않는 version을 거부합니다.
- 생성 중 파일 쓰기가 실패하면 새로 만든 불완전 상태를 제거합니다.
- JSON의 `true`가 정수 version 1로 허용되던 결함을 수정했습니다.
- 영문·한국어 README와 CHANGELOG를 갱신했습니다.

## 검증

- 구현 전 targeted test에서 미지원 `setup`으로 3개 실패를 확인했습니다.
- 방어 테스트에서 boolean version 오인식 실패 2개를 확인한 뒤 수정했습니다.
- 로컬 Ruff lint·format, mypy strict: 통과
- 로컬 전체 unittest 13개: 12개 통과, Windows 권한상 실제 symlink 1개 skip
- wheel·sdist build 및 wheel 재설치: 통과
- 설치된 `sb setup` 임시 프로젝트 smoke test: 통과
- GitHub Actions run 30758900581: Ubuntu·Windows × Python 3.10·3.14 네 job 모두 통과
- Ubuntu 3.10 로그: symlink 테스트가 두 차례 실행되어 모두 통과했고 skip 없음

## 제외 범위와 남은 제한

로컬 Windows에서는 symlink 생성 권한이 없어 해당 실제 파일시스템 테스트를 실행하지 못했으며 Ubuntu CI로 보완했습니다. `ignore`, `init`, `log`, `chat`과 `index.json` 생성은 포함하지 않습니다.