### PR TITLE
feat(review): select and expand project context

### DIFF
--- a/src/silobrief/review.py
+++ b/src/silobrief/review.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from silobrief.index import IndexData, IndexNode, NodeKind
+from silobrief.ranking import RankedCandidate, RankEvidence
+
+_MAX_OPTIONS = 10
+_KIND_ORDER = {"module": 0, "class": 1, "function": 2}
+
+
+class ReviewError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewNode:
+    id: str
+    path: str
+    kind: NodeKind
+    name: str
+    qualified_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateOption:
+    number: int
+    node: ReviewNode
+    score: int
+    evidence: RankEvidence
+
+
+@dataclass(frozen=True, slots=True)
+class DisclosureChoices:
+    paths: bool
+    symbols: bool
+    public_libraries: bool
+    human_notes: bool
+    boundary_placeholders: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewSelection:
+    selected: tuple[ReviewNode, ...]
+    expanded: tuple[ReviewNode, ...]
+    fields: DisclosureChoices
+
+
+def candidate_options(candidates: tuple[RankedCandidate, ...]) -> tuple[CandidateOption, ...]:
+    ordered = sorted(candidates, key=_ranked_key)
+    seen: set[str] = set()
+    options: list[CandidateOption] = []
+    for candidate in ordered:
+        if candidate.node.id in seen:
+            raise ReviewError("ranked candidates contain duplicate nodes")
+        seen.add(candidate.node.id)
+        options.append(
+            CandidateOption(
+                number=len(options) + 1,
+                node=_review_node(candidate.node),
+                score=candidate.score,
+                evidence=candidate.evidence,
+            )
+        )
+    return tuple(options[:_MAX_OPTIONS])
+
+
+def review_selection(
+    index: IndexData,
+    options: tuple[CandidateOption, ...],
+    *,
+    selected_numbers: tuple[int, ...],
+    added: tuple[str, ...],
+    excluded: tuple[str, ...],
+    fields: DisclosureChoices,
+) -> ReviewSelection:
+    if not options:
+        raise ReviewError("no ranked candidates are available")
+
+    nodes = _node_map(index)
+    modules = _module_path_map(nodes.values())
+    option_by_number = _option_map(options, nodes)
+    selected_ids = {_selected_id(number, option_by_number) for number in selected_numbers}
+    selected_ids.update(_resolve_selector(selector, nodes, modules) for selector in added)
+    excluded_ids = {_resolve_selector(selector, nodes, modules) for selector in excluded}
+    selected_ids.difference_update(excluded_ids)
+    if not selected_ids:
+        raise ReviewError("start selection is empty")
+
+    expanded_ids = _expanded_ids(index, selected_ids, set(nodes))
+    expanded_ids.difference_update(selected_ids)
+    expanded_ids.difference_update(excluded_ids)
+    return ReviewSelection(
+        selected=_ordered_review_nodes(selected_ids, nodes),
+        expanded=_ordered_review_nodes(expanded_ids, nodes),
+        fields=fields,
+    )
+
+
+def _node_map(index: IndexData) -> dict[str, IndexNode]:
+    nodes = {node.id: node for node in index.nodes}
+    if len(nodes) != len(index.nodes):
+        raise ReviewError("current index contains duplicate node IDs")
+    return nodes
+
+
+def _module_path_map(nodes: Iterable[IndexNode]) -> dict[str, str]:
+    modules: dict[str, str] = {}
+    for node in nodes:
+        if node.kind != "module":
+            continue
+        if node.path in modules:
+            raise ReviewError("current index contains duplicate module paths")
+        modules[node.path] = node.id
+    return modules
+
+
+def _option_map(
+    options: tuple[CandidateOption, ...],
+    nodes: dict[str, IndexNode],
+) -> dict[int, CandidateOption]:
+    result: dict[int, CandidateOption] = {}
+    for option in options:
+        indexed = nodes.get(option.node.id)
+        if indexed is None or _review_node(indexed) != option.node:
+            raise ReviewError("candidate does not belong to the current index")
+        if option.number < 1 or option.number in result:
+            raise ReviewError("candidate numbers must be unique positive integers")
+        result[option.number] = option
+    return result
+
+
+def _selected_id(number: int, options: dict[int, CandidateOption]) -> str:
+    try:
+        return options[number].node.id
+    except KeyError as error:
+        raise ReviewError(f"unknown candidate number: {number}") from error
+
+
+def _resolve_selector(
+    selector: str,
+    nodes: dict[str, IndexNode],
+    modules: dict[str, str],
+) -> str:
+    if selector in nodes:
+        return selector
+    if selector in modules:
+        return modules[selector]
+    raise ReviewError(f"unknown node ID or path selector: {selector}")
+
+
+def _expanded_ids(
+    index: IndexData,
+    selected_ids: set[str],
+    node_ids: set[str],
+) -> set[str]:
+    expanded: set[str] = set()
+    for edge in index.edges:
+        target_id = edge.target_id
+        if (
+            edge.source_id not in node_ids
+            or target_id not in node_ids
+            or edge.source_id == target_id
+        ):
+            continue
+        if edge.source_id in selected_ids:
+            expanded.add(target_id)
+        if target_id in selected_ids:
+            expanded.add(edge.source_id)
+    return expanded
+
+
+def _ordered_review_nodes(
+    node_ids: set[str],
+    nodes: dict[str, IndexNode],
+) -> tuple[ReviewNode, ...]:
+    selected = (_review_node(nodes[node_id]) for node_id in node_ids)
+    return tuple(sorted(selected, key=_review_node_key))
+
+
+def _review_node(node: IndexNode) -> ReviewNode:
+    return ReviewNode(
+        id=node.id,
+        path=node.path,
+        kind=node.kind,
+        name=node.name,
+        qualified_name=node.qualified_name,
+    )
+
+
+def _ranked_key(candidate: RankedCandidate) -> tuple[int, str, int, str, str, str]:
+    return (-candidate.score, *_index_node_key(candidate.node))
+
+
+def _index_node_key(node: IndexNode) -> tuple[str, int, str, str, str]:
+    return node.path, _KIND_ORDER[node.kind], node.name, node.qualified_name, node.id
+
+
+def _review_node_key(node: ReviewNode) -> tuple[str, int, str, str, str]:
+    return node.path, _KIND_ORDER[node.kind], node.name, node.qualified_name, node.id

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import asdict, replace
+
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.ranking import RankedCandidate, RankEvidence
+from silobrief.review import (
+    CandidateOption,
+    DisclosureChoices,
+    ReviewError,
+    ReviewNode,
+    candidate_options,
+    review_selection,
+)
+
+
+def node(node_id: str, path: str, kind: NodeKind, name: str) -> IndexNode:
+    return IndexNode(
+        id=node_id,
+        kind=kind,
+        name=name,
+        qualified_name=name,
+        path=path,
+        tokens=NodeTokens(
+            path=("raw-canary",),
+            symbol=("raw-canary",),
+            imports=("raw-canary",),
+            comments=("raw-canary",),
+            docstrings=("raw-canary",),
+        ),
+    )
+
+
+def index(*nodes: IndexNode, edges: tuple[IndexEdge, ...] = ()) -> IndexData:
+    return IndexData(
+        config_digest="a" * 64,
+        edges=edges,
+        index_version=1,
+        nodes=nodes,
+        source_digest="b" * 64,
+        stale=False,
+    )
+
+
+def ranked(candidate: IndexNode, score: int) -> RankedCandidate:
+    return RankedCandidate(
+        node=candidate,
+        score=score,
+        evidence=RankEvidence(
+            path_matches=1,
+            symbol_matches=0,
+            import_matches=0,
+            docstring_matches=0,
+            comment_matches=0,
+            note_match=False,
+            connected_nodes=0,
+        ),
+    )
+
+
+FIELDS = DisclosureChoices(
+    paths=True,
+    symbols=True,
+    public_libraries=False,
+    human_notes=True,
+    boundary_placeholders=False,
+)
+
+
+class CandidateOptionTests(unittest.TestCase):
+    def test_builds_deterministic_safe_options_without_search_tokens(self) -> None:
+        alpha = node("alpha", "a.py", "function", "alpha")
+        beta = node("beta", "b.py", "class", "beta")
+        source = (ranked(beta, 4), ranked(alpha, 8))
+
+        options = candidate_options(source)
+        reordered = candidate_options(tuple(reversed(source)))
+
+        self.assertEqual(options, reordered)
+        self.assertEqual([option.number for option in options], [1, 2])
+        self.assertEqual([option.node.id for option in options], ["alpha", "beta"])
+        self.assertEqual(options[0].score, 8)
+        self.assertEqual(options[0].evidence, source[1].evidence)
+        self.assertFalse(hasattr(options[0].node, "tokens"))
+        self.assertNotIn("raw-canary", repr(tuple(asdict(option) for option in options)))
+
+
+class ReviewSelectionTests(unittest.TestCase):
+    def test_selects_adds_excludes_and_expands_exactly_one_step(self) -> None:
+        root = node("root", "src/a.py", "function", "root")
+        added_module = node("added-module", "src/added.py", "module", "added")
+        added_function = node("added-function", "src/added.py", "function", "work")
+        neighbor = node("neighbor", "src/b.py", "class", "neighbor")
+        second_hop = node("second", "src/c.py", "function", "second")
+        excluded = node("excluded", "src/excluded.py", "module", "excluded")
+        edges = (
+            IndexEdge("root", "call", "neighbor", "neighbor"),
+            IndexEdge("neighbor", "reference", "second", "second"),
+            IndexEdge("root", "contains", "excluded", "excluded"),
+            IndexEdge("root", "import", "external", None),
+            IndexEdge("root", "call", "root", "root"),
+        )
+        source_index = index(
+            second_hop,
+            excluded,
+            neighbor,
+            added_function,
+            added_module,
+            root,
+            edges=edges,
+        )
+        options = candidate_options((ranked(root, 5),))
+
+        result = review_selection(
+            source_index,
+            options,
+            selected_numbers=(1, 1),
+            added=("src/added.py", "added-module"),
+            excluded=("src/excluded.py",),
+            fields=FIELDS,
+        )
+        reordered = review_selection(
+            replace(
+                source_index,
+                edges=tuple(reversed(source_index.edges)),
+                nodes=tuple(reversed(source_index.nodes)),
+            ),
+            tuple(reversed(options)),
+            selected_numbers=(1,),
+            added=("added-module", "src/added.py"),
+            excluded=("src/excluded.py", "src/excluded.py"),
+            fields=FIELDS,
+        )
+
+        self.assertEqual(result, reordered)
+        self.assertEqual([item.id for item in result.selected], ["root", "added-module"])
+        self.assertEqual(
+            result.expanded, (ReviewNode("neighbor", "src/b.py", "class", "neighbor", "neighbor"),)
+        )
+        self.assertEqual(result.fields, FIELDS)
+        self.assertNotIn("raw-canary", repr(asdict(result)))
+
+    def test_direct_node_addition_is_an_explicit_start_selection(self) -> None:
+        suggested = node("suggested", "suggested.py", "module", "suggested")
+        direct = node("direct", "direct.py", "function", "direct")
+        options = candidate_options((ranked(suggested, 4),))
+
+        result = review_selection(
+            index(suggested, direct),
+            options,
+            selected_numbers=(),
+            added=("direct",),
+            excluded=(),
+            fields=FIELDS,
+        )
+
+        self.assertEqual([item.id for item in result.selected], ["direct"])
+
+    def test_rejects_missing_candidates_selections_and_unknown_references(self) -> None:
+        root = node("root", "root.py", "module", "root")
+        options = candidate_options((ranked(root, 4),))
+        source_index = index(root)
+
+        cases = (
+            ((), (), (), (), "ranked candidates"),
+            (options, (2,), (), (), "candidate number"),
+            (options, (), ("missing.py",), (), "selector"),
+            (options, (1,), (), ("missing",), "selector"),
+            (options, (1,), (), ("root",), "start selection"),
+        )
+        for supplied_options, selected, added, excluded, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ReviewError, message):
+                    review_selection(
+                        source_index,
+                        supplied_options,
+                        selected_numbers=selected,
+                        added=added,
+                        excluded=excluded,
+                        fields=FIELDS,
+                    )
+
+    def test_rejects_candidate_from_another_index(self) -> None:
+        root = node("root", "root.py", "module", "root")
+        foreign = node("foreign", "foreign.py", "module", "foreign")
+        option = CandidateOption(
+            number=1,
+            node=ReviewNode("foreign", "foreign.py", "module", "foreign", "foreign"),
+            score=4,
+            evidence=ranked(foreign, 4).evidence,
+        )
+
+        with self.assertRaisesRegex(ReviewError, "current index"):
+            review_selection(
+                index(root),
+                (option,),
+                selected_numbers=(1,),
+                added=(),
+                excluded=(),
+                fields=FIELDS,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- 순위 결과를 검색 토큰이나 원문이 없는 안전한 후보 표시 모델로 변환합니다.
- 사용자가 후보 번호와 정확한 상대 경로·노드 ID로 시작 맥락을 선택할 수 있습니다.
- 명시적 제외를 적용한 뒤 resolved 내부 간선을 방향과 무관하게 한 단계만 확장합니다.
- 공개할 다섯 필드의 선택을 불변 결과 모델에 보존합니다.
- 입력 순서와 중복에 관계없는 결정적 결과와 잘못된 참조 거부를 검증합니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests` (64 tests, 4 skipped)
- `python -m build --no-isolation --outdir build/verify-21`

Refs #21