### PR TITLE
feat(output): require explicit write approval

### DIFF
--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -53,7 +53,7 @@ def _output_path(root: Path, start: Path, output_text: str) -> Path:
     windows = PureWindowsPath(output_text)
     if ".." in posix.parts or ".." in windows.parts:
         raise OutputBlockedError("output path must not contain ..")
-    if os.name != "nt" and (windows.drive or windows.root):
+    if _uses_foreign_windows_path(output_text, platform=os.name):
         raise OutputBlockedError("output path uses a Windows absolute path on this system")
 
     try:
@@ -85,6 +85,11 @@ def _output_path(root: Path, start: Path, output_text: str) -> Path:
         raise OutputBlockedError("output path already exists")
     _require_allowed_location(destination, resolved_root)
     return destination
+
+
+def _uses_foreign_windows_path(path: str, *, platform: str) -> bool:
+    windows = PureWindowsPath(path)
+    return platform != "nt" and bool(windows.drive or "\\" in path)
 
 
 def _real_directory(path: Path, label: str) -> Path:

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TextIO
+
+from silobrief.renderer import RenderedBrief
+from silobrief.state import STATE_DIRECTORY
+
+_APPROVAL_PROMPT = "Type exactly WRITE to create the Markdown file: "
+
+
+class OutputBlockedError(Exception):
+    pass
+
+
+def approve_and_write(
+    root: Path,
+    output_text: str,
+    rendered: RenderedBrief,
+    *,
+    start: Path,
+    input_stream: TextIO,
+    output_stream: TextIO,
+) -> Path:
+    if not input_stream.isatty() or not output_stream.isatty():
+        raise OutputBlockedError("approval requires interactive input and output")
+    if type(rendered) is not RenderedBrief:
+        raise OutputBlockedError("output requires a rendered brief")
+
+    destination = _output_path(root, start, output_text)
+    try:
+        output_stream.write(rendered.markdown)
+        output_stream.write(f"\n{_APPROVAL_PROMPT}")
+        output_stream.flush()
+        approval = input_stream.readline()
+    except OSError as error:
+        raise OutputBlockedError(f"cannot complete interactive approval: {error}") from error
+    if _without_line_ending(approval) != "WRITE":
+        raise OutputBlockedError("output was not approved with exact WRITE")
+
+    _write_new_file(destination, rendered.markdown)
+    return destination
+
+
+def _output_path(root: Path, start: Path, output_text: str) -> Path:
+    if not isinstance(output_text, str) or not output_text:
+        raise OutputBlockedError("output path must not be empty")
+    if "/" in output_text and "\\" in output_text:
+        raise OutputBlockedError("output path must not mix path separators")
+
+    posix = PurePosixPath(output_text)
+    windows = PureWindowsPath(output_text)
+    if ".." in posix.parts or ".." in windows.parts:
+        raise OutputBlockedError("output path must not contain ..")
+    if os.name != "nt" and (windows.drive or windows.root):
+        raise OutputBlockedError("output path uses a Windows absolute path on this system")
+
+    try:
+        requested = Path(output_text)
+    except (OSError, ValueError) as error:
+        raise OutputBlockedError(f"output path is invalid: {error}") from error
+    if requested.suffix != ".md":
+        raise OutputBlockedError("output path must use the .md extension")
+
+    resolved_root = _real_directory(root, "project root")
+    resolved_start = _real_directory(start, "current directory")
+    try:
+        resolved_start.relative_to(resolved_root)
+    except ValueError as error:
+        raise OutputBlockedError("current directory is outside the project root") from error
+
+    candidate = requested if requested.is_absolute() else resolved_start / requested
+    candidate = candidate.absolute()
+    if candidate.is_symlink():
+        raise OutputBlockedError("output path must not be a symbolic link")
+    if candidate.exists():
+        raise OutputBlockedError("output path already exists")
+
+    parent = _real_parent(candidate.parent)
+    destination = parent / candidate.name
+    if destination.is_symlink():
+        raise OutputBlockedError("output path must not be a symbolic link")
+    if destination.exists():
+        raise OutputBlockedError("output path already exists")
+    _require_allowed_location(destination, resolved_root)
+    return destination
+
+
+def _real_directory(path: Path, label: str) -> Path:
+    if path.is_symlink() or not path.is_dir():
+        raise OutputBlockedError(f"{label} must be a real directory")
+    try:
+        return path.resolve(strict=True)
+    except OSError as error:
+        raise OutputBlockedError(f"cannot resolve {label}: {error}") from error
+
+
+def _real_parent(parent: Path) -> Path:
+    current = Path(parent.anchor)
+    for part in parent.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise OutputBlockedError("output path contains a symbolic link")
+    if not parent.is_dir():
+        raise OutputBlockedError("output parent must be an existing directory")
+    try:
+        return parent.resolve(strict=True)
+    except OSError as error:
+        raise OutputBlockedError(f"cannot resolve output parent: {error}") from error
+
+
+def _require_allowed_location(destination: Path, root: Path) -> None:
+    try:
+        destination.relative_to(root)
+    except ValueError:
+        return
+
+    exports = root / STATE_DIRECTORY / "exports"
+    if exports.is_symlink() or not exports.is_dir():
+        raise OutputBlockedError("project exports must be a real directory")
+    try:
+        resolved_exports = exports.resolve(strict=True)
+        destination.relative_to(resolved_exports)
+    except (OSError, ValueError) as error:
+        raise OutputBlockedError(
+            f"project output must be inside {STATE_DIRECTORY}/exports"
+        ) from error
+
+
+def _without_line_ending(value: str) -> str:
+    if value.endswith("\r\n"):
+        return value[:-2]
+    if value.endswith(("\r", "\n")):
+        return value[:-1]
+    return value
+
+
+def _write_new_file(path: Path, content: str) -> None:
+    try:
+        encoded = content.encode("utf-8")
+    except UnicodeError as error:
+        raise OutputBlockedError("rendered brief is not valid UTF-8 text") from error
+
+    created = False
+    try:
+        with path.open("xb") as stream:
+            created = True
+            stream.write(encoded)
+    except FileExistsError as error:
+        raise OutputBlockedError("output path already exists") from error
+    except OSError as error:
+        if created:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise OutputBlockedError(f"cannot create output file: {error}") from error

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -6,7 +6,11 @@ import unittest
 from pathlib import Path
 from typing import TextIO, cast
 
