### PR TITLE
feat: build deterministic source index

### DIFF
--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Literal, TypeAlias
+
+from silobrief.python_structure import ImportEntry, ModuleStructure, SymbolUse
+from silobrief.search_tokens import extract_source_text_tokens, normalize_search_tokens
+from silobrief.sources import SourceFile, SourceSnapshot
+from silobrief.state import ConfigData
+
+NodeKind: TypeAlias = Literal["module", "class", "function"]
+EdgeKind: TypeAlias = Literal["contains", "import", "call", "reference"]
+
+
+class IndexBuildError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class NodeTokens:
+    path: tuple[str, ...]
+    symbol: tuple[str, ...]
+    imports: tuple[str, ...]
+    comments: tuple[str, ...]
+    docstrings: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class IndexNode:
+    id: str
+    kind: NodeKind
+    name: str
+    qualified_name: str
+    path: str
+    tokens: NodeTokens
+
+
+@dataclass(frozen=True, slots=True)
+class IndexEdge:
+    source_id: str
+    kind: EdgeKind
+    target: str
+    target_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class IndexData:
+    config_digest: str
+    edges: tuple[IndexEdge, ...]
+    index_version: int
+    nodes: tuple[IndexNode, ...]
+    source_digest: str
+    stale: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _ModuleContext:
+    module_id: str
+    module_name: str
+    structure: ModuleStructure
+    definition_nodes: tuple[IndexNode, ...]
+    context_ids: dict[str, str]
+    path_tokens: tuple[str, ...]
+    import_tokens: tuple[str, ...]
+    comment_tokens: tuple[str, ...]
+    docstring_tokens: tuple[str, ...]
+
+
+def stable_node_id(path: str, kind: NodeKind, qualified_name: str) -> str:
+    _validate_relative_path(path)
+    if not qualified_name:
+        raise IndexBuildError("node qualified name must not be empty")
+    canonical = "\0".join((path, kind, qualified_name)).encode("utf-8")
+    return f"node-{hashlib.sha256(canonical).hexdigest()}"
+
+
+def build_index(
+    snapshot: SourceSnapshot,
+    structures: tuple[ModuleStructure, ...],
+    config: ConfigData,
+) -> IndexData:
+    sources = _source_map(snapshot.files)
+    modules = _module_map(structures)
+    if set(sources) != set(modules):
+        raise IndexBuildError("source and structure paths do not match")
+
+    contexts: dict[str, _ModuleContext] = {}
+    all_nodes: list[IndexNode] = []
+    global_targets: dict[str, str] = {}
+    for path in sorted(sources):
+        context = _build_module_context(sources[path], modules[path])
+        contexts[path] = context
+        module_node = _module_node(context)
+        all_nodes.append(module_node)
+        all_nodes.extend(context.definition_nodes)
+        global_targets.setdefault(context.module_name, context.module_id)
+        for qualified_name, node_id in context.context_ids.items():
+            global_targets.setdefault(f"{context.module_name}.{qualified_name}", node_id)
+
+    edges: set[IndexEdge] = set()
+    for path in sorted(contexts):
+        context = contexts[path]
+        _add_containment_edges(edges, context)
+        _add_import_edges(edges, context, global_targets)
+        _add_use_edges(edges, context, context.structure.calls, "call", global_targets)
+        _add_use_edges(edges, context, context.structure.references, "reference", global_targets)
+
+    return IndexData(
+        config_digest=_config_digest(config),
+        edges=tuple(sorted(edges, key=_edge_key)),
+        index_version=1,
+        nodes=tuple(sorted(all_nodes, key=_node_key)),
+        source_digest=snapshot.digest,
+        stale=False,
+    )
+
+
+def render_index_json(index: IndexData) -> bytes:
+    value: dict[str, object] = {
+        "config_digest": index.config_digest,
+        "edges": [_edge_value(edge) for edge in index.edges],
+        "index_version": index.index_version,
+        "nodes": [_node_value(node) for node in index.nodes],
+        "source_digest": index.source_digest,
+        "stale": index.stale,
+    }
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _build_module_context(source: SourceFile, structure: ModuleStructure) -> _ModuleContext:
+    module_name = _module_name(source.path)
+    module_id = stable_node_id(source.path, "module", module_name)
+    text_tokens = extract_source_text_tokens(source)
+    path_tokens = normalize_search_tokens(source.path.removesuffix(".py"))
+    import_tokens = normalize_search_tokens(*_import_search_values(structure.imports))
+
+    definition_nodes: list[IndexNode] = []
+    context_ids: dict[str, str] = {}
+    seen_ids: set[str] = set()
+    for definition in structure.definitions:
+        node_id = stable_node_id(source.path, definition.kind, definition.qualified_name)
+        context_ids.setdefault(definition.qualified_name, node_id)
+        if node_id in seen_ids:
+            continue
+        seen_ids.add(node_id)
+        definition_nodes.append(
+            IndexNode(
+                id=node_id,
+                kind=definition.kind,
+                name=definition.name,
+                qualified_name=definition.qualified_name,
+                path=source.path,
+                tokens=NodeTokens(
+                    path=path_tokens,
+                    symbol=normalize_search_tokens(definition.qualified_name),
+                    imports=import_tokens,
+                    comments=text_tokens.comments,
+                    docstrings=text_tokens.docstrings,
+                ),
+            )
+        )
+    return _ModuleContext(
+        module_id=module_id,
+        module_name=module_name,
+        structure=structure,
+        definition_nodes=tuple(definition_nodes),
+        context_ids=context_ids,
+        path_tokens=path_tokens,
+        import_tokens=import_tokens,
+        comment_tokens=text_tokens.comments,
+        docstring_tokens=text_tokens.docstrings,
+    )
+
+
+def _module_node(context: _ModuleContext) -> IndexNode:
+    return IndexNode(
+        id=context.module_id,
+        kind="module",
+        name=context.module_name.rsplit(".", 1)[-1],
+        qualified_name=context.module_name,
+        path=context.structure.path,
+        tokens=NodeTokens(
+            path=context.path_tokens,
+            symbol=normalize_search_tokens(context.module_name),
+            imports=context.import_tokens,
+            comments=context.comment_tokens,
+            docstrings=context.docstring_tokens,
+        ),
+    )
+
+
+def _add_containment_edges(edges: set[IndexEdge], context: _ModuleContext) -> None:
+    for node in context.definition_nodes:
+        parent_name, separator, _ = node.qualified_name.rpartition(".")
+        source_id = (
+            context.context_ids.get(parent_name, context.module_id)
+            if separator
+            else context.module_id
+        )
+        edges.add(IndexEdge(source_id, "contains", node.qualified_name, node.id))
+
+
+def _add_import_edges(
+    edges: set[IndexEdge],
+    context: _ModuleContext,
+    global_targets: dict[str, str],
+) -> None:
+    for imported in context.structure.imports:
+        source_id = _context_id(context, imported.context)
+        target = _import_target(imported)
+        edges.add(IndexEdge(source_id, "import", target, global_targets.get(target)))
+
+
+def _add_use_edges(
+    edges: set[IndexEdge],
+    context: _ModuleContext,
+    uses: tuple[SymbolUse, ...],
+    kind: Literal["call", "reference"],
+    global_targets: dict[str, str],
+) -> None:
+    for use in uses:
+        source_id = _context_id(context, use.context)
+        target_id = _resolve_target(context, use.context, use.target, global_targets)
+        edges.add(IndexEdge(source_id, kind, use.target, target_id))
+
+
+def _resolve_target(
+    context: _ModuleContext,
+    source_context: str | None,
+    target: str,
+    global_targets: dict[str, str],
+) -> str | None:
+    if source_context is not None and target.startswith("self."):
+        owner, separator, _ = source_context.rpartition(".")
+        if separator:
+            candidate = f"{owner}.{target.removeprefix('self.')}"
+            if candidate in context.context_ids:
+                return context.context_ids[candidate]
+
+    if source_context is not None:
+        parts = source_context.split(".")
+        for length in range(len(parts) - 1, -1, -1):
+            prefix = ".".join(parts[:length])
+            candidate = f"{prefix}.{target}" if prefix else target
+            if candidate in context.context_ids:
+                return context.context_ids[candidate]
+    if target in context.context_ids:
+        return context.context_ids[target]
+    return global_targets.get(target)
+
+
+def _context_id(context: _ModuleContext, qualified_name: str | None) -> str:
+    if qualified_name is None:
+        return context.module_id
+    try:
+        return context.context_ids[qualified_name]
+    except KeyError as error:
+        raise IndexBuildError(f"unknown source context: {qualified_name}") from error
+
+
+def _module_name(path: str) -> str:
+    _validate_relative_path(path)
+    parts = list(PurePosixPath(path).parts)
+    filename = parts[-1]
+    if filename == "__init__.py" and len(parts) > 1:
+        parts.pop()
+    else:
+        parts[-1] = filename.removesuffix(".py")
+    return ".".join(parts)
+
+
+def _import_target(imported: ImportEntry) -> str:
+    prefix = "." * imported.level
+    module = imported.module or ""
+    base = f"{prefix}{module}"
+    if imported.name is None:
+        return base
+    separator = "" if not base or base.endswith(".") else "."
+    return f"{base}{separator}{imported.name}"
+
+
+def _import_search_values(imports: tuple[ImportEntry, ...]) -> tuple[str, ...]:
+    values: list[str] = []
+    for imported in imports:
+        values.append(_import_target(imported))
+        if imported.alias is not None:
+            values.append(imported.alias)
+    return tuple(values)
+
+
+def _source_map(files: tuple[SourceFile, ...]) -> dict[str, SourceFile]:
+    result = {source.path: source for source in files}
+    if len(result) != len(files):
+        raise IndexBuildError("source snapshot contains duplicate paths")
+    return result
+
+
+def _module_map(structures: tuple[ModuleStructure, ...]) -> dict[str, ModuleStructure]:
+    result = {module.path: module for module in structures}
+    if len(result) != len(structures):
+        raise IndexBuildError("structure input contains duplicate paths")
+    return result
+
+
+def _config_digest(config: ConfigData) -> str:
+    boundaries = sorted(
+        config["boundaries"],
+        key=lambda item: (item["path"], item["alias"], item["description"]),
+    )
+    value: dict[str, object] = {
+        "boundaries": [dict(boundary) for boundary in boundaries],
+        "default_excludes": sorted(config["default_excludes"]),
+        "schema_version": config["schema_version"],
+    }
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _node_value(node: IndexNode) -> dict[str, object]:
+    return {
+        "id": node.id,
+        "kind": node.kind,
+        "name": node.name,
+        "path": node.path,
+        "qualified_name": node.qualified_name,
+        "tokens": {
+            "comments": list(node.tokens.comments),
+            "docstrings": list(node.tokens.docstrings),
+            "imports": list(node.tokens.imports),
+            "path": list(node.tokens.path),
+            "symbol": list(node.tokens.symbol),
+        },
+    }
+
+
+def _edge_value(edge: IndexEdge) -> dict[str, object]:
+    return {
+        "kind": edge.kind,
+        "source_id": edge.source_id,
+        "target": edge.target,
+        "target_id": edge.target_id,
+    }
+
+
+def _node_key(node: IndexNode) -> tuple[str, int, str, str]:
+    kind_order = {"module": 0, "class": 1, "function": 2}
+    return node.path, kind_order[node.kind], node.qualified_name, node.id
+
+
+def _edge_key(edge: IndexEdge) -> tuple[str, str, str, str]:
+    return edge.source_id, edge.kind, edge.target, edge.target_id or ""
+
+
+def _validate_relative_path(path: str) -> None:
+    posix = PurePosixPath(path)
+    windows = PureWindowsPath(path)
+    if (
+        not path
+        or "\\" in path
+        or posix.is_absolute()
+        or windows.drive
+        or windows.root
+        or ".." in posix.parts
+        or posix.as_posix() != path
+    ):
+        raise IndexBuildError("node path must be a normalized relative POSIX path")

