### PR TITLE
feat: extract Python source structures

### DIFF
--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from silobrief.sources import SourceFile, SourceSnapshot
+
+DefinitionKind: TypeAlias = Literal["class", "function"]
+
+
+class PythonParseError(Exception):
+    path: str
+    line: int | None
+    column: int | None
+    reason: str
+
+    def __init__(
+        self,
+        path: str,
+        line: int | None,
+        column: int | None,
+        reason: str,
+    ) -> None:
+        self.path = path
+        self.line = line
+        self.column = column
+        self.reason = reason
+        location = ":".join(
+            (
+                path,
+                str(line) if line is not None else "?",
+                str(column) if column is not None else "?",
+            )
+        )
+        super().__init__(f"cannot parse {location}: {reason}")
+
+
+@dataclass(frozen=True, slots=True)
+class Definition:
+    kind: DefinitionKind
+    name: str
+    qualified_name: str
+    is_async: bool
+    line: int
+    column: int
+
+
+@dataclass(frozen=True, slots=True)
+class ImportEntry:
+    module: str | None
+    name: str | None
+    alias: str | None
+    level: int
+    context: str | None
+    line: int
+    column: int
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolUse:
+    context: str | None
+    target: str
+    line: int
+    column: int
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleStructure:
+    path: str
+    definitions: tuple[Definition, ...]
+    imports: tuple[ImportEntry, ...]
+    calls: tuple[SymbolUse, ...]
+    references: tuple[SymbolUse, ...]
+
+
+def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
+    return tuple(
+        _extract_module(source)
+        for source in sorted(snapshot.files, key=lambda candidate: candidate.path)
+    )
+
+
+def _extract_module(source: SourceFile) -> ModuleStructure:
+    try:
+        tree = ast.parse(source.content, filename=source.path, mode="exec")
+    except SyntaxError as error:
+        raise PythonParseError(
+            path=source.path,
+            line=error.lineno,
+            column=error.offset,
+            reason=error.msg,
+        ) from error
+
+    visitor = _StructureVisitor()
+    visitor.visit(tree)
+    return ModuleStructure(
+        path=source.path,
+        definitions=tuple(visitor.definitions),
+        imports=tuple(visitor.imports),
+        calls=tuple(visitor.calls),
+        references=tuple(visitor.references),
+    )
+
+
+class _StructureVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.definitions: list[Definition] = []
+        self.imports: list[ImportEntry] = []
+        self.calls: list[SymbolUse] = []
+        self.references: list[SymbolUse] = []
+        self._contexts: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_definition(node, "class", is_async=False)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_definition(node, "function", is_async=False)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_definition(node, "function", is_async=True)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        line, column = _location(node)
+        for imported in node.names:
+            self.imports.append(
+                ImportEntry(
+                    module=imported.name,
+                    name=None,
+                    alias=imported.asname,
+                    level=0,
+                    context=self._context,
+                    line=line,
+                    column=column,
+                )
+            )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        line, column = _location(node)
+        for imported in node.names:
+            self.imports.append(
+                ImportEntry(
+                    module=node.module,
+                    name=imported.name,
+                    alias=imported.asname,
+                    level=node.level,
+                    context=self._context,
+                    line=line,
+                    column=column,
+                )
+            )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        target = _dotted_name(node.func)
+        if target is None:
+            self.visit(node.func)
+        else:
+            line, column = _location(node)
+            self.calls.append(SymbolUse(self._context, target, line, column))
+
+        for argument in node.args:
+            self.visit(argument)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if isinstance(node.ctx, ast.Load):
+            target = _dotted_name(node)
+            if target is not None:
+                line, column = _location(node)
+                self.references.append(SymbolUse(self._context, target, line, column))
+                return
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load):
+            line, column = _location(node)
+            self.references.append(SymbolUse(self._context, node.id, line, column))
+
+    def _visit_definition(
+        self,
+        node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+        kind: DefinitionKind,
+        *,
+        is_async: bool,
+    ) -> None:
+        qualified_name = f"{self._context}.{node.name}" if self._context else node.name
+        line, column = _location(node)
+        self.definitions.append(Definition(kind, node.name, qualified_name, is_async, line, column))
+        self._contexts.append(qualified_name)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._contexts.pop()
+
+    @property
+    def _context(self) -> str | None:
+        return self._contexts[-1] if self._contexts else None
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    parts.reverse()
+    return ".".join(parts)
+
+
+def _location(node: ast.stmt | ast.expr) -> tuple[int, int]:
+    return node.lineno, node.col_offset + 1

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import hashlib
+import unittest
+from unittest import mock
+
+from silobrief.python_structure import (
+    Definition,
+    ImportEntry,
+    PythonParseError,
+    SymbolUse,
+    extract_structures,
+)
+from silobrief.sources import SourceFile, SourceSnapshot
+
+
+def source_file(path: str, content: bytes) -> SourceFile:
+    return SourceFile(
+        path=path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def source_snapshot(*files: SourceFile) -> SourceSnapshot:
+    return SourceSnapshot(files=files, warnings=(), digest="test-snapshot")
+
+
+class PythonStructureTests(unittest.TestCase):
+    def test_extracts_nested_classes_and_sync_and_async_functions(self) -> None:
+        source = source_file(
+            "package/service.py",
+            (
+                b"class Outer:\n"
+                b"    class Inner:\n"
+                b"        pass\n"
+                b"    def method(self):\n"
+                b"        pass\n"
+                b"    async def fetch(self):\n"
+                b"        pass\n"
+                b"def top():\n"
+                b"    def nested():\n"
+                b"        pass\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(module.path, "package/service.py")
+        self.assertEqual(
+            module.definitions,
+            (
+                Definition("class", "Outer", "Outer", False, 1, 1),
+                Definition("class", "Inner", "Outer.Inner", False, 2, 5),
+                Definition("function", "method", "Outer.method", False, 4, 5),
+                Definition("function", "fetch", "Outer.fetch", True, 6, 5),
+                Definition("function", "top", "top", False, 8, 1),
+                Definition("function", "nested", "top.nested", False, 9, 5),
+            ),
+        )
+        self.assertEqual(module.imports, ())
+        self.assertEqual(module.calls, ())
+        self.assertEqual(module.references, ())
+
+    def test_extracts_import_variants_in_source_order(self) -> None:
+        source = source_file(
+            "imports.py",
+            (
+                b"import os, package.client as client\n"
+                b"from .service import send as deliver, receive\n"
+                b"from .. import shared\n"
+                b"from plugins import *\n"
+                b"def load():\n"
+                b"    import local as scoped\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.imports,
+            (
+                ImportEntry("os", None, None, 0, None, 1, 1),
+                ImportEntry("package.client", None, "client", 0, None, 1, 1),
+                ImportEntry("service", "send", "deliver", 1, None, 2, 1),
+                ImportEntry("service", "receive", None, 1, None, 2, 1),
+                ImportEntry(None, "shared", None, 2, None, 3, 1),
+                ImportEntry("plugins", "*", None, 0, None, 4, 1),
+                ImportEntry("local", None, "scoped", 0, "load", 6, 5),
+            ),
+        )
+
+    def test_extracts_static_calls_and_load_references_without_duplicates(self) -> None:
+        source = source_file(
+            "calls.py",
+            (
+                b"def run(payload):\n"
+                b"    client.send(payload)\n"
+                b"    handler = client.callback\n"
+                b"    (get_factory())()\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.calls,
+            (
+                SymbolUse("run", "client.send", 2, 5),
+                SymbolUse("run", "get_factory", 4, 6),
+            ),
+        )
+        self.assertEqual(
+            module.references,
+            (
+                SymbolUse("run", "payload", 2, 17),
+                SymbolUse("run", "client.callback", 3, 15),
+            ),
+        )
+
+    def test_omits_source_text_comments_docstrings_and_string_literals(self) -> None:
+        source = source_file(
+            "canaries.py",
+            (
+                b'"""DOCSTRING_CANARY"""\n'
+                b"# COMMENT_CANARY\n"
+                b'SECRET = "STRING_CANARY"\n'
+                b"def run():\n"
+                b'    """METHOD_DOCSTRING_CANARY"""\n'
+                b'    return "RETURN_STRING_CANARY"\n'
+            ),
+        )
+
+        result = extract_structures(source_snapshot(source))
+        rendered = repr(result)
+
+        self.assertEqual(
+            result[0].definitions,
+            (Definition("function", "run", "run", False, 4, 1),),
+        )
+        for canary in (
+            "DOCSTRING_CANARY",
+            "COMMENT_CANARY",
+            "STRING_CANARY",
+            "METHOD_DOCSTRING_CANARY",
+            "RETURN_STRING_CANARY",
+        ):
+            with self.subTest(canary=canary):
+                self.assertNotIn(canary, rendered)
+
+    def test_reports_relative_file_and_location_without_source_line(self) -> None:
+        good = source_file("a_good.py", b"VALUE = 1\n")
+        invalid = source_file("package/bad.py", b"def broken(:  # ERROR_LINE_CANARY\n")
+
+        with self.assertRaises(PythonParseError) as caught:
+            extract_structures(source_snapshot(good, invalid))
+
+        error = caught.exception
+        self.assertEqual(error.path, "package/bad.py")
+        self.assertEqual(error.line, 1)
+        self.assertEqual(error.column, 12)
+        self.assertIn("invalid syntax", error.reason)
+        self.assertNotIn("ERROR_LINE_CANARY", str(error))
+
+    def test_parses_encoding_cookie_from_memory_without_opening_files(self) -> None:
+        source = source_file(
+            "legacy.py",
+            b'# -*- coding: latin-1 -*-\nlabel = "caf\xe9"\n',
+        )
+
+        with (
+            mock.patch("builtins.open", side_effect=AssertionError("must not open source")),
+            mock.patch("pathlib.Path.open", side_effect=AssertionError("must not open source")),
+        ):
+            result = extract_structures(source_snapshot(source))
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].path, "legacy.py")
+        self.assertEqual(result[0].definitions, ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- `SourceSnapshot`의 메모리 내 bytes를 `ast`로 파싱합니다.
- 중첩 class와 sync/async function의 qualified name을 추출합니다.
- 일반·alias·상대·wildcard import와 해당 정의 문맥을 추출합니다.
- 정적 dotted call과 load reference를 구분해 기록합니다.
- 구문 오류를 상대 파일, line·column, 원인으로 보고합니다.
- source body·주석·docstring·문자열 원문은 결과에 저장하지 않습니다.

## 이유

결정적 index를 만들기 전에 공개 경계를 통과한 source만 사용해 검색 후보의 구조적 기반을 만들어야 합니다. 파일 재읽기 없이 이전 단계의 snapshot을 소비하므로 경계 적용 순서를 유지합니다.

## 영향

아직 `tokenize`, stable ID, boundary placeholder, `index.json`, `sb init` CLI에는 연결하지 않습니다. Python 라이브러리 API도 v0.1 공개 계약이 아닙니다.

## 검증

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `python -m unittest discover -s tests -v` (38 tests, 로컬 Windows 권한상 symlink 3 tests skipped)
- `python -m build --no-isolation`

Refs #11