### PR TITLE
feat: replace boundary references with placeholders

### DIFF
--- a/src/silobrief/boundary_placeholders.py
+++ b/src/silobrief/boundary_placeholders.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from silobrief.python_structure import ImportEntry
+from silobrief.state import BoundaryData
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryPlaceholder:
+    alias: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class _BoundaryRule:
+    module: str
+    placeholder: BoundaryPlaceholder
+
+
+class BoundaryMatcher:
+    def __init__(
+        self,
+        source_path: str,
+        imports: tuple[ImportEntry, ...],
+        boundaries: tuple[BoundaryData, ...],
+    ) -> None:
+        self._source_path = source_path
+        self._rules = tuple(
+            sorted(
+                (_boundary_rule(boundary) for boundary in boundaries),
+                key=lambda rule: (
+                    -(rule.module.count(".") + 1 if rule.module else 0),
+                    rule.module,
+                    rule.placeholder.alias,
+                    rule.placeholder.description,
+                ),
+            )
+        )
+        bindings: dict[str | None, dict[str, str]] = {}
+        for imported in imports:
+            resolved = _resolved_import_target(source_path, imported)
+            visible = _visible_binding(imported)
+            if resolved is not None and visible is not None:
+                bindings.setdefault(imported.context, {})[visible] = resolved
+        self._bindings = {
+            context: tuple(
+                sorted(values.items(), key=lambda item: (-len(item[0].split(".")), item[0]))
+            )
+            for context, values in bindings.items()
+        }
+
+    def match_import(self, imported: ImportEntry) -> BoundaryPlaceholder | None:
+        resolved = _resolved_import_target(self._source_path, imported)
+        return self._match_module(resolved)
+
+    def match_use(
+        self,
+        target: str,
+        context: str | None,
+    ) -> BoundaryPlaceholder | None:
+        direct = self._match_module(target)
+        if direct is not None:
+            return direct
+        for visible, origin in self._visible_origins(context):
+            if target == visible:
+                return self._match_module(origin)
+            if target.startswith(f"{visible}."):
+                suffix = target[len(visible) :]
+                return self._match_module(f"{origin}{suffix}")
+        return None
+
+    def _visible_origins(self, context: str | None) -> tuple[tuple[str, str], ...]:
+        contexts: list[str | None] = []
+        current = context
+        while current is not None:
+            contexts.append(current)
+            current, separator, _ = current.rpartition(".")
+            if not separator:
+                current = None
+        contexts.append(None)
+
+        result: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for candidate in contexts:
+            for visible, origin in self._bindings.get(candidate, ()):
+                if visible not in seen:
+                    seen.add(visible)
+                    result.append((visible, origin))
+        return tuple(result)
+
+    def _match_module(self, module: str | None) -> BoundaryPlaceholder | None:
+        if module is None:
+            return None
+        for rule in self._rules:
+            if not rule.module or module == rule.module or module.startswith(f"{rule.module}."):
+                return rule.placeholder
+        return None
+
+
+def import_target(imported: ImportEntry) -> str:
+    prefix = "." * imported.level
+    module = imported.module or ""
+    base = f"{prefix}{module}"
+    if imported.name is None:
+        return base
+    separator = "" if not base or base.endswith(".") else "."
+    return f"{base}{separator}{imported.name}"
+
+
+def _boundary_rule(boundary: BoundaryData) -> _BoundaryRule:
+    parts = list(PurePosixPath(boundary["path"]).parts)
+    if boundary["path"] == ".":
+        module = ""
+    elif parts[-1] == "__init__.py":
+        module = ".".join(parts[:-1])
+    elif parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+        module = ".".join(parts)
+    else:
+        module = ".".join(parts)
+    return _BoundaryRule(
+        module=module,
+        placeholder=BoundaryPlaceholder(
+            alias=boundary["alias"],
+            description=boundary["description"],
+        ),
+    )
+
+
+def _resolved_import_target(source_path: str, imported: ImportEntry) -> str | None:
+    if imported.level == 0:
+        return import_target(imported)
+
+    path_parts = list(PurePosixPath(source_path).parts)
+    path_parts.pop()
+    package = path_parts
+    upward = imported.level - 1
+    if upward > len(package):
+        return None
+    if upward:
+        package = package[:-upward]
+
+    parts = [*package]
+    if imported.module:
+        parts.extend(imported.module.split("."))
+    if imported.name and imported.name != "*":
+        parts.append(imported.name)
+    return ".".join(parts) or None
+
+
+def _visible_binding(imported: ImportEntry) -> str | None:
+    if imported.alias is not None:
+        return imported.alias
+    if imported.name is not None:
+        return None if imported.name == "*" else imported.name
+    return imported.module

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -6,10 +6,15 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Literal, TypeAlias
 