--- a/src/silobrief/search_tokens.py
+++ b/src/silobrief/search_tokens.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import ast
+import io
+import re
+import tokenize
+from dataclasses import dataclass
+
+from silobrief.python_structure import PythonParseError
+from silobrief.sources import SourceFile
+
+_WORD_PATTERN = re.compile(r"[^\W_]+", re.UNICODE)
+_IDENTIFIER_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+_CODING_COOKIE = re.compile(r"coding[:=][ \t]*[-\w.]+", re.ASCII)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceTextTokens:
+    comments: tuple[str, ...]
+    docstrings: tuple[str, ...]
+
+
+def normalize_search_tokens(*values: str) -> tuple[str, ...]:
+    normalized: set[str] = set()
+    for value in values:
+        for word in _WORD_PATTERN.findall(value):
+            for part in _IDENTIFIER_BOUNDARY.split(word):
+                token = part.casefold()
+                if token:
+                    normalized.add(token)
+    return tuple(sorted(normalized))
+
+
+def extract_source_text_tokens(source: SourceFile) -> SourceTextTokens:
+    tree = _parse_source(source)
+    docstrings = tuple(_docstrings(tree))
+    comments = tuple(_comments(source))
+    return SourceTextTokens(
+        comments=normalize_search_tokens(*comments),
+        docstrings=normalize_search_tokens(*docstrings),
+    )
+
+
+def _parse_source(source: SourceFile) -> ast.Module:
+    try:
+        return ast.parse(source.content, filename=source.path, mode="exec")
+    except SyntaxError as error:
+        raise PythonParseError(
+            path=source.path,
+            line=error.lineno,
+            column=error.offset,
+            reason=error.msg,
+        ) from error
+
+
+def _docstrings(tree: ast.Module) -> list[str]:
+    result: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            value = ast.get_docstring(node, clean=False)
+            if value is not None:
+                result.append(value)
+    return result
+
+
+def _comments(source: SourceFile) -> list[str]:
+    result: list[str] = []
+    try:
+        tokens = tokenize.tokenize(io.BytesIO(source.content).readline)
+        for token in tokens:
+            if token.type != tokenize.COMMENT or _is_metadata_comment(token):
+                continue
+            result.append(token.string.removeprefix("#"))
+    except tokenize.TokenError as error:
+        line, column = _token_error_location(error)
+        reason = str(error.args[0]) if error.args else "tokenization failed"
+        raise PythonParseError(source.path, line, column, reason) from error
+    return result
+
+
+def _is_metadata_comment(token: tokenize.TokenInfo) -> bool:
+    if token.start[0] == 1 and token.string.startswith("#!"):
+        return True
+    return token.start[0] <= 2 and _CODING_COOKIE.search(token.string) is not None
+
+
+def _token_error_location(error: tokenize.TokenError) -> tuple[int | None, int | None]:
+    if len(error.args) < 2:
+        return None, None
+    location = error.args[1]
+    if not isinstance(location, tuple) or len(location) != 2:
+        return None, None
+    line, column = location
+    if not isinstance(line, int) or not isinstance(column, int):
+        return None, None
+    return line, column + 1

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from dataclasses import replace
+
+from silobrief.index import (
+    IndexBuildError,
+    IndexEdge,
+    build_index,
+    render_index_json,
+    stable_node_id,
+)
+from silobrief.python_structure import extract_structures
+from silobrief.sources import SourceFile, SourceSnapshot
+from silobrief.state import DEFAULT_EXCLUDES, BoundaryData, ConfigData
+
+
+def source_file(path: str, content: bytes) -> SourceFile:
+    return SourceFile(
+        path=path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def source_snapshot(*files: SourceFile) -> SourceSnapshot:
+    digest = hashlib.sha256()
+    for source in sorted(files, key=lambda item: item.path):
+        digest.update(source.path.encode())
+        digest.update(bytes.fromhex(source.sha256))
+    return SourceSnapshot(files=files, warnings=(), digest=digest.hexdigest())
+
+
+def config(*boundaries: BoundaryData) -> ConfigData:
+    return ConfigData(
+        boundaries=list(boundaries),
+        default_excludes=list(DEFAULT_EXCLUDES),
+        schema_version=1,
+    )
+
+
+class DeterministicIndexTests(unittest.TestCase):
+    def test_stable_node_id_uses_path_kind_and_qualified_name(self) -> None:
+        node_id = stable_node_id("package/service.py", "function", "Worker.run")
+
+        self.assertEqual(
+            node_id,
+            "node-e7c8eeef16b7a03f28e3b09b380ad1bc79aea32e37840daac175804d3d8d0356",
+        )
+        self.assertEqual(node_id, stable_node_id("package/service.py", "function", "Worker.run"))
+        self.assertNotEqual(node_id, stable_node_id("other/service.py", "function", "Worker.run"))
+        self.assertNotEqual(node_id, stable_node_id("package/service.py", "class", "Worker.run"))
+        self.assertNotEqual(
+            node_id, stable_node_id("package/service.py", "function", "Worker.stop")
+        )
+
+    def test_builds_nodes_tokens_and_structure_edges(self) -> None:
+        source = source_file(
+            "package/service.py",
+            (
+                b'"""Service module."""\n'
+                b"import requests as http\n"
+                b"def helper():\n"
+                b"    pass\n"
+                b"class Worker:\n"
+                b'    """Worker docs."""\n'
+                b"    def execute(self):\n"
+                b"        helper()\n"
+                b"        self.finish()\n"
+                b"        external.call()\n"
+                b"    def finish(self):\n"
+                b"        pass\n"
+                b'SECRET = "INDEX_STRING_CANARY"\n'
+            ),
+        )
+        snapshot = source_snapshot(source)
+        structures = extract_structures(snapshot)
+
+        index = build_index(snapshot, structures, config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        self.assertEqual(
+            set(nodes), {"package.service", "helper", "Worker", "Worker.execute", "Worker.finish"}
+        )
+        execute = nodes["Worker.execute"]
+        self.assertEqual(execute.tokens.path, ("package", "service"))
+        self.assertEqual(execute.tokens.symbol, ("execute", "worker"))
+        self.assertEqual(execute.tokens.imports, ("http", "requests"))
+        self.assertEqual(execute.tokens.comments, ())
+        self.assertEqual(execute.tokens.docstrings, ("docs", "module", "service", "worker"))
+
+        module = nodes["package.service"]
+        worker = nodes["Worker"]
+        helper = nodes["helper"]
+        finish = nodes["Worker.finish"]
+        self.assertEqual(
+            set(index.edges),
+            {
+                IndexEdge(module.id, "contains", "helper", helper.id),
+                IndexEdge(module.id, "contains", "Worker", worker.id),
+                IndexEdge(worker.id, "contains", "Worker.execute", execute.id),
+                IndexEdge(worker.id, "contains", "Worker.finish", finish.id),
+                IndexEdge(module.id, "import", "requests", None),
+                IndexEdge(execute.id, "call", "helper", helper.id),
+                IndexEdge(execute.id, "call", "self.finish", finish.id),
+                IndexEdge(execute.id, "call", "external.call", None),
+            },
+        )
+
+    def test_json_is_identical_for_equivalent_input_order(self) -> None:
+        first_source = source_file(
+            "a.py",
+            b'"""Alpha docs."""\n# Useful comment\nVALUE = "STRING_LITERAL_CANARY"\n',
+        )
+        second_source = source_file("package/b.py", b"def BetaValue():\n    pass\n")
+        first_snapshot = source_snapshot(first_source, second_source)
+        second_snapshot = source_snapshot(second_source, first_source)
+        first_structures = extract_structures(first_snapshot)
+        second_structures = tuple(reversed(extract_structures(second_snapshot)))
+        private = BoundaryData(alias="private", description="Private code", path="private")
+        generated = BoundaryData(alias="generated", description="Generated code", path="gen")
+
+        first = build_index(first_snapshot, first_structures, config(private, generated))
+        second = build_index(second_snapshot, second_structures, config(generated, private))
+        first_json = render_index_json(first)
+        second_json = render_index_json(second)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first_json, second_json)
+        self.assertTrue(first_json.endswith(b"\n"))
+        self.assertFalse(first_json.endswith(b"\n\n"))
+        self.assertNotIn(b"\r\n", first_json)
+        self.assertNotIn(b"STRING_LITERAL_CANARY", first_json)
+        parsed = json.loads(first_json)
+        self.assertEqual(
+            set(parsed),
+            {"config_digest", "edges", "index_version", "nodes", "source_digest", "stale"},
+        )
+        self.assertEqual(parsed["index_version"], 1)
+        self.assertIs(parsed["stale"], False)
+
+    def test_config_and_source_digest_changes_are_visible(self) -> None:
+        source = source_file("module.py", b"VALUE = 1\n")
+        snapshot = source_snapshot(source)
+        structures = extract_structures(snapshot)
+        original = build_index(
+            snapshot,
+            structures,
+            config(BoundaryData(alias="private", description="Private code", path="private")),
+        )
+        changed_config = build_index(
+            snapshot,
+            structures,
+            config(BoundaryData(alias="private", description="Internal code", path="private")),
+        )
+        changed_source = build_index(
+            replace(snapshot, digest="f" * 64),
+            structures,
+            config(BoundaryData(alias="private", description="Private code", path="private")),
+        )
+
+        self.assertNotEqual(original.config_digest, changed_config.config_digest)
+        self.assertEqual(original.source_digest, changed_config.source_digest)
+        self.assertEqual(original.config_digest, changed_source.config_digest)
+        self.assertNotEqual(original.source_digest, changed_source.source_digest)
+
+    def test_rejects_mismatched_source_and_structure_paths(self) -> None:
+        snapshot = source_snapshot(source_file("module.py", b"VALUE = 1\n"))
+
+        with self.assertRaisesRegex(IndexBuildError, "paths do not match"):
+            build_index(snapshot, (), config())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_search_tokens.py
+++ b/tests/test_search_tokens.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import unittest
+from unittest import mock
+
+from silobrief.python_structure import PythonParseError
+from silobrief.search_tokens import extract_source_text_tokens, normalize_search_tokens
+from silobrief.sources import SourceFile
+
+
+def source_file(path: str, content: bytes) -> SourceFile:
+    return SourceFile(
+        path=path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+class SearchTokenTests(unittest.TestCase):
+    def test_normalizes_identifiers_punctuation_unicode_and_duplicates(self) -> None:
+        tokens = normalize_search_tokens(
+            "ParcelClient retry_queue HTTPResponse2XX",
+            "배송_상태, Straße; parcel-client",
+        )
+
+        self.assertEqual(
+            tokens,
+            (
+                "client",
+                "http",
+                "parcel",
+                "queue",
+                "response2",
+                "retry",
+                "strasse",
+                "xx",
+                "배송",
+                "상태",
+            ),
+        )
+        self.assertEqual(normalize_search_tokens("---", "___"), ())
+
+    def test_extracts_comment_and_real_docstring_tokens_by_source(self) -> None:
+        source = source_file(
+            "worker.py",
+            (
+                b'"""Parse ParcelClient responses."""\n'
+                b"# Retry HTTPResponse parsing\n"
+                b"class Worker:\n"
+                b'    """Handles retry_queue."""\n'
+                b'    note = "STRING_LITERAL_CANARY"\n'
+                b"    async def run(self):\n"
+                b'        """Sync external API."""\n'
+                b"        # Convert json_payload now\n"
+                b'        value = f"FSTRING_CANARY {self}"\n'
+                b'        marker = "# STRING_COMMENT_CANARY"\n'
+            ),
+        )
+
+        tokens = extract_source_text_tokens(source)
+
+        self.assertEqual(
+            tokens.comments,
+            ("convert", "http", "json", "now", "parsing", "payload", "response", "retry"),
+        )
+        self.assertEqual(
+            tokens.docstrings,
+            (
+                "api",
+                "client",
+                "external",
+                "handles",
+                "parcel",
+                "parse",
+                "queue",
+                "responses",
+                "retry",
+                "sync",
+            ),
+        )
+        rendered = repr(tokens)
+        for canary in ("STRING_LITERAL_CANARY", "FSTRING_CANARY", "STRING_COMMENT_CANARY"):
+            with self.subTest(canary=canary):
+                self.assertNotIn(canary, rendered)
+
+    def test_ignores_shebang_and_encoding_cookie_comments(self) -> None:
+        source = source_file(
+            "legacy.py",
+            (
+                b"#!/usr/bin/env python\n"
+                b"# -*- coding: latin-1 -*-\n"
+                b'"""Legacy worker."""\n'
+                b"# Process caf\xe9_jobs\n"
+            ),
+        )
+
+        tokens = extract_source_text_tokens(source)
+
+        self.assertEqual(tokens.comments, ("caf\u00e9", "jobs", "process"))
+        self.assertEqual(tokens.docstrings, ("legacy", "worker"))
+        for metadata_token in ("usr", "bin", "env", "python", "coding", "latin"):
+            with self.subTest(token=metadata_token):
+                self.assertNotIn(metadata_token, tokens.comments)
+
+    def test_is_deterministic_and_does_not_open_source_files(self) -> None:
+        source = source_file(
+            "memory_only.py",
+            b'"""Repeated repeated Words."""\n# Words more_words\n',
+        )
+
+        with (
+            mock.patch("builtins.open", side_effect=AssertionError("must not open source")),
+            mock.patch("pathlib.Path.open", side_effect=AssertionError("must not open source")),
+        ):
+            first = extract_source_text_tokens(source)
+            second = extract_source_text_tokens(source)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.comments, ("more", "words"))
+        self.assertEqual(first.docstrings, ("repeated", "words"))
+
+    def test_reports_syntax_error_without_source_line(self) -> None:
+        source = source_file(
+            "package/bad.py",
+            b"def broken(:  # TOKEN_ERROR_CANARY\n",
+        )
+
+        with self.assertRaises(PythonParseError) as caught:
+            extract_source_text_tokens(source)
+
+        error = caught.exception
+        self.assertEqual(error.path, "package/bad.py")
+        self.assertEqual(error.line, 1)
+        self.assertEqual(error.column, 12)
+        self.assertNotIn("TOKEN_ERROR_CANARY", str(error))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- Python 주석과 실제 docstring에서 검색 토큰을 추출합니다.
- 경로·종류·qualified name으로 안정적인 노드 ID를 생성합니다.
- module/class/function 노드와 contains/import/call/reference 간선을 구성합니다.
- 설정 및 소스 digest를 포함한 결정적 UTF-8/LF JSON을 렌더링합니다.

## 이유

동일한 프로젝트 입력에서 운영체제나 입력 순서와 관계없이 같은 구조 index를 생성해야 이후 lexical ranking과 검토 흐름이 재현 가능합니다.

## 영향

아직 `sb init`이나 디스크 쓰기에는 연결하지 않은 내부 index 계층입니다. 경계 placeholder와 원자적 index 저장은 후속 Issue에서 구현합니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests -v` (48개 통과, Windows 권한상 symlink 3개 제외)
- `python -m build`

Refs #13