### PR TITLE
feat(index): validate current index state

### DIFF
--- a/src/silobrief/current_index.py
+++ b/src/silobrief/current_index.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from silobrief.index import IndexData, config_digest
+from silobrief.sources import SourceWarning, snapshot_sources
+from silobrief.state import load_config
+from silobrief.stored_index import load_stored_index
+
+
+class CurrentIndexError(Exception):
+    pass
+
+
+def load_current_index(root: Path) -> tuple[IndexData, tuple[SourceWarning, ...]]:
+    index = load_stored_index(root)
+    if index.stale:
+        raise CurrentIndexError("index is stale; run sb init")
+
+    config = load_config(root)
+    if index.config_digest != config_digest(config):
+        raise CurrentIndexError("project configuration changed; run sb init")
+
+    snapshot = snapshot_sources(root, config)
+    if index.source_digest != snapshot.digest:
+        raise CurrentIndexError("project sources changed; run sb init")
+    return index, snapshot.warnings

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -119,7 +119,7 @@ def build_index(
         _add_use_edges(edges, context, context.structure.references, "reference", global_targets)
 
     return IndexData(
-        config_digest=_config_digest(config),
+        config_digest=config_digest(config),
         edges=tuple(sorted(edges, key=_edge_key)),
         index_version=1,
         nodes=tuple(sorted(all_nodes, key=_node_key)),
@@ -332,7 +332,7 @@ def _module_map(structures: tuple[ModuleStructure, ...]) -> dict[str, ModuleStru
     return result
 
 
-def _config_digest(config: ConfigData) -> str:
+def config_digest(config: ConfigData) -> str:
     boundaries = sorted(
         config["boundaries"],
         key=lambda item: (item["path"], item["alias"], item["description"]),

--- a/tests/test_current_index.py
+++ b/tests/test_current_index.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+from unittest import mock
+
+import silobrief.current_index as current_index
+from silobrief.current_index import CurrentIndexError, load_current_index
+
+from silobrief.boundaries import register_boundary
+from silobrief.initialization import initialize_index
+from silobrief.sources import SourceCollectionError, SourceWarning, snapshot_sources
+from silobrief.state import SetupError, load_config, setup_project
+from silobrief.stored_index import StoredIndexError, load_stored_index
+
+
+def create_project(project: Path) -> tuple[Path, Path]:
+    package = project / "package"
+    private = project / "private"
+    package.mkdir()
+    private.mkdir()
+    source = package / "service.py"
+    source.write_text("def run():\n    return 1\n", encoding="utf-8", newline="\n")
+    secret = private / "secret.py"
+    secret.write_text("CANARY = 'private-canary'\n", encoding="utf-8", newline="\n")
+    setup_project(project)
+    register_boundary(
+        "private",
+        "External delivery adapter",
+        "delivery-boundary",
+        start=project,
+    )
+    initialize_index(project)
+    return source, secret
+
+
+def file_state(project: Path) -> dict[str, tuple[bytes, int]]:
+    return {
+        path.relative_to(project).as_posix(): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in sorted(project.rglob("*"))
+        if path.is_file()
+    }
+
+
+def object_file(path: Path) -> dict[str, object]:
+    value: object = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("expected a JSON object")
+    return cast(dict[str, object], value)
+
+
+def write_object(path: Path, value: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+class CurrentIndexTests(unittest.TestCase):
+    def assert_current_error(self, project: Path, expected: str) -> None:
+        before = file_state(project)
+
+        with self.assertRaises(CurrentIndexError) as caught:
+            load_current_index(project)
+
+        message = str(caught.exception)
+        self.assertIn(expected, message)
+        self.assertIn("run sb init", message)
+        self.assertNotIn(str(project), message)
+        self.assertNotIn("private-canary", message)
+        self.assertEqual(file_state(project), before)
+
+    def test_loads_current_index_and_returns_source_warnings_read_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            _, secret = create_project(project)
+            secret.write_text("CANARY = 'changed-private-canary'\n", encoding="utf-8")
+            expected = load_stored_index(project)
+            snapshot = snapshot_sources(project, load_config(project))
+            warning = SourceWarning(path="linked.py", reason="symbolic link skipped")
+            before = file_state(project)
+
+            with mock.patch.object(
+                current_index,
+                "snapshot_sources",
+                return_value=replace(snapshot, warnings=(warning,)),
+            ):
+                loaded, warnings = load_current_index(project)
+
+            self.assertEqual(loaded, expected)
+            self.assertEqual(warnings, (warning,))
+            self.assertEqual(file_state(project), before)
+
+    def test_stale_and_config_mismatch_stop_before_source_collection(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            create_project(project)
+            index_path = project / ".silobrief" / "index.json"
+            index = object_file(index_path)
+            index["stale"] = True
+            write_object(index_path, index)
+
+            with (
+                mock.patch.object(current_index, "load_config") as load_current_config,
+                mock.patch.object(current_index, "snapshot_sources") as collect_sources,
+            ):
+                self.assert_current_error(project, "stale")
+
+            load_current_config.assert_not_called()
+            collect_sources.assert_not_called()
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            create_project(project)
+            config_path = project / ".silobrief" / "config.json"
+            config = object_file(config_path)
+            boundaries = config["boundaries"]
+            if not isinstance(boundaries, list) or not isinstance(boundaries[0], dict):
+                raise AssertionError("fixture config must contain a boundary")
+            cast(dict[str, object], boundaries[0])["description"] = "Changed description"
+            write_object(config_path, config)
+
+            with mock.patch.object(current_index, "snapshot_sources") as collect_sources:
+                self.assert_current_error(project, "configuration changed")
+
+            collect_sources.assert_not_called()
+
+    def test_rejects_added_removed_and_modified_allowed_sources(self) -> None:
+        for change in ("added", "removed", "modified"):
+            with self.subTest(change=change), tempfile.TemporaryDirectory() as directory:
+                project = Path(directory)
+                source, _ = create_project(project)
+                if change == "added":
+                    (project / "added.py").write_text("VALUE = 1\n", encoding="utf-8")
+                elif change == "removed":
+                    source.unlink()
+                else:
+                    source.write_text("def run():\n    return 2\n", encoding="utf-8")
+
+                self.assert_current_error(project, "sources changed")
+
+    def test_preserves_existing_loader_error_boundaries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            create_project(project)
+            (project / ".silobrief" / "index.json").unlink()
+
+            with self.assertRaises(StoredIndexError):
+                load_current_index(project)
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            create_project(project)
+            (project / ".silobrief" / "config.json").write_text("{}\n", encoding="utf-8")
+
+            with self.assertRaises(SetupError):
+                load_current_index(project)
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            create_project(project)
+
+            with (
+                mock.patch.object(
+                    current_index,
+                    "snapshot_sources",
+                    side_effect=SourceCollectionError("cannot collect sources"),
+                ),
+                self.assertRaises(SourceCollectionError),
+            ):
+                load_current_index(project)

--- a/tests/test_current_index.py
+++ b/tests/test_current_index.py
@@ -8,10 +8,9 @@ from pathlib import Path
 from typing import cast
 from unittest import mock
 
-import silobrief.current_index as current_index
-from silobrief.current_index import CurrentIndexError, load_current_index
-
+from silobrief import current_index
 from silobrief.boundaries import register_boundary
+from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import initialize_index
 from silobrief.sources import SourceCollectionError, SourceWarning, snapshot_sources
 from silobrief.state import SetupError, load_config, setup_project


### PR DESCRIPTION
## 변경 사항

- canonical 저장 index를 읽은 뒤 stale 상태를 가장 먼저 거부합니다.
- 현재 config digest가 다르면 source를 순회하지 않고 `sb init` 재실행을 요구합니다.
- 현재 제외 규칙으로 수집한 허용 Python source digest가 다르면 오래된 index를 거부합니다.
- 모든 검증이 통과할 때만 `IndexData`와 결정적인 source warning을 반환합니다.
- schema, config와 source 수집 오류는 기존 typed error 경계를 유지합니다.

## 이유

저장된 index가 안전한 schema여도 현재 설정이나 source와 다르면 ranking이 오래된 프로젝트 맥락을 사용할 수 있습니다. 이후 `sb chat` 연결 전에 currentness를 확인하는 읽기 전용 경계가 필요합니다.

## 영향

공개 CLI는 바뀌지 않습니다. stale 또는 digest mismatch는 raw 값과 절대경로 없이 `sb init` 재실행 안내로 보고됩니다. root 탐색, notes, ranking, review, renderer와 CLI 종료 코드는 포함하지 않습니다.

## 검증

- 구현 전 새 모듈 부재로 targeted acceptance test 실패 확인
- `python -m unittest tests.test_current_index -v` — 4개 성공
- `python -m unittest discover -s tests` — 85개 성공, 로컬 Windows symlink 권한으로 5개 제외
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m build --no-isolation --outdir build/verify-31-implementation`
- GitHub Actions run 30781507164 — Ubuntu·Windows × Python 3.10·3.14 통과
- 최종 통계 204 additions, 2 deletions; 제품 구현 29줄

Refs #31