-from silobrief.output import OutputBlockedError, approve_and_write
+from silobrief.output import (
+    OutputBlockedError,
+    _uses_foreign_windows_path,
+    approve_and_write,
+)
 from silobrief.renderer import BriefInput, RenderedBrief, render_brief
 from silobrief.state import setup_project
 
@@ -58,6 +62,12 @@ def project_in(directory: str) -> Path:
 
 
 class ApprovedOutputTests(unittest.TestCase):
+    def test_distinguishes_posix_absolute_paths_from_windows_syntax(self) -> None:
+        self.assertFalse(_uses_foreign_windows_path("/tmp/brief.md", platform="posix"))
+        self.assertTrue(_uses_foreign_windows_path("C:\\temp\\brief.md", platform="posix"))
+        self.assertTrue(_uses_foreign_windows_path("\\temp\\brief.md", platform="posix"))
+        self.assertFalse(_uses_foreign_windows_path("C:\\temp\\brief.md", platform="nt"))
+
     def test_previews_full_markdown_and_writes_new_utf8_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             project = project_in(directory)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from typing import TextIO, cast
+
+from silobrief.output import OutputBlockedError, approve_and_write
+from silobrief.renderer import BriefInput, RenderedBrief, render_brief
+from silobrief.state import setup_project
+
+
+class TtyBuffer(io.StringIO):
+    def __init__(self, value: str = "", *, tty: bool = True) -> None:
+        super().__init__(value)
+        self.tty = tty
+        self.flush_count = 0
+
+    def isatty(self) -> bool:
+        return self.tty
+
+    def flush(self) -> None:
+        self.flush_count += 1
+        super().flush()
+
+
+class RacingInput:
+    def __init__(self, target: Path) -> None:
+        self.target = target
+
+    def isatty(self) -> bool:
+        return True
+
+    def readline(self, size: int = -1) -> str:
+        self.target.write_text("rival content", encoding="utf-8")
+        return "WRITE\n" if size != 0 else ""
+
+
+def rendered_brief() -> RenderedBrief:
+    return render_brief(
+        BriefInput(
+            user_prompt="공식 문서를 확인해줘",
+            relative_paths=("src/api.py",),
+            symbols=(),
+            public_dependencies=("Python",),
+            human_notes=(),
+            boundaries=(),
+        )
+    )
+
+
+def project_in(directory: str) -> Path:
+    project = Path(directory) / "project"
+    project.mkdir()
+    setup_project(project)
+    return project
+
+
+class ApprovedOutputTests(unittest.TestCase):
+    def test_previews_full_markdown_and_writes_new_utf8_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            rendered = rendered_brief()
+            stdin = TtyBuffer("WRITE\n")
+            stdout = TtyBuffer()
+
+            result = approve_and_write(
+                project,
+                ".silobrief/exports/result.md",
+                rendered,
+                start=project,
+                input_stream=stdin,
+                output_stream=stdout,
+            )
+
+            destination = project / ".silobrief" / "exports" / "result.md"
+            self.assertEqual(result, destination.resolve())
+            self.assertEqual(destination.read_bytes(), rendered.markdown.encode("utf-8"))
+            self.assertTrue(stdout.getvalue().startswith(rendered.markdown))
+            self.assertIn("exactly WRITE", stdout.getvalue())
+            self.assertGreaterEqual(stdout.flush_count, 1)
+            self.assertEqual([path.name for path in destination.parent.iterdir()], ["result.md"])
+
+    def test_allows_explicit_output_outside_the_project(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            destination = outside / "brief.md"
+
+            result = approve_and_write(
+                project,
+                str(destination),
+                rendered_brief(),
+                start=project,
+                input_stream=TtyBuffer("WRITE\r\n"),
+                output_stream=TtyBuffer(),
+            )
+
+            self.assertEqual(result, destination.resolve())
+            self.assertTrue(destination.is_file())
+
+    def test_requires_both_ttys_and_an_exact_approval(self) -> None:
+        cases = (
+            (False, True, "WRITE\n"),
+            (True, False, "WRITE\n"),
+            (True, True, "write\n"),
+            (True, True, " WRITE\n"),
+            (True, True, "WRITE \n"),
+            (True, True, "YES\n"),
+            (True, True, ""),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            exports = project / ".silobrief" / "exports"
+            before = tuple(exports.iterdir())
+
+            for number, (input_tty, output_tty, approval) in enumerate(cases):
+                with self.subTest(approval=approval, input_tty=input_tty, output_tty=output_tty):
+                    destination = f".silobrief/exports/refused-{number}.md"
+                    with self.assertRaises(OutputBlockedError):
+                        approve_and_write(
+                            project,
+                            destination,
+                            rendered_brief(),
+                            start=project,
+                            input_stream=TtyBuffer(approval, tty=input_tty),
+                            output_stream=TtyBuffer(tty=output_tty),
+                        )
+                    self.assertFalse((project / destination).exists())
+                    self.assertEqual(tuple(exports.iterdir()), before)
+
+    def test_rejects_invalid_and_existing_output_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            existing = project / ".silobrief" / "exports" / "existing.md"
+            existing.write_text("keep this", encoding="utf-8")
+            existing_directory = project / ".silobrief" / "exports" / "folder.md"
+            existing_directory.mkdir()
+            cases = (
+                "result.md",
+                ".silobrief/exports/result.txt",
+                ".silobrief/exports/result.MD",
+                ".silobrief/exports/missing/result.md",
+                "../outside/traversal.md",
+                ".silobrief/exports\\mixed.md",
+                ".silobrief/exports/existing.md",
+                ".silobrief/exports/folder.md",
+            )
+
+            for output in cases:
+                with self.subTest(output=output):
+                    with self.assertRaises(OutputBlockedError):
+                        approve_and_write(
+                            project,
+                            output,
+                            rendered_brief(),
+                            start=project,
+                            input_stream=TtyBuffer("WRITE\n"),
+                            output_stream=TtyBuffer(),
+                        )
+            self.assertEqual(existing.read_text(encoding="utf-8"), "keep this")
+            self.assertTrue(existing_directory.is_dir())
+            self.assertFalse((outside / "traversal.md").exists())
+
+    def test_exclusive_creation_blocks_a_file_created_during_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            destination = project / ".silobrief" / "exports" / "race.md"
+
+            with self.assertRaisesRegex(OutputBlockedError, "already exists"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/race.md",
+                    rendered_brief(),
+                    start=project,
+                    input_stream=cast(TextIO, RacingInput(destination)),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertEqual(destination.read_text(encoding="utf-8"), "rival content")
+
+    def test_rejects_output_and_parent_symbolic_links(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            exports = project / ".silobrief" / "exports"
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            target = outside / "target.md"
+            target.write_text("target content", encoding="utf-8")
+            output_link = exports / "linked.md"
+            parent_link = exports / "linked-parent"
+            try:
+                output_link.symlink_to(target)
+                parent_link.symlink_to(outside, target_is_directory=True)
+            except OSError as error:
+                self.skipTest(f"symbolic links are unavailable: {error}")
+
+            for output in (
+                ".silobrief/exports/linked.md",
+                ".silobrief/exports/linked-parent/result.md",
+            ):
+                with self.subTest(output=output):
+                    with self.assertRaisesRegex(OutputBlockedError, "symbolic link"):
+                        approve_and_write(
+                            project,
+                            output,
+                            rendered_brief(),
+                            start=project,
+                            input_stream=TtyBuffer("WRITE\n"),
+                            output_stream=TtyBuffer(),
+                        )
+            self.assertEqual(target.read_text(encoding="utf-8"), "target content")
+            self.assertFalse((outside / "result.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- 표준 입력과 출력이 모두 TTY일 때만 저장 승인을 시작합니다.
- 완성된 Markdown 전체를 preview하고 줄 끝을 제외해 정확히 `WRITE`인 입력만 승인합니다.
- `.md` 확장자, 실제 부모 디렉터리, 프로젝트 내부 exports 위치와 symlink 경계를 검증합니다.
- 승인 전에는 산출물을 만들지 않고 승인 후 UTF-8 bytes를 `xb`로 배타 생성합니다.
- 기존 파일·디렉터리·symlink와 승인 도중 생성된 경합 파일을 덮어쓰지 않습니다.

## 검증

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m unittest discover -s tests` (75 tests, 5 skipped on local Windows)
- `python -m build --no-isolation --outdir build/verify-25`

Refs #25