### PR TITLE
feat: record public project context

### DIFF
--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 from silobrief import __version__
 from silobrief.boundaries import register_boundary
+from silobrief.notes import add_note
 from silobrief.state import SetupError, setup_project
 
 
@@ -22,6 +24,9 @@ def _build_parser() -> argparse.ArgumentParser:
     ignore.add_argument("path")
     ignore.add_argument("--as", dest="description", required=True)
     ignore.add_argument("--alias")
+    log = subcommands.add_parser("log", help="Record public project context.")
+    log.add_argument("path")
+    log.add_argument("--comment", required=True)
     return parser
 
 
@@ -58,5 +63,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print(f"boundary {boundary['alias']} for {boundary['path']} is already registered")
+
+    if arguments.command == "log":
+        path_text = arguments.path
+        comment = arguments.comment
+        if not isinstance(path_text, str) or not isinstance(comment, str):
+            parser.error("log path and comment must be text")
+        if not comment.strip():
+            parser.error("note comment must not be empty")
+        print(
+            "warning: this comment may be included in the final brief",
+            file=sys.stderr,
+        )
+        try:
+            note = add_note(path_text, comment, start=Path.cwd())
+        except SetupError as error:
+            parser.error(str(error))
+        print(f"recorded note {note['id']} for {note['path']}; updated .silobrief/notes.json")
 
     return 0

--- a/src/silobrief/notes.py
+++ b/src/silobrief/notes.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from silobrief.state import (
+    ConfigData,
+    HumanNoteData,
+    NotesData,
+    SetupError,
+    find_project_root,
+    load_config,
+    load_notes,
+    save_notes,
+)
+
+
+def add_note(
+    path_text: str,
+    comment: str,
+    *,
+    start: Path,
+) -> HumanNoteData:
+    if not comment.strip():
+        raise SetupError("note comment must not be empty")
+
+    root = find_project_root(start)
+    relative_path = _note_path(root, start, path_text)
+    config = load_config(root)
+    _require_allowed_path(relative_path, config)
+    notes = load_notes(root)
+    note = HumanNoteData(
+        comment=comment,
+        id=_note_id(len(notes["notes"]), relative_path, comment),
+        path=relative_path,
+    )
+    updated = NotesData(notes=[*notes["notes"], note], notes_version=1)
+    save_notes(root, updated)
+    return note
+
+
+def _note_path(root: Path, start: Path, path_text: str) -> str:
+    if not path_text:
+        raise SetupError("note path must not be empty")
+    windows_path = PureWindowsPath(path_text)
+    normalized = PurePosixPath(path_text.replace("\\", "/"))
+    if normalized.is_absolute() or windows_path.drive or windows_path.root:
+        raise SetupError("note path must be relative")
+    if ".." in normalized.parts:
+        raise SetupError("note path must not contain ..")
+
+    try:
+        current = start.resolve(strict=True)
+        current.relative_to(root)
+    except (OSError, ValueError) as error:
+        raise SetupError("current directory is outside the project root") from error
+
+    candidate = current
+    for part in (part for part in normalized.parts if part not in ("", ".")):
+        candidate /= part
+        if candidate.is_symlink():
+            raise SetupError("note path must not contain symbolic links")
+    if not candidate.is_file() and not candidate.is_dir():
+        raise SetupError("note path must be an existing file or directory")
+
+    try:
+        relative = candidate.resolve(strict=True).relative_to(root)
+    except (OSError, ValueError) as error:
+        raise SetupError("note path resolves outside the project root") from error
+    return relative.as_posix() or "."
+
+
+def _require_allowed_path(path: str, config: ConfigData) -> None:
+    parts = PurePosixPath(path).parts
+    excluded_names = {excluded.removesuffix("/") for excluded in config["default_excludes"]}
+    if any(part in excluded_names for part in parts):
+        raise SetupError("note path is excluded by the default policy")
+    if any(
+        boundary["path"] == "."
+        or path == boundary["path"]
+        or path.startswith(f"{boundary['path']}/")
+        for boundary in config["boundaries"]
+    ):
+        raise SetupError("note path is inside a registered boundary")
+
+
+def _note_id(position: int, path: str, comment: str) -> str:
+    value: dict[str, object] = {
+        "comment": comment,
+        "path": path,
+        "position": position,
+    }
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"note-{hashlib.sha256(encoded).hexdigest()}"

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 
 STATE_DIRECTORY = ".silobrief"
 _BOUNDARY_ALIAS_PATTERN = re.compile(r"[a-z0-9-]{1,40}")