+from silobrief.boundary_placeholders import (
+    BoundaryMatcher,
+    BoundaryPlaceholder,
+    import_target,
+)
 from silobrief.python_structure import ImportEntry, ModuleStructure, SymbolUse
 from silobrief.search_tokens import extract_source_text_tokens, normalize_search_tokens
 from silobrief.sources import SourceFile, SourceSnapshot
-from silobrief.state import ConfigData
+from silobrief.state import BoundaryData, ConfigData
 
 NodeKind: TypeAlias = Literal["module", "class", "function"]
 EdgeKind: TypeAlias = Literal["contains", "import", "call", "reference"]
@@ -42,7 +47,7 @@ class IndexNode:
 class IndexEdge:
     source_id: str
     kind: EdgeKind
-    target: str
+    target: str | BoundaryPlaceholder
     target_id: str | None
 
 
@@ -67,6 +72,7 @@ class _ModuleContext:
     import_tokens: tuple[str, ...]
     comment_tokens: tuple[str, ...]
     docstring_tokens: tuple[str, ...]
+    boundary_matcher: BoundaryMatcher
 
 
 def stable_node_id(path: str, kind: NodeKind, qualified_name: str) -> str:
@@ -91,7 +97,11 @@ def build_index(
     all_nodes: list[IndexNode] = []
     global_targets: dict[str, str] = {}
     for path in sorted(sources):
-        context = _build_module_context(sources[path], modules[path])
+        context = _build_module_context(
+            sources[path],
+            modules[path],
+            tuple(config["boundaries"]),
+        )
         contexts[path] = context
         module_node = _module_node(context)
         all_nodes.append(module_node)
@@ -130,12 +140,19 @@ def render_index_json(index: IndexData) -> bytes:
     return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
-def _build_module_context(source: SourceFile, structure: ModuleStructure) -> _ModuleContext:
+def _build_module_context(
+    source: SourceFile,
+    structure: ModuleStructure,
+    boundaries: tuple[BoundaryData, ...],
+) -> _ModuleContext:
     module_name = _module_name(source.path)
     module_id = stable_node_id(source.path, "module", module_name)
     text_tokens = extract_source_text_tokens(source)
     path_tokens = normalize_search_tokens(source.path.removesuffix(".py"))
-    import_tokens = normalize_search_tokens(*_import_search_values(structure.imports))
+    boundary_matcher = BoundaryMatcher(source.path, structure.imports, boundaries)
+    import_tokens = normalize_search_tokens(
+        *_import_search_values(structure.imports, boundary_matcher)
+    )
 
     definition_nodes: list[IndexNode] = []
     context_ids: dict[str, str] = {}
@@ -172,6 +189,7 @@ def _build_module_context(source: SourceFile, structure: ModuleStructure) -> _Mo
         import_tokens=import_tokens,
         comment_tokens=text_tokens.comments,
         docstring_tokens=text_tokens.docstrings,
+        boundary_matcher=boundary_matcher,
     )
 
 
@@ -210,8 +228,14 @@ def _add_import_edges(
 ) -> None:
     for imported in context.structure.imports:
         source_id = _context_id(context, imported.context)
