### PR TITLE
feat: collect safe source snapshots

### DIFF
--- a/src/silobrief/sources.py
+++ b/src/silobrief/sources.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from silobrief.state import ConfigData
+
+_DIGEST_DOMAIN = b"silobrief-source-snapshot-v1\0"
+
+
+class SourceCollectionError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SourceFile:
+    path: str
+    content: bytes
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceWarning:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSnapshot:
+    files: tuple[SourceFile, ...]
+    warnings: tuple[SourceWarning, ...]
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceChanges:
+    added: tuple[str, ...]
+    removed: tuple[str, ...]
+    modified: tuple[str, ...]
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.removed or self.modified)
+
+
+def snapshot_sources(root: Path, config: ConfigData) -> SourceSnapshot:
+    project = _validated_root(root)
+    default_excludes = frozenset(item.removesuffix("/") for item in config["default_excludes"])
+    boundaries = tuple(item["path"] for item in config["boundaries"])
+    files: list[SourceFile] = []
+    warnings: list[SourceWarning] = []
+
+    _walk_sources(
+        project,
+        "",
+        default_excludes=default_excludes,
+        boundaries=boundaries,
+        files=files,
+        warnings=warnings,
+    )
+    files.sort(key=lambda source: source.path)
+    warnings.sort(key=lambda warning: (warning.path, warning.reason))
+    frozen_files = tuple(files)
+    return SourceSnapshot(
+        files=frozen_files,
+        warnings=tuple(warnings),
+        digest=_snapshot_digest(frozen_files),
+    )
+
+
+def compare_snapshots(before: SourceSnapshot, after: SourceSnapshot) -> SourceChanges:
+    before_files = {source.path: source.sha256 for source in before.files}
+    after_files = {source.path: source.sha256 for source in after.files}
+    before_paths = set(before_files)
+    after_paths = set(after_files)
+    return SourceChanges(
+        added=tuple(sorted(after_paths - before_paths)),
+        removed=tuple(sorted(before_paths - after_paths)),
+        modified=tuple(
+            path
+            for path in sorted(before_paths & after_paths)
+            if before_files[path] != after_files[path]
+        ),
+    )
+
+
+def _validated_root(root: Path) -> Path:
+    if root.is_symlink() or not root.is_dir():
+        raise SourceCollectionError("project root must be a real directory")
+    try:
+        return root.resolve(strict=True)
+    except OSError as error:
+        raise SourceCollectionError(
+            f"cannot resolve project root: {_error_reason(error)}"
+        ) from error
+
+
+def _walk_sources(
+    directory: Path,
+    relative_directory: str,
+    *,
+    default_excludes: frozenset[str],
+    boundaries: tuple[str, ...],
+    files: list[SourceFile],
+    warnings: list[SourceWarning],
+) -> None:
+    try:
+        metadata = directory.stat(follow_symlinks=False)
+    except OSError as error:
+        label = relative_directory or "."
+        raise SourceCollectionError(
+            f"cannot inspect source directory {label}: {_error_reason(error)}"
+        ) from error
+    if stat.S_ISLNK(metadata.st_mode):
+        warnings.append(SourceWarning(path=relative_directory, reason="symbolic link skipped"))
+        return
+    if not stat.S_ISDIR(metadata.st_mode):
+        label = relative_directory or "."
+        raise SourceCollectionError(f"source directory changed during traversal: {label}")
+
+    try:
+        with os.scandir(directory) as iterator:
+            entries = sorted(iterator, key=lambda entry: entry.name)
+    except OSError as error:
+        label = relative_directory or "."
+        raise SourceCollectionError(
+            f"cannot scan source directory {label}: {_error_reason(error)}"
+        ) from error
+
+    for entry in entries:
+        relative_path = _join_path(relative_directory, entry.name)
+        if _is_excluded(relative_path, entry.name, default_excludes, boundaries):
+            continue
+        try:
+            if entry.is_symlink():
+                warnings.append(SourceWarning(path=relative_path, reason="symbolic link skipped"))
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                _walk_sources(
+                    Path(entry.path),
+                    relative_path,
+                    default_excludes=default_excludes,
+                    boundaries=boundaries,
+                    files=files,
+                    warnings=warnings,
+                )
+                continue
+            if relative_path.endswith(".py") and entry.is_file(follow_symlinks=False):
+                files.append(_read_regular_source(Path(entry.path), relative_path))
+        except OSError as error:
+            raise SourceCollectionError(
+                f"cannot inspect source entry {relative_path}: {_error_reason(error)}"
+            ) from error
+
+
+def _is_excluded(
+    relative_path: str,
+    name: str,
+    default_excludes: frozenset[str],
+    boundaries: tuple[str, ...],
+) -> bool:
+    if name in default_excludes:
+        return True
+    return any(
+        boundary == "." or relative_path == boundary or relative_path.startswith(f"{boundary}/")
+        for boundary in boundaries
+    )
+
+
+def _read_regular_source(path: Path, relative_path: str) -> SourceFile:
+    try:
+        before = path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(before.st_mode):
+            raise SourceCollectionError(f"source entry changed before read: {relative_path}")
+        with path.open("rb") as stream:
+            content = stream.read()
+            opened = os.fstat(stream.fileno())
+        after = path.stat(follow_symlinks=False)
+    except SourceCollectionError:
+        raise
+    except OSError as error:
+        raise SourceCollectionError(
+            f"cannot read source file {relative_path}: {_error_reason(error)}"
+        ) from error
+
+    if not _same_file_state(before, opened) or not _same_file_state(opened, after):
+        raise SourceCollectionError(f"source file changed while being read: {relative_path}")
+    return SourceFile(
+        path=relative_path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def _same_file_state(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        stat.S_ISREG(left.st_mode)
+        and stat.S_ISREG(right.st_mode)
+        and left.st_dev == right.st_dev
+        and left.st_ino == right.st_ino
+        and left.st_size == right.st_size
+        and left.st_mtime_ns == right.st_mtime_ns
+    )
+
+
+def _snapshot_digest(files: tuple[SourceFile, ...]) -> str:
+    digest = hashlib.sha256(_DIGEST_DOMAIN)
+    for source in files:
+        path_bytes = source.path.encode("utf-8")
+        digest.update(len(path_bytes).to_bytes(8, byteorder="big"))
+        digest.update(path_bytes)
+        digest.update(bytes.fromhex(source.sha256))
+    return digest.hexdigest()
+
+
+def _join_path(parent: str, name: str) -> str:
+    return f"{parent}/{name}" if parent else name
+
+
+def _error_reason(error: OSError) -> str:
+    return error.strerror or type(error).__name__

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+from unittest import mock
+
+import silobrief.sources as sources
+from silobrief.boundaries import register_boundary
+from silobrief.sources import SourceWarning, compare_snapshots, snapshot_sources
+from silobrief.state import load_config, setup_project
+
+
+def file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class SourceSnapshotTests(unittest.TestCase):
+    def test_snapshot_skips_excluded_trees_before_scan_or_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "package").mkdir()
+            (project / "package" / "visible.py").write_text("VISIBLE = 1\n", encoding="utf-8")
+            (project / "allowed.py").write_text("ALLOWED = 1\n", encoding="utf-8")
+            (project / "notes.txt").write_text("not source\n", encoding="utf-8")
+            private = project / "private"
+            private.mkdir()
+            (private / "secret.py").write_text("BOUNDARY_CANARY\n", encoding="utf-8")
+            private_file = project / "private_file.py"
+            private_file.write_text("FILE_BOUNDARY_CANARY\n", encoding="utf-8")
+            build = project / "package" / "build"
+            build.mkdir()
+            (build / "generated.py").write_text("DEFAULT_CANARY\n", encoding="utf-8")
+            setup_project(project)
+            register_boundary("private", "Private implementation", "private-code", start=project)
+            register_boundary(
+                "private_file.py",
+                "Private source file",
+                "private-file",
+                start=project,
+            )
+            config = load_config(project)
+
+            with (
+                mock.patch("silobrief.sources.os.scandir", wraps=os.scandir) as scan,
+                mock.patch(
+                    "silobrief.sources._read_regular_source",
+                    wraps=sources._read_regular_source,
+                ) as read_source,
+            ):
+                snapshot = snapshot_sources(project, config)
+
+            scanned = {
+                Path(cast(str | os.PathLike[str], call.args[0])).relative_to(project).as_posix()
+                for call in scan.call_args_list
+            }
+            opened = {
+                Path(cast(Path, call.args[0])).relative_to(project).as_posix()
+                for call in read_source.call_args_list
+            }
+            self.assertEqual(
+                [source.path for source in snapshot.files], ["allowed.py", "package/visible.py"]
+            )
+            self.assertEqual(opened, {"allowed.py", "package/visible.py"})
+            self.assertNotIn("private", scanned)
+            self.assertNotIn("package/build", scanned)
+            self.assertNotIn(".silobrief", scanned)
+            collected = b"".join(source.content for source in snapshot.files)
+            self.assertNotIn(b"BOUNDARY_CANARY", collected)
+            self.assertNotIn(b"FILE_BOUNDARY_CANARY", collected)
+            self.assertNotIn(b"DEFAULT_CANARY", collected)
+
+    def test_snapshot_is_deterministic_and_uses_posix_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            package = project / "package"
+            package.mkdir()
+            (project / "z.py").write_bytes(b"VALUE = 26\n")
+            (project / "a.py").write_bytes(b"VALUE = 1\n")
+            (package / "module.py").write_bytes(b"VALUE = 2\n")
+            setup_project(project)
+            config = load_config(project)
+
+            first = snapshot_sources(project, config)
+            second = snapshot_sources(project, config)
+
+            self.assertEqual(first, second)
+            self.assertEqual(
+                [source.path for source in first.files],
+                ["a.py", "package/module.py", "z.py"],
+            )
+            self.assertEqual(
+                first.digest,
+                "492afd37cb3a7e918d1399bdf560cb72f46da2dd2a793ba80b0afb31efefa427",
+            )
+
+    def test_snapshot_digest_includes_relative_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "before.py"
+            source.write_bytes(b"VALUE = 1\n")
+            setup_project(project)
+            config = load_config(project)
+            before = snapshot_sources(project, config)
+
+            source.rename(project / "after.py")
+            after = snapshot_sources(project, config)
+            changes = compare_snapshots(before, after)
+
+            self.assertNotEqual(before.digest, after.digest)
+            self.assertEqual(changes.added, ("after.py",))
+            self.assertEqual(changes.removed, ("before.py",))
+            self.assertEqual(changes.modified, ())
+            self.assertTrue(changes.has_changes)
+
+    def test_compare_snapshots_reports_added_removed_and_modified_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "changed.py").write_bytes(b"VALUE = 1\n")
+            (project / "removed.py").write_bytes(b"VALUE = 2\n")
+            setup_project(project)
+            config = load_config(project)
+            before = snapshot_sources(project, config)
+
+            (project / "changed.py").write_bytes(b"VALUE = 3\n")
+            (project / "removed.py").unlink()
+            (project / "added.py").write_bytes(b"VALUE = 4\n")
+            after = snapshot_sources(project, config)
+            changes = compare_snapshots(before, after)
+
+            self.assertEqual(changes.added, ("added.py",))
+            self.assertEqual(changes.removed, ("removed.py",))
+            self.assertEqual(changes.modified, ("changed.py",))
+            self.assertTrue(changes.has_changes)
+            self.assertFalse(compare_snapshots(after, after).has_changes)
+
+    def test_snapshot_does_not_modify_source_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "service.py"
+            source.write_bytes(b"VALUE = 1\n")
+            setup_project(project)
+            config = load_config(project)
+            before = (file_digest(source), source.stat().st_mtime_ns)
+
+            snapshot_sources(project, config)
+
+            self.assertEqual((file_digest(source), source.stat().st_mtime_ns), before)
+
+    def test_snapshot_warns_about_symlinks_without_reading_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            project.mkdir()
+            outside_file = root / "outside.py"
+            outside_file.write_bytes(b"OUTSIDE_FILE_CANARY\n")
+            outside_directory = root / "outside-directory"
+            outside_directory.mkdir()
+            (outside_directory / "module.py").write_bytes(b"OUTSIDE_DIRECTORY_CANARY\n")
+            file_link = project / "linked.py"
+            directory_link = project / "linked-directory"
+            try:
+                file_link.symlink_to(outside_file)
+                directory_link.symlink_to(outside_directory, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"symbolic links unavailable: {error}")
+            setup_project(project)
+            config = load_config(project)
+
+            snapshot = snapshot_sources(project, config)
+
+            self.assertEqual(snapshot.files, ())
+            self.assertEqual(
+                snapshot.warnings,
+                (
+                    SourceWarning(path="linked-directory", reason="symbolic link skipped"),
+                    SourceWarning(path="linked.py", reason="symbolic link skipped"),
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -53,12 +53,16 @@ class SourceSnapshotTests(unittest.TestCase):
             ):
                 snapshot = snapshot_sources(project, config)
 
+            resolved_project = project.resolve()
             scanned = {
-                Path(cast(str | os.PathLike[str], call.args[0])).relative_to(project).as_posix()
+                Path(cast(str | os.PathLike[str], call.args[0]))
+                .resolve()
+                .relative_to(resolved_project)
+                .as_posix()
                 for call in scan.call_args_list
             }
             opened = {
-                Path(cast(Path, call.args[0])).relative_to(project).as_posix()
+                Path(cast(Path, call.args[0])).resolve().relative_to(resolved_project).as_posix()
                 for call in read_source.call_args_list
             }
             self.assertEqual(


### PR DESCRIPTION
## 변경 사항

- 기본 제외 디렉터리와 등록된 boundary를 파일 읽기 전에 적용합니다.
- 허용된 `.py` 파일만 POSIX 상대 경로 순서로 수집합니다.
- symlink를 따라가지 않고 상대 경로와 건너뛴 이유를 기록합니다.
- 파일별 SHA-256과 경로를 포함한 전체 source digest를 생성합니다.
- 두 스냅샷의 추가·삭제·수정 파일을 비교합니다.

## 이유

AST 파싱과 인덱스 저장 전에 공개 경계를 확실히 적용하고, 인덱싱 중 소스 변경 여부를 판단할 수 있는 결정적 입력 계층이 필요합니다.

## 영향

아직 `sb init` CLI에는 연결하지 않습니다. 다음 Issue의 Python 구조 추출기가 이 스냅샷의 메모리 내 소스 내용을 사용하게 됩니다.

## 검증

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `python -m unittest discover -s tests -v` (32 tests, Windows에서 symlink 권한 관련 3 tests skipped)
- `python -m build --no-isolation`

Refs #9