+_NOTE_ID_PATTERN = re.compile(r"note-[0-9a-f]{64}")
 DEFAULT_EXCLUDES = (
     ".git/",
     ".silobrief/",
@@ -37,8 +38,14 @@ class ConfigData(TypedDict):
     schema_version: int
 
 
-class _NotesData(TypedDict):
-    notes: list[object]
+class HumanNoteData(TypedDict):
+    comment: str
+    id: str
+    path: str
+
+
+class NotesData(TypedDict):
+    notes: list[HumanNoteData]
     notes_version: int
 
 
@@ -68,7 +75,7 @@ def setup_project(project: Path) -> None:
                 schema_version=1,
             ),
         )
-        _write_json(state / "notes.json", _NotesData(notes=[], notes_version=1))
+        _write_json(state / "notes.json", NotesData(notes=[], notes_version=1))
     except OSError as error:
         shutil.rmtree(state, ignore_errors=True)
         raise SetupError(f"cannot initialize {STATE_DIRECTORY}: {error}") from error
@@ -110,6 +117,14 @@ def save_config(root: Path, config: ConfigData) -> None:
     _write_json_atomic(root / STATE_DIRECTORY / "config.json", config)
 
 
+def load_notes(root: Path) -> NotesData:
+    return _parse_notes(_read_object(root / STATE_DIRECTORY / "notes.json"))
+
+
+def save_notes(root: Path, notes: NotesData) -> None:
+    _write_json_atomic(root / STATE_DIRECTORY / "notes.json", notes)
+
+
 def mark_index_stale(root: Path) -> None:
     index = root / STATE_DIRECTORY / "index.json"
     if not index.exists() and not index.is_symlink():
@@ -125,12 +140,15 @@ def is_valid_boundary_alias(alias: str) -> bool:
     return _BOUNDARY_ALIAS_PATTERN.fullmatch(alias) is not None
 
 
-def _write_json(path: Path, value: ConfigData | _NotesData | dict[str, object]) -> None:
+def _write_json(path: Path, value: ConfigData | NotesData | dict[str, object]) -> None:
     content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     path.write_text(content, encoding="utf-8", newline="\n")
 
 
