### PR TITLE
feat(ranking): rank lexical candidates

### DIFF
--- a/src/silobrief/ranking.py
+++ b/src/silobrief/ranking.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from silobrief.index import IndexData, IndexNode
+from silobrief.search_tokens import normalize_search_tokens
+from silobrief.state import HumanNoteData, NotesData
+
+_SYMBOL_WEIGHT = 5
+_PATH_WEIGHT = 4
+_IMPORT_WEIGHT = 3
+_DOCSTRING_WEIGHT = 2
+_COMMENT_WEIGHT = 1
+_NOTE_WEIGHT = 4
+_MAX_CONNECTIVITY_SCORE = 3
+_MAX_CANDIDATES = 10
+
+
+@dataclass(frozen=True, slots=True)
+class RankEvidence:
+    path_matches: int
+    symbol_matches: int
+    import_matches: int
+    docstring_matches: int
+    comment_matches: int
+    note_match: bool
+    connected_nodes: int
+
+
+@dataclass(frozen=True, slots=True)
+class RankedCandidate:
+    node: IndexNode
+    score: int
+    evidence: RankEvidence
+
+
+def rank_candidates(
+    prompt: str,
+    index: IndexData,
+    notes: NotesData,
+) -> tuple[RankedCandidate, ...]:
+    query = frozenset(normalize_search_tokens(prompt))
+    if not query:
+        return ()
+
+    adjacency = _adjacency(index)
+    note_tokens = tuple(
+        (note, frozenset(normalize_search_tokens(note["comment"]))) for note in notes["notes"]
+    )
+    candidates: list[RankedCandidate] = []
+    for candidate in index.nodes:
+        evidence = _evidence(candidate, query, adjacency, note_tokens)
+        if not _has_text_match(evidence):
+            continue
+        candidates.append(
+            RankedCandidate(
+                node=candidate,
+                score=_score(evidence),
+                evidence=evidence,
+            )
+        )
+    candidates.sort(key=_candidate_key)
+    return tuple(candidates[:_MAX_CANDIDATES])
+
+
+def _evidence(
+    node: IndexNode,
+    query: frozenset[str],
+    adjacency: dict[str, frozenset[str]],
+    note_tokens: tuple[tuple[HumanNoteData, frozenset[str]], ...],
+) -> RankEvidence:
+    return RankEvidence(
+        path_matches=_match_count(query, node.tokens.path),
+        symbol_matches=_match_count(query, node.tokens.symbol),
+        import_matches=_match_count(query, node.tokens.imports),
+        docstring_matches=_match_count(query, node.tokens.docstrings),
+        comment_matches=_match_count(query, node.tokens.comments),
+        note_match=any(
+            _note_applies(note["path"], node.path) and not query.isdisjoint(tokens)
+            for note, tokens in note_tokens
+        ),
+        connected_nodes=len(adjacency.get(node.id, ())),
+    )
+
+
+def _adjacency(index: IndexData) -> dict[str, frozenset[str]]:
+    node_ids = {node.id for node in index.nodes}
+    neighbors: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+    for edge in index.edges:
+        target_id = edge.target_id
+        if (
+            edge.source_id not in node_ids
+            or target_id not in node_ids
+            or edge.source_id == target_id
+        ):
+            continue
+        neighbors[edge.source_id].add(target_id)
+        neighbors[target_id].add(edge.source_id)
+    return {node_id: frozenset(values) for node_id, values in neighbors.items()}
+
+
+def _note_applies(note_path: str, node_path: str) -> bool:
+    return note_path == "." or node_path == note_path or node_path.startswith(f"{note_path}/")
+
+
+def _match_count(query: frozenset[str], tokens: tuple[str, ...]) -> int:
+    return len(query.intersection(tokens))
+
+
+def _has_text_match(evidence: RankEvidence) -> bool:
+    return bool(
+        evidence.path_matches
+        or evidence.symbol_matches
+        or evidence.import_matches
+        or evidence.docstring_matches
+        or evidence.comment_matches
+        or evidence.note_match
+    )
+
+
+def _score(evidence: RankEvidence) -> int:
+    return (
+        evidence.symbol_matches * _SYMBOL_WEIGHT
+        + evidence.path_matches * _PATH_WEIGHT
+        + evidence.import_matches * _IMPORT_WEIGHT
+        + evidence.docstring_matches * _DOCSTRING_WEIGHT
+        + evidence.comment_matches * _COMMENT_WEIGHT
+        + (_NOTE_WEIGHT if evidence.note_match else 0)
+        + min(evidence.connected_nodes, _MAX_CONNECTIVITY_SCORE)
+    )
+
+
+def _candidate_key(candidate: RankedCandidate) -> tuple[int, str, int, str, str, str]:
+    kind_order = {"module": 0, "class": 1, "function": 2}
+    node = candidate.node
+    return (
+        -candidate.score,
+        node.path,
+        kind_order[node.kind],
+        node.name,
+        node.qualified_name,
+        node.id,
+    )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.ranking import RankedCandidate, RankEvidence, rank_candidates
+from silobrief.state import HumanNoteData, NotesData
+
+
+def node(
+    node_id: str,
+    path: str,
+    kind: NodeKind,
+    name: str,
+    *,
+    path_tokens: tuple[str, ...] = (),
+    symbol_tokens: tuple[str, ...] = (),
+    import_tokens: tuple[str, ...] = (),
+    comment_tokens: tuple[str, ...] = (),
+    docstring_tokens: tuple[str, ...] = (),
+) -> IndexNode:
+    return IndexNode(
+        id=node_id,
+        kind=kind,
+        name=name,
+        qualified_name=name,
+        path=path,
+        tokens=NodeTokens(
+            path=path_tokens,
+            symbol=symbol_tokens,
+            imports=import_tokens,
+            comments=comment_tokens,
+            docstrings=docstring_tokens,
+        ),
+    )
+
+
+def index(
+    *nodes: IndexNode,
+    edges: tuple[IndexEdge, ...] = (),
+) -> IndexData:
+    return IndexData(
+        config_digest="a" * 64,
+        edges=edges,
+        index_version=1,
+        nodes=nodes,
+        source_digest="b" * 64,
+        stale=False,
+    )
+
+
+def notes(*items: HumanNoteData) -> NotesData:
+    return NotesData(notes=list(items), notes_version=1)
+
+
+class LexicalRankingTests(unittest.TestCase):
+    def test_scores_each_explainable_component_and_caps_connectivity(self) -> None:
+        candidate = node(
+            "candidate",
+            "package/service.py",
+            "function",
+            "RetryClient",
+            path_tokens=("package", "retry", "service"),
+            symbol_tokens=("client", "retry"),
+            import_tokens=("http",),
+            comment_tokens=("comment",),
+            docstring_tokens=("docs",),
+        )
+        neighbors = tuple(
+            node(f"neighbor-{number}", f"other/{number}.py", "function", f"neighbor{number}")
+            for number in range(4)
+        )
+        edges = (
+            IndexEdge("candidate", "call", "one", "neighbor-0"),
+            IndexEdge("candidate", "reference", "one", "neighbor-0"),
+            IndexEdge("candidate", "call", "two", "neighbor-1"),
+            IndexEdge("neighbor-2", "call", "candidate", "candidate"),
+            IndexEdge("neighbor-3", "reference", "candidate", "candidate"),
+            IndexEdge("candidate", "import", "external", None),
+        )
+        human_notes = notes(
+            HumanNoteData(
+                id=f"note-{'a' * 64}",
+                path="package/service.py",
+                comment="NOTE maintenance context",
+            )
+        )
+
+        source_index = index(candidate, *neighbors, edges=edges)
+        ranked = rank_candidates(
+            "RetryClient retry HTTP docs comment note",
+            source_index,
+            human_notes,
+        )
+        reordered = rank_candidates(
+            "RetryClient retry HTTP docs comment note",
+            replace(
+                source_index,
+                edges=tuple(reversed(source_index.edges)),
+                nodes=tuple(reversed(source_index.nodes)),
+            ),
+            human_notes,
+        )
+
+        self.assertEqual(ranked, reordered)
+        self.assertEqual(
+            ranked,
+            (
+                RankedCandidate(
+                    node=candidate,
+                    score=27,
+                    evidence=RankEvidence(
+                        path_matches=1,
+                        symbol_matches=2,
+                        import_matches=1,
+                        docstring_matches=1,
+                        comment_matches=1,
+                        note_match=True,
+                        connected_nodes=4,
+                    ),
+                ),
+            ),
+        )
+
+    def test_directory_and_file_notes_apply_only_to_matching_nodes(self) -> None:
+        service = node("service", "package/service.py", "function", "service")
+        worker = node("worker", "package/jobs/worker.py", "function", "worker")
+        unrelated = node("other", "other.py", "function", "other")
+        human_notes = notes(
+            HumanNoteData(
+                id=f"note-{'a' * 64}",
+                path="package",
+                comment="Retry ownership",
+            ),
+            HumanNoteData(
+                id=f"note-{'b' * 64}",
+                path="other.py",
+                comment="Different context",
+            ),
+        )
+
+        ranked = rank_candidates("retry", index(unrelated, worker, service), human_notes)
+        reversed_notes = notes(*reversed(human_notes["notes"]))
+        reordered = rank_candidates(
+            "retry",
+            index(service, worker, unrelated),
+            reversed_notes,
+        )
+
+        self.assertEqual(ranked, reordered)
+        self.assertEqual([item.node.id for item in ranked], ["worker", "service"])
+        self.assertTrue(all(item.score == 4 for item in ranked))
+        self.assertTrue(all(item.evidence.note_match for item in ranked))
+
+    def test_limits_results_and_uses_deterministic_tie_breakers(self) -> None:
+        same_path = (
+            node("module", "a.py", "module", "module", symbol_tokens=("match",)),
+            node("class", "a.py", "class", "class", symbol_tokens=("match",)),
+            node("function-a", "a.py", "function", "alpha", symbol_tokens=("match",)),
+            node("function-b", "a.py", "function", "beta", symbol_tokens=("match",)),
+        )
+        remaining = tuple(
+            node(
+                f"node-{number:02}",
+                f"path-{number:02}.py",
+                "function",
+                f"name-{number:02}",
+                symbol_tokens=("match",),
+            )
+            for number in range(9)
+        )
+        source_index = index(*same_path, *remaining)
+
+        ranked = rank_candidates("match", source_index, notes())
+        reordered = rank_candidates(
+            "match",
+            replace(source_index, nodes=tuple(reversed(source_index.nodes))),
+            notes(),
+        )
+
+        self.assertEqual(ranked, reordered)
+        self.assertEqual(len(ranked), 10)
+        self.assertEqual(
+            [item.node.id for item in ranked[:4]],
+            ["module", "class", "function-a", "function-b"],
+        )
+        self.assertTrue(all(item.score == 5 for item in ranked))
+
+    def test_requires_literal_token_overlap_without_translation(self) -> None:
+        retry = node(
+            "retry",
+            "service.py",
+            "function",
+            "RetryRequest",
+            symbol_tokens=("request", "retry"),
+        )
+
+        self.assertEqual(rank_candidates("재시도", index(retry), notes()), ())
+        self.assertEqual(rank_candidates("---", index(retry), notes()), ())
+        self.assertEqual(rank_candidates("RetryRequest", index(retry), notes())[0].score, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- 인덱스 노드를 경로·심볼·공개 import·docstring·comment·사람 메모 기준으로 점수화합니다.
- 인접 노드 수를 중복 없이 계산하고 최대 3점으로 제한합니다.
- 입력 순서와 무관한 결정적 정렬 및 최대 10개 제한을 적용합니다.
- 원문이나 검색 토큰을 노출하지 않는 구조화된 점수 근거만 반환합니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests` (59 tests, 4 skipped)
- `python -m build --no-isolation --outdir build/verify-19`

Refs #19