### PR TITLE
feat(init): build local source index

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -29,8 +29,7 @@ sb setup [PATH]
 ```
 
 이 명령은 `.silobrief/config.json`, `.silobrief/notes.json`, `.silobrief/exports/`를
-만듭니다. 다시 실행하면 기존 상태를 덮어쓰지 않고 호환 여부만 검사합니다. 인덱스는
-아직 구현되지 않은 `sb init`에서 생성합니다.
+만듭니다. 다시 실행하면 기존 상태를 덮어쓰지 않고 호환 여부만 검사합니다.
 
 기존 프로젝트 파일이나 디렉터리를 제외 경계로 등록합니다.
 
@@ -42,6 +41,15 @@ sb ignore PATH --as "공개 가능한 설명" [--alias NAME]
 상대경로여야 하며 `..`를 포함하거나 symbolic link를 통과할 수 없습니다. 저장 경로는
 `/` 구분자를 사용합니다. `--alias`를 생략하면 실제 경로명과 무관한 `boundary-N`이
 부여됩니다. 설명은 공개 가능한 문장으로 간주합니다.
+
+경계를 등록한 다음 로컬 소스 인덱스를 생성하거나 갱신합니다.
+
+```console
+sb init
+```
+
+이 명령은 symbolic link를 따라가지 않고 허용된 Python 파일만 읽습니다. 파싱에 성공하고
+소스 snapshot이 바뀌지 않은 경우에만 `.silobrief/index.json`을 교체합니다.
 
 ## 범위와 한계
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sb setup [PATH]
 
 This creates `.silobrief/config.json`, `.silobrief/notes.json`, and
 `.silobrief/exports/`. Running the command again validates compatible state without
-overwriting it. The index is created later by `sb init`, which is not implemented yet.
+overwriting it.
 
 Register an existing project file or directory as an excluded boundary:
 
@@ -42,6 +42,15 @@ Run this command from the project root or one of its subdirectories. `PATH` must
 to the current directory and cannot contain `..` or pass through a symbolic link. Stored paths
 use `/` separators. If `--alias` is omitted, siloBrief assigns a path-independent
 `boundary-N` name. The description is treated as public text.
+
+Build or refresh the local source index after registering boundaries:
+
+```console
+sb init
+```
+
+The command reads allowed Python files without following symbolic links and replaces
+`.silobrief/index.json` only after parsing succeeds and the source snapshot remains unchanged.
 
 ## Boundaries
 

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from silobrief import __version__
 from silobrief.boundaries import register_boundary
+from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
 from silobrief.notes import add_note
 from silobrief.state import SetupError, setup_project
 
@@ -24,6 +25,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ignore.add_argument("path")
     ignore.add_argument("--as", dest="description", required=True)
     ignore.add_argument("--alias")
+    subcommands.add_parser("init", help="Build the local source index.")
     log = subcommands.add_parser("log", help="Record public project context.")
     log.add_argument("path")
     log.add_argument("--comment", required=True)
@@ -52,17 +54,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         if alias is not None and not isinstance(alias, str):
             parser.error("ignore alias must be text")
         try:
-            result = register_boundary(path_text, description, alias, start=Path.cwd())
+            registration = register_boundary(path_text, description, alias, start=Path.cwd())
         except SetupError as error:
             parser.error(str(error))
-        boundary = result.boundary
-        if result.changed:
+        boundary = registration.boundary
+        if registration.changed:
             print(
                 f"registered boundary {boundary['alias']} for {boundary['path']}; "
                 "updated .silobrief/config.json"
             )
         else:
             print(f"boundary {boundary['alias']} for {boundary['path']} is already registered")
+
+    if arguments.command == "init":
+        try:
+            warnings = initialize_index(Path.cwd())
+        except SetupError as error:
+            parser.error(str(error))
+        except IndexingError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 3
+        except SourceChangedError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 4
+        for warning in warnings:
+            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
+        print("built .silobrief/index.json")
 
     if arguments.command == "log":
         path_text = arguments.path

--- a/src/silobrief/initialization.py
+++ b/src/silobrief/initialization.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from silobrief import sources
+from silobrief.index import IndexBuildError, build_index, render_index_json
+from silobrief.python_structure import PythonParseError, extract_structures
+from silobrief.sources import SourceChanges, SourceCollectionError, SourceWarning
+from silobrief.state import SetupError, find_project_root, load_config, save_index
+
+
+class IndexingError(Exception):
+    pass
+
+
+class SourceChangedError(Exception):
+    pass
+
+
+def initialize_index(start: Path) -> tuple[SourceWarning, ...]:
+    root = find_project_root(start)
+    config = load_config(root)
+    try:
+        before = sources.snapshot_sources(root, config)
+        structures = extract_structures(before)
+        index = build_index(before, structures, config)
+        after = sources.snapshot_sources(root, config)
+    except (SourceCollectionError, PythonParseError, IndexBuildError) as error:
+        raise IndexingError(str(error)) from error
+
+    changes = sources.compare_snapshots(before, after)
+    if changes.has_changes:
+        raise SourceChangedError(_source_change_message(changes))
+
+    try:
+        save_index(root, render_index_json(index))
+    except SetupError as error:
+        raise IndexingError(str(error)) from error
+    return before.warnings
+
+
+def _source_change_message(changes: SourceChanges) -> str:
+    details: list[str] = []
+    for label, paths in (
+        ("added", changes.added),
+        ("removed", changes.removed),
+        ("modified", changes.modified),
+    ):
+        if paths:
+            details.append(f"{label}: {', '.join(paths)}")
+    return f"source changed during indexing: {'; '.join(details)}"

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -125,6 +125,10 @@ def save_notes(root: Path, notes: NotesData) -> None:
     _write_json_atomic(root / STATE_DIRECTORY / "notes.json", notes)
 
 
+def save_index(root: Path, content: bytes) -> None:
+    _write_bytes_atomic(root / STATE_DIRECTORY / "index.json", content)
+
+
 def mark_index_stale(root: Path) -> None:
     index = root / STATE_DIRECTORY / "index.json"
     if not index.exists() and not index.is_symlink():
@@ -149,19 +153,24 @@ def _write_json_atomic(
     path: Path,
     value: ConfigData | NotesData | dict[str, object],
 ) -> None:
-    content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    content = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    _write_bytes_atomic(path, content)
+
+
+def _write_bytes_atomic(path: Path, content: bytes) -> None:
     try:
         descriptor, temporary_name = tempfile.mkstemp(
             dir=path.parent,
             prefix=f".{path.name}-",
             suffix=".tmp",
-            text=True,
         )
     except OSError as error:
         raise SetupError(f"cannot create temporary file for {path.name}: {error}") from error
     temporary = Path(temporary_name)
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+        with os.fdopen(descriptor, "wb") as stream:
             stream.write(content)
         temporary.replace(path)
     except OSError as error:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+import silobrief.sources as sources
+from silobrief.cli import main
+from silobrief.sources import SourceFile, SourceSnapshot
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def source_bytes(project: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(project).as_posix(): path.read_bytes()
+        for path in sorted(project.rglob("*.py"))
+    }
+
+
+def index_object(project: Path) -> dict[str, object]:
+    value: object = json.loads((project / ".silobrief" / "index.json").read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("index must be a JSON object")
+    return {str(key): item for key, item in value.items()}
+
+
+class InitCommandTests(unittest.TestCase):
+    def test_init_builds_a_deterministic_index_from_a_subdirectory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            package = project / "package"
+            private = project / "private"
+            package.mkdir()
+            private.mkdir()
+            service = package / "service.py"
+            service.write_text(
+                "from private.secret import send\n\n\ndef run():\n    send()\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            (private / "secret.py").write_text(
+                "CANARY = 'fixture-private-canary'\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            self.assertEqual(main(["setup", str(project)]), 0)
+            with working_directory(project), contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(
+                    main(
+                        [
+                            "ignore",
+                            "private",
+                            "--as",
+                            "External delivery adapter",
+                            "--alias",
+                            "delivery-boundary",
+                        ]
+                    ),
+                    0,
+                )
+            before_sources = source_bytes(project)
+
+            first_stdout = io.StringIO()
+            with working_directory(package), contextlib.redirect_stdout(first_stdout):
+                first_result = main(["init"])
+            first_index = (project / ".silobrief" / "index.json").read_bytes()
+
+            with working_directory(project), contextlib.redirect_stdout(io.StringIO()):
+                second_result = main(["init"])
+
+            self.assertEqual(first_result, 0)
+            self.assertEqual(second_result, 0)
+            self.assertIn("index.json", first_stdout.getvalue())
+            self.assertEqual((project / ".silobrief" / "index.json").read_bytes(), first_index)
+            self.assertEqual(source_bytes(project), before_sources)
+            self.assertNotIn(b"fixture-private-canary", first_index)
+            self.assertIn(b"delivery-boundary", first_index)
+            index = index_object(project)
+            self.assertEqual(index["index_version"], 1)
+            self.assertIs(index["stale"], False)
+
+    def test_init_reports_parse_error_and_preserves_existing_index(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "broken.py"
+            source.write_text("def broken(:\n", encoding="utf-8", newline="\n")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            index = project / ".silobrief" / "index.json"
+            index.write_bytes(b'{"index_version": 1, "sentinel": true}\n')
+            fixed_time = 1_700_000_000_000_000_000
+            os.utime(index, ns=(fixed_time, fixed_time))
+            before = (index.read_bytes(), index.stat().st_mtime_ns)
+            stderr = io.StringIO()
+
+            with working_directory(project), contextlib.redirect_stderr(stderr):
+                result = main(["init"])
+
+            self.assertEqual(result, 3)
+            self.assertIn("broken.py", stderr.getvalue())
+            self.assertIn("cannot parse", stderr.getvalue())
+            self.assertEqual((index.read_bytes(), index.stat().st_mtime_ns), before)
+
+    def test_init_detects_source_changes_before_replacing_index(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "service.py"
+            original = b"def run():\n    return 1\n"
+            changed = b"def run():\n    return 2\n"
+            source.write_bytes(original)
+            self.assertEqual(main(["setup", str(project)]), 0)
+            index = project / ".silobrief" / "index.json"
+            index.write_bytes(b'{"index_version": 1, "sentinel": true}\n')
+            fixed_time = 1_700_000_000_000_000_000
+            os.utime(index, ns=(fixed_time, fixed_time))
+            before_index = (index.read_bytes(), index.stat().st_mtime_ns)
+            before = SourceSnapshot(
+                files=(
+                    SourceFile(
+                        path="service.py",
+                        content=original,
+                        sha256=hashlib.sha256(original).hexdigest(),
+                    ),
+                ),
+                warnings=(),
+                digest="before",
+            )
+            after = SourceSnapshot(
+                files=(
+                    SourceFile(
+                        path="service.py",
+                        content=changed,
+                        sha256=hashlib.sha256(changed).hexdigest(),
+                    ),
+                ),
+                warnings=(),
+                digest="after",
+            )
+            stderr = io.StringIO()
+
+            with (
+                working_directory(project),
+                contextlib.redirect_stderr(stderr),
+                mock.patch.object(sources, "snapshot_sources", side_effect=(before, after)),
+            ):
+                result = main(["init"])
+
+            self.assertEqual(result, 4)
+            self.assertIn("changed", stderr.getvalue())
+            self.assertIn("service.py", stderr.getvalue())
+            self.assertEqual((index.read_bytes(), index.stat().st_mtime_ns), before_index)
+            self.assertEqual(source.read_bytes(), original)


### PR DESCRIPTION
## 변경 사항

- `sb init` 공개 명령을 추가했습니다.
- 허용된 Python source snapshot을 메모리에서 파싱해 결정적 `.silobrief/index.json`을 생성합니다.
- 인덱싱 전후 source 변경을 비교하고 변경된 경우 기존 index를 보존합니다.
- 성공한 경우에만 UTF-8/LF index bytes를 원자적으로 교체합니다.
- 입력·상태 오류는 코드 `2`, 수집·파싱·index 오류는 `3`, source 변경은 `4`로 구분합니다.
- 영문·한국어 README에서 `sb init` 사용법과 교체 조건을 설명합니다.

## 이유

안전 순회, Python 구조 추출과 index 생성 계층은 이미 있었지만 공개 CLI에 연결되지 않아 사용자가 index를 만들 수 없었습니다. 이번 변경은 새 기능을 추가하지 않고 기존 계층을 가장 작은 실행 흐름으로 연결합니다.

## 영향

`setup → ignore → init` 흐름이 실행 가능해집니다. 파싱 실패, source 변경과 원자적 저장 실패에서는 기존 index를 교체하지 않습니다. 저장된 index의 chat용 역직렬화, `sb chat`, 공개 fixture는 포함하지 않습니다.

## 검증

- 구현 전 `sb init` 미지원으로 acceptance test 3개 실패 확인
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy src tests`
- `python -m unittest discover -s tests` — 79개 성공, 로컬 Windows symlink 권한으로 5개 제외
- `python -m build --no-isolation --outdir build/verify-27-final`

Refs #27