-def _write_json_atomic(path: Path, value: ConfigData | dict[str, object]) -> None:
+def _write_json_atomic(
+    path: Path,
+    value: ConfigData | NotesData | dict[str, object],
+) -> None:
     content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     try:
         descriptor, temporary_name = tempfile.mkstemp(
@@ -161,11 +179,7 @@ def _validate_state(state: Path) -> ConfigData:
 
     config = _parse_config(_read_object(state / "config.json"))
 
-    notes = _read_object(state / "notes.json")
-    if set(notes) != {"notes", "notes_version"}:
-        raise SetupError("notes.json has an incompatible schema")
-    if not _is_version_one(notes["notes_version"]) or not isinstance(notes["notes"], list):
-        raise SetupError("notes.json is not compatible with version 1")
+    _parse_notes(_read_object(state / "notes.json"))
 
     exports = state / "exports"
     if exports.is_symlink() or not exports.is_dir():
@@ -228,6 +242,44 @@ def _parse_boundary(value: object) -> BoundaryData:
     if not _is_stored_boundary_path(path):
         raise SetupError("config.json boundary path is invalid")
     return BoundaryData(alias=alias, description=description, path=path)
+
+
+def _parse_notes(value: dict[str, object]) -> NotesData:
+    if set(value) != {"notes", "notes_version"}:
+        raise SetupError("notes.json has an incompatible schema")
+    if not _is_version_one(value["notes_version"]):
+        raise SetupError("notes.json has an unsupported version")
+    raw_notes = value["notes"]
+    if not isinstance(raw_notes, list):
+        raise SetupError("notes.json notes must be an array")
+    notes = [_parse_note(item) for item in raw_notes]
+    if len({note["id"] for note in notes}) != len(notes):
+        raise SetupError("notes.json contains duplicate note IDs")
+    return NotesData(notes=notes, notes_version=1)
+
+
+def _parse_note(value: object) -> HumanNoteData:
+    if not isinstance(value, dict):
+        raise SetupError("notes.json note must be an object")
+    note: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise SetupError("notes.json note contains a non-string key")
+        note[key] = item
+    if set(note) != {"comment", "id", "path"}:
+        raise SetupError("notes.json note has an incompatible schema")
+    comment = note["comment"]
+    note_id = note["id"]
+    path = note["path"]
+    if not isinstance(comment, str) or not isinstance(note_id, str) or not isinstance(path, str):
+        raise SetupError("notes.json note fields must be strings")
+    if not comment.strip():
+        raise SetupError("notes.json note comment is empty")
+    if _NOTE_ID_PATTERN.fullmatch(note_id) is None:
+        raise SetupError("notes.json note ID is invalid")
+    if not _is_stored_boundary_path(path):
+        raise SetupError("notes.json note path is invalid")
+    return HumanNoteData(comment=comment, id=note_id, path=path)
 
 
 def _is_stored_boundary_path(path: str) -> bool:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+from silobrief.cli import main
+from silobrief.state import SetupError
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def read_notes(project: Path) -> dict[str, object]:
+    value: object = json.loads((project / ".silobrief" / "notes.json").read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("notes must be a JSON object")
+    return {str(key): item for key, item in value.items()}
+
+
+class HumanNotesTests(unittest.TestCase):
+    def assert_log_error(self, arguments: list[str]) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main(["log", *arguments])
+        self.assertEqual(caught.exception.code, 2)
+        return stderr.getvalue()
+
+    def test_log_preserves_order_and_is_independent_of_absolute_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            projects = (root / "first", root / "second")
+            rendered: list[bytes] = []
+
+            for project in projects:
+                package = project / "package"
+                package.mkdir(parents=True)
+                source = package / "service.py"
+                source.write_text("VALUE = 1\n", encoding="utf-8", newline="\n")
+                source_digest = hashlib.sha256(source.read_bytes()).digest()
+                self.assertEqual(main(["setup", str(project)]), 0)
+                index = project / ".silobrief" / "index.json"
+                index.write_text(
+                    '{"index_version": 1, "stale": false}\n',
+                    encoding="utf-8",
+                    newline="\n",
+                )
+                fixed_time = 1_700_000_000_000_000_000
+                os.utime(index, ns=(fixed_time, fixed_time))
+                index_before = (index.read_bytes(), index.stat().st_mtime_ns)
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+
+                with (
+                    working_directory(project),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    self.assertEqual(
+                        main(
+                            [
+                                "log",
+                                "package/service.py",
+                                "--comment",
+                                " Handles retry policy ",
+                            ]
+                        ),
+                        0,
+                    )
+                with (
+                    working_directory(package),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(stderr),
+                ):
+                    self.assertEqual(
+                        main(["log", ".", "--comment", "Package maintenance context"]),
+                        0,
+                    )
+
+                notes_path = project / ".silobrief" / "notes.json"
+                rendered.append(notes_path.read_bytes())
+                notes = read_notes(project)["notes"]
+                if not isinstance(notes, list) or len(notes) != 2:
+                    self.fail("two notes must be stored")
+                first, second = notes
+                if not isinstance(first, dict) or not isinstance(second, dict):
+                    self.fail("notes must be objects")
+                self.assertEqual(first.get("path"), "package/service.py")
+                self.assertEqual(first.get("comment"), " Handles retry policy ")
+                self.assertEqual(second.get("path"), "package")
+                self.assertEqual(second.get("comment"), "Package maintenance context")
+                first_id = first.get("id")
+                second_id = second.get("id")
+                self.assertIsInstance(first_id, str)
+                self.assertIsInstance(second_id, str)
+                self.assertRegex(str(first_id), r"note-[0-9a-f]{64}")
+                self.assertRegex(str(second_id), r"note-[0-9a-f]{64}")
+                self.assertNotEqual(first_id, second_id)
+                self.assertEqual(index_before, (index.read_bytes(), index.stat().st_mtime_ns))
+                self.assertEqual(hashlib.sha256(source.read_bytes()).digest(), source_digest)
+                self.assertEqual(stderr.getvalue().count("may be included in the final brief"), 2)
+                self.assertEqual(stdout.getvalue().count("updated .silobrief/notes.json"), 2)
+
+            self.assertEqual(rendered[0], rendered[1])
+            self.assertNotIn(str(projects[0]).encode(), rendered[0])
+            self.assertNotIn(str(projects[1]).encode(), rendered[1])
+
+    def test_log_rejects_invalid_or_excluded_paths_and_blank_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            project.mkdir()
+            allowed = project / "allowed.py"
+            allowed.write_text("pass\n", encoding="utf-8", newline="\n")
+            private = project / "private.py"
+            private.write_text("pass\n", encoding="utf-8", newline="\n")
+            (project / ".git").mkdir()
+            outside = root / "outside.py"
+            outside.write_text("pass\n", encoding="utf-8", newline="\n")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            with working_directory(project), contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(main(["ignore", "private.py", "--as", "Private module"]), 0)
+            notes = project / ".silobrief" / "notes.json"
+            before = notes.read_bytes()
+            cases = [
+                [str(allowed.resolve()), "--comment", "Absolute"],
+                ["../outside.py", "--comment", "Parent"],
+                ["missing.py", "--comment", "Missing"],
+                [".git", "--comment", "Default excluded"],
+                ["private.py", "--comment", "Boundary"],
+                ["allowed.py", "--comment", " \t"],
+            ]
+
+            with working_directory(project):
+                for arguments in cases:
+                    with self.subTest(arguments=arguments):
+                        self.assert_log_error(arguments)
+                        self.assertEqual(notes.read_bytes(), before)
+
+    def test_log_rejects_symlink_target_and_component(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            actual = project / "actual"
+            actual.mkdir(parents=True)
+            source = actual / "service.py"
+            source.write_text("pass\n", encoding="utf-8", newline="\n")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            file_link = project / "service-link.py"
+            directory_link = project / "directory-link"
+            try:
+                file_link.symlink_to(source)
+                directory_link.symlink_to(actual, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"symbolic links unavailable: {error}")
+            notes = project / ".silobrief" / "notes.json"
+            before = notes.read_bytes()
+
+            with working_directory(project):
+                for path_text in ("service-link.py", "directory-link/service.py"):
+                    with self.subTest(path=path_text):
+                        self.assert_log_error([path_text, "--comment", "Must fail"])
+                        self.assertEqual(notes.read_bytes(), before)
+
+    def test_state_rejects_invalid_note_entries(self) -> None:
+        invalid_notes: list[object] = [
+            "not-an-object",
+            {"id": "note-short", "path": "module.py", "comment": "Context"},
+            {"id": f"note-{'a' * 64}", "path": "../module.py", "comment": "Context"},
+            {"id": f"note-{'a' * 64}", "path": "module.py", "comment": "   "},
+            {
+                "id": f"note-{'a' * 64}",
+                "path": "module.py",
+                "comment": "Context",
+                "extra": True,
+            },
+        ]
+
+        for invalid in invalid_notes:
+            with self.subTest(invalid=invalid), tempfile.TemporaryDirectory() as directory:
+                project = Path(directory)
+                self.assertEqual(main(["setup", str(project)]), 0)
+                notes = project / ".silobrief" / "notes.json"
+                notes.write_text(
+                    json.dumps({"notes": [invalid], "notes_version": 1}) + "\n",
+                    encoding="utf-8",
+                    newline="\n",
+                )
+                before = notes.read_bytes()
+
+                with (
+                    contextlib.redirect_stderr(io.StringIO()),
+                    self.assertRaises(SystemExit) as caught,
+                ):
+                    main(["setup", str(project)])
+
+                self.assertEqual(caught.exception.code, 2)
+                self.assertEqual(notes.read_bytes(), before)
+
+    def test_log_preserves_notes_when_atomic_save_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "module.py"
+            source.write_text("pass\n", encoding="utf-8", newline="\n")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            notes = project / ".silobrief" / "notes.json"
+            before = notes.read_bytes()
+            stderr = io.StringIO()
+
+            with (
+                working_directory(project),
+                contextlib.redirect_stderr(stderr),
+                mock.patch("silobrief.notes.save_notes", side_effect=SetupError("write failed")),
+            ):
+                with self.assertRaises(SystemExit) as caught:
+                    main(["log", "module.py", "--comment", "Public context"])
+
+            self.assertEqual(caught.exception.code, 2)
+            self.assertEqual(notes.read_bytes(), before)
+            self.assertLess(
+                stderr.getvalue().index("may be included in the final brief"),
+                stderr.getvalue().index("write failed"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- `sb log PATH --comment TEXT` 명령을 추가합니다.
- 메모가 최종 브리프에 포함될 수 있음을 저장 전에 경고합니다.
- 프로젝트 안의 허용 파일·디렉터리만 메모 대상으로 받습니다.
- 절대경로, `..`, 기본 제외, 등록 경계와 symbolic link 경로를 거부합니다.
- 작성 순서와 원문을 보존하면서 시간·절대경로에 의존하지 않는 note ID를 생성합니다.
- `notes.json` entry schema와 ID 중복을 엄격히 검증하고 원자적으로 저장합니다.

## 이유

코드 구조만으로 설명할 수 없는 공개 가능한 유지보수 맥락을 기록할 공개 CLI와 검증된 상태 계약이 필요합니다.

## 영향

메모 추가는 기존 `index.json`을 변경하거나 stale 처리하지 않습니다. lexical ranking, Markdown renderer, 메모 수정·삭제는 이 PR 범위에 포함하지 않습니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests -v` (55개 통과, Windows 권한상 symlink 4개 제외)
- `python -m build --no-isolation --outdir build/verify-17`

Refs #17