-        target = _import_target(imported)
-        edges.add(IndexEdge(source_id, "import", target, global_targets.get(target)))
+        placeholder = context.boundary_matcher.match_import(imported)
+        if placeholder is not None:
+            target: str | BoundaryPlaceholder = placeholder
+            target_id = None
+        else:
+            target = import_target(imported)
+            target_id = global_targets.get(target)
+        edges.add(IndexEdge(source_id, "import", target, target_id))
 
 
 def _add_use_edges(
@@ -223,8 +247,14 @@ def _add_use_edges(
 ) -> None:
     for use in uses:
         source_id = _context_id(context, use.context)
-        target_id = _resolve_target(context, use.context, use.target, global_targets)
-        edges.add(IndexEdge(source_id, kind, use.target, target_id))
+        placeholder = context.boundary_matcher.match_use(use.target, use.context)
+        target: str | BoundaryPlaceholder = placeholder or use.target
+        target_id = (
+            None
+            if placeholder is not None
+            else _resolve_target(context, use.context, use.target, global_targets)
+        )
+        edges.add(IndexEdge(source_id, kind, target, target_id))
 
 
 def _resolve_target(
@@ -272,21 +302,18 @@ def _module_name(path: str) -> str:
     return ".".join(parts)
 
 
-def _import_target(imported: ImportEntry) -> str:
-    prefix = "." * imported.level
-    module = imported.module or ""
-    base = f"{prefix}{module}"
-    if imported.name is None:
-        return base
-    separator = "" if not base or base.endswith(".") else "."
-    return f"{base}{separator}{imported.name}"
-
-
-def _import_search_values(imports: tuple[ImportEntry, ...]) -> tuple[str, ...]:
+def _import_search_values(
+    imports: tuple[ImportEntry, ...],
+    boundary_matcher: BoundaryMatcher,
+) -> tuple[str, ...]:
     values: list[str] = []
     for imported in imports:
-        values.append(_import_target(imported))
-        if imported.alias is not None:
+        placeholder = boundary_matcher.match_import(imported)
+        if placeholder is not None:
+            values.extend((placeholder.alias, placeholder.description))
+        else:
+            values.append(import_target(imported))
+        if placeholder is None and imported.alias is not None:
             values.append(imported.alias)
     return tuple(values)
 
@@ -345,8 +372,18 @@ def _edge_value(edge: IndexEdge) -> dict[str, object]:
     return {
         "kind": edge.kind,
         "source_id": edge.source_id,
-        "target": edge.target,
+        "target": _edge_target_value(edge.target),
         "target_id": edge.target_id,
+    }
+
+
+def _edge_target_value(target: str | BoundaryPlaceholder) -> object:
+    if isinstance(target, str):
+        return target
+    return {
+        "alias": target.alias,
+        "description": target.description,
+        "kind": "boundary-placeholder",
     }
 
 
@@ -356,7 +393,11 @@ def _node_key(node: IndexNode) -> tuple[str, int, str, str]:
 
 
 def _edge_key(edge: IndexEdge) -> tuple[str, str, str, str]:
-    return edge.source_id, edge.kind, edge.target, edge.target_id or ""
+    if isinstance(edge.target, str):
+        target = f"public:{edge.target}"
+    else:
+        target = f"boundary:{edge.target.alias}:{edge.target.description}"
+    return edge.source_id, edge.kind, target, edge.target_id or ""
 
 
 def _validate_relative_path(path: str) -> None:

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+import unittest
+
+from silobrief.index import build_index, render_index_json
+from silobrief.python_structure import extract_structures
+from silobrief.sources import SourceFile, SourceSnapshot
+from silobrief.state import DEFAULT_EXCLUDES, BoundaryData, ConfigData
+
+
+def source_snapshot(path: str, content: bytes) -> SourceSnapshot:
+    source = SourceFile(
+        path=path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+    return SourceSnapshot(files=(source,), warnings=(), digest="a" * 64)
+
+
+def config(*boundaries: BoundaryData) -> ConfigData:
+    return ConfigData(
+        boundaries=list(boundaries),
+        default_excludes=list(DEFAULT_EXCLUDES),
+        schema_version=1,
+    )
+
+
+class BoundaryPlaceholderTests(unittest.TestCase):
+    def test_replaces_directory_boundary_imports_calls_and_references(self) -> None:
+        snapshot = source_snapshot(
+            "app.py",
+            (
+                b"from vault_private.gateway import SecretClient as hidden_client\n"
+                b"import vault_private.worker as hidden_worker\n"
+                b"import requests as http\n"
+                b"def run():\n"
+                b"    client = hidden_client\n"
+                b"    hidden_client()\n"
+                b"    hidden_worker.execute()\n"
+                b"    vault_private.worker.status\n"
+                b"    http.get()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="internal-service",
+            description="Approved internal service",
+            path="vault_private",
+        )
+
+        rendered = render_index_json(
+            build_index(snapshot, extract_structures(snapshot), config(boundary))
+        )
+
+        placeholder = (
+            b'{\n        "alias": "internal-service",\n'
+            b'        "description": "Approved internal service",\n'
+            b'        "kind": "boundary-placeholder"\n      }'
+        )
+        self.assertIn(placeholder, rendered)
+        self.assertIn(b'"target": "requests"', rendered)
+        self.assertIn(b'"target": "http.get"', rendered)
+        self.assertIn(
+            b'"imports": [\n          "approved",\n          "http",\n'
+            b'          "internal",\n          "requests",\n          "service"\n        ]',
+            rendered,
+        )
+        for forbidden in (
+            b"vault_private",
+            b"gateway",
+            b"SecretClient",
+            b"secret",
+            b"client",
+            b"hidden_client",
+            b"hidden_worker",
+            b"worker",
+            b"status",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_resolves_relative_file_boundary_deterministically(self) -> None:
+        snapshot = source_snapshot(
+            "package/public.py",
+            (
+                b"from .private_zone import HiddenThing as local_hidden\n"
+                b"def build():\n"
+                b"    return local_hidden\n"
+            ),
+        )
+        private = BoundaryData(
+            alias="internal-module",
+            description="Approved module",
+            path="package/private_zone.py",
+        )
+        unused = BoundaryData(
+            alias="unused-boundary",
+            description="Unused boundary",
+            path="unused",
+        )
+        structures = extract_structures(snapshot)
+
+        first = render_index_json(build_index(snapshot, structures, config(private, unused)))
+        second = render_index_json(build_index(snapshot, structures, config(unused, private)))
+
+        self.assertEqual(first, second)
+        self.assertIn(b'"alias": "internal-module"', first)
+        self.assertIn(b'"description": "Approved module"', first)
+        for forbidden in (b"private_zone", b"HiddenThing", b"local_hidden"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, first)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- 등록된 Python 파일·디렉터리 경계를 module prefix로 변환합니다.
- 절대·상대 import와 import alias를 통한 정적 call·reference를 경계에 대조합니다.
- 일치하는 graph target을 alias와 공개 설명만 가진 `boundary-placeholder`로 치환합니다.
- 경계 import의 실제 target과 source alias를 검색 토큰에서 제거합니다.
- 공개 import와 공개 call·reference의 기존 형식은 유지합니다.

## 이유

허용 파일이 제외 영역을 정적으로 참조할 때 기존 index는 제외 module·symbol 이름과 import alias 토큰을 그대로 직렬화할 수 있었습니다. AC-04를 만족하려면 JSON 생성 전에 이 값을 공개 가능한 placeholder로 바꿔야 합니다.

## 영향

index 계층의 경계 target 형식이 문자열 대신 `{kind, alias, description}` 객체가 될 수 있습니다. 동적 import, `sb init`, index 파일 저장, 검색 순위와 Markdown renderer는 이 PR 범위에 포함하지 않습니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests -v` (50개 통과, Windows 권한상 symlink 3개 제외)
- `python -m build --no-isolation --outdir build/verify-15`

Refs #15