### PR TITLE
feat(chat): assemble reviewed brief context

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from typing import TextIO
+
+from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.index import IndexData
+from silobrief.ranking import rank_candidates
+from silobrief.renderer import (
+    ApprovedBoundary,
+    ApprovedSymbol,
+    BriefInput,
+    RenderedBrief,
+    RenderError,
+    render_brief,
+)
+from silobrief.review import (
+    CandidateOption,
+    DisclosureChoices,
+    ReviewError,
+    ReviewSelection,
+    candidate_options,
+    review_selection,
+)
+from silobrief.state import NotesData
+
+
+class ChatReviewError(ValueError):
+    pass
+
+
+_NO_FIELDS = DisclosureChoices(False, False, False, False, False)
+
+
+def review_brief(
+    prompt: str,
+    index: IndexData,
+    notes: NotesData,
+    *,
+    input_stream: TextIO,
+    output_stream: TextIO,
+) -> RenderedBrief:
+    if not prompt.strip():
+        raise ChatReviewError("request must not be empty")
+    if not input_stream.isatty() or not output_stream.isatty():
+        raise ChatReviewError("review requires an interactive terminal")
+
+    try:
+        options = candidate_options(rank_candidates(prompt, index, notes))
+    except ReviewError as error:
+        raise ChatReviewError(str(error)) from error
+    if not options:
+        raise ChatReviewError("no candidate matches the request")
+
+    _show_candidates(options, output_stream)
+    selected_numbers = _read_numbers(input_stream, output_stream)
+    added = _read_selectors("Add path or node ID", input_stream, output_stream)
+    excluded = _read_selectors("Exclude path or node ID", input_stream, output_stream)
+    try:
+        selection = review_selection(
+            index,
+            options,
+            selected_numbers=selected_numbers,
+            added=added,
+            excluded=excluded,
+            fields=_NO_FIELDS,
+        )
+    except ReviewError as error:
+        raise ChatReviewError(str(error)) from error
+    _show_selection(selection, output_stream)
+    reviewed = ReviewSelection(
+        selection.selected, selection.expanded, _read_fields(input_stream, output_stream)
+    )
+
+    try:
+        return render_brief(_brief_input(prompt, index, notes, reviewed))
+    except RenderError as error:
+        raise ChatReviewError(str(error)) from error
+
+
+def _show_candidates(options: tuple[CandidateOption, ...], output: TextIO) -> None:
+    _write(output, "Candidates:\n")
+    for option in options:
+        evidence = option.evidence
+        note = "yes" if evidence.note_match else "no"
+        _write(
+            output,
+            f"{option.number}. {option.node.path} | {option.node.kind} "
+            f"{option.node.qualified_name} | score={option.score} | "
+            f"path={evidence.path_matches} symbol={evidence.symbol_matches} "
+            f"import={evidence.import_matches} docstring={evidence.docstring_matches} "
+            f"comment={evidence.comment_matches} note={note} "
+            f"connected={evidence.connected_nodes}\n",
+        )
+
+
+def _read_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[int, ...]:
+    value = _read_line("Select candidate numbers: ", input_stream, output_stream)
+    if not value:
+        return ()
+    try:
+        return tuple(int(part) for part in value.split())
+    except ValueError as error:
+        raise ChatReviewError("candidate numbers must be space-separated integers") from error
+
+
+def _read_selectors(label: str, input_stream: TextIO, output_stream: TextIO) -> tuple[str, ...]:
+    values: list[str] = []
+    while value := _read_line(f"{label} (blank to finish): ", input_stream, output_stream):
+        values.append(value)
+    return tuple(values)
+
+
+def _show_selection(selection: ReviewSelection, output: TextIO) -> None:
+    for label, nodes in (
+        ("Selected context", selection.selected),
+        ("Expanded context", selection.expanded),
+    ):
+        _write(output, f"{label}:\n")
+        if not nodes:
+            _write(output, "- none\n")
+        for node in nodes:
+            _write(output, f"- {node.path} | {node.kind} {node.qualified_name}\n")
+
+
+def _read_fields(input_stream: TextIO, output_stream: TextIO) -> DisclosureChoices:
+    return DisclosureChoices(
+        paths=_read_choice("Include relative paths?", input_stream, output_stream),
+        symbols=_read_choice("Include symbols?", input_stream, output_stream),
+        public_libraries=_read_choice("Include public libraries?", input_stream, output_stream),
+        human_notes=_read_choice("Include human notes?", input_stream, output_stream),
+        boundary_placeholders=_read_choice(
+            "Include boundary placeholders?", input_stream, output_stream
+        ),
+    )
+
+
+def _read_choice(label: str, input_stream: TextIO, output_stream: TextIO) -> bool:
+    value = _read_line(f"{label} [y/n]: ", input_stream, output_stream)
+    if value not in {"y", "n"}:
+        raise ChatReviewError("field answer must be exactly y or n")
+    return value == "y"
+
+
+def _read_line(label: str, input_stream: TextIO, output_stream: TextIO) -> str:
+    _write(output_stream, label)
+    try:
+        output_stream.flush()
+        return input_stream.readline().rstrip("\r\n")
+    except OSError as error:
+        raise ChatReviewError("interactive terminal input failed") from error
+
+
+def _write(output: TextIO, value: str) -> None:
+    try:
+        output.write(value)
+    except OSError as error:
+        raise ChatReviewError("interactive terminal output failed") from error
+
+
+def _brief_input(
+    prompt: str,
+    index: IndexData,
+    notes: NotesData,
+    selection: ReviewSelection,
+) -> BriefInput:
+    nodes = (*selection.selected, *selection.expanded)
+    node_ids = {node.id for node in nodes}
+    paths = {node.path for node in nodes}
+    choices = selection.fields
+    return BriefInput(
+        user_prompt=prompt,
+        relative_paths=tuple(node.path for node in nodes) if choices.paths else (),
+        symbols=(
+            tuple(ApprovedSymbol(node.kind, node.qualified_name) for node in nodes)
+            if choices.symbols
+            else ()
+        ),
+        public_dependencies=_public_dependencies(index, node_ids)
+        if choices.public_libraries
+        else (),
+        human_notes=_human_notes(notes, paths) if choices.human_notes else (),
+        boundaries=_boundaries(index, node_ids) if choices.boundary_placeholders else (),
+    )
+
+
+def _public_dependencies(index: IndexData, node_ids: set[str]) -> tuple[str, ...]:
+    return tuple(
+        edge.target
+        for edge in index.edges
+        if edge.source_id in node_ids
+        and edge.kind == "import"
+        and edge.target_id is None
+        and isinstance(edge.target, str)
+    )
+
+
+def _human_notes(notes: NotesData, paths: set[str]) -> tuple[str, ...]:
+    return tuple(
+        note["comment"]
+        for note in notes["notes"]
+        if any(
+            note["path"] == "." or path == note["path"] or path.startswith(f"{note['path']}/")
+            for path in paths
+        )
+    )
+
+
+def _boundaries(index: IndexData, node_ids: set[str]) -> tuple[ApprovedBoundary, ...]:
+    return tuple(
+        ApprovedBoundary(edge.target.alias, edge.target.description)
+        for edge in index.edges
+        if edge.source_id in node_ids and isinstance(edge.target, BoundaryPlaceholder)
+    )

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -4,9 +4,8 @@ import io
 import unittest
 from dataclasses import replace
 
-from silobrief.chat_review import ChatReviewError, review_brief
-
 from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
 from silobrief.renderer import RenderedBrief
 from silobrief.state import HumanNoteData, NotesData
@@ -124,17 +123,11 @@ class ChatReviewTests(unittest.TestCase):
 
         self.assertEqual(rendered, reordered)
         self.assertEqual(disclosure_counts(rendered), (2, 2, 2, 2, 1))
-        for approved in (
-            "src/service.py",
-            "src/helper.py",
-            "helper.run",
-            "urllib3",
-            "json",
-            "Use Python 3.10",
-            "Keep the retry policy public",
-            "transport",
-            "Public transport adapter",
-        ):
+        approved_values = (
+            "src/service.py|src/helper.py|helper.run|urllib3|json|Use Python 3.10|"
+            "Keep the retry policy public|transport|Public transport adapter"
+        )
+        for approved in approved_values.split("|"):
             self.assertIn(approved, rendered.markdown)
 
         visible = output.getvalue()
@@ -142,15 +135,11 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("src/helper.py", visible)
         self.assertIn("path=1", visible)
         self.assertIn("connected=1", visible)
-        for hidden in (
-            "source-body-canary",
-            "internal-real-name",
-            "src/direct.py",
-            "src/second.py",
-            "second-hop-canary",
-            "unselected-note-canary",
-            "root-id",
-        ):
+        hidden_values = (
+            "source-body-canary|internal-real-name|src/direct.py|src/second.py|"
+            "second-hop-canary|unselected-note-canary|root-id"
+        )
+        for hidden in hidden_values.split("|"):
             self.assertNotIn(hidden, visible + rendered.markdown)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
@@ -170,8 +159,6 @@ class ChatReviewTests(unittest.TestCase):
             (" ", "", "request"),
             ("absent", "", "candidate"),
             ("retry", "2\n\n\n", "candidate number"),
-            ("retry", "1\nmissing-id\n\n\n", "selector"),
-            ("retry", "1\n\nroot-id\n\n", "start selection"),
             ("retry", "1\n\n\nY\n", "y or n"),
         )
         for prompt, input_text, message in cases:
@@ -196,7 +183,3 @@ class ChatReviewTests(unittest.TestCase):
                         input_stream=TtyBuffer(APPROVED_INPUT, tty=input_tty),
                         output_stream=TtyBuffer(tty=output_tty),
                     )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import io
+import unittest
+from dataclasses import replace
+
+from silobrief.chat_review import ChatReviewError, review_brief
+
+from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.renderer import RenderedBrief
+from silobrief.state import HumanNoteData, NotesData
+
+
+class TtyBuffer(io.StringIO):
+    def __init__(self, value: str = "", *, tty: bool = True) -> None:
+        super().__init__(value)
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+EMPTY_TOKENS = NodeTokens(path=(), symbol=(), imports=(), comments=(), docstrings=())
+
+
+def node(
+    node_id: str, path: str, kind: NodeKind, name: str, qualified_name: str | None = None
+) -> IndexNode:
+    return IndexNode(
+        id=node_id,
+        kind=kind,
+        name=name,
+        qualified_name=qualified_name or name,
+        path=path,
+        tokens=EMPTY_TOKENS,
+    )
+
+
+def source_index() -> IndexData:
+    root = replace(
+        node("root-id", "src/service.py", "module", "service"),
+        tokens=NodeTokens(
+            path=("retry",),
+            symbol=(),
+            imports=("internal-real-name",),
+            comments=("source-body-canary",),
+            docstrings=(),
+        ),
+    )
+    neighbor = node("neighbor-id", "src/helper.py", "function", "run", "helper.run")
+    direct = node("direct-id", "src/direct.py", "module", "direct")
+    second = node("second-id", "src/second.py", "function", "second")
+    return IndexData(
+        config_digest="a" * 64,
+        edges=(
+            IndexEdge("root-id", "call", "helper.run", "neighbor-id"),
+            IndexEdge("neighbor-id", "call", "second", "second-id"),
+            IndexEdge("root-id", "import", "urllib3", None),
+            IndexEdge("neighbor-id", "import", "json", None),
+            IndexEdge("second-id", "import", "second-hop-canary", None),
+            IndexEdge(
+                "root-id",
+                "import",
+                BoundaryPlaceholder("transport", "Public transport adapter"),
+                None,
+            ),
+        ),
+        index_version=1,
+        nodes=(root, neighbor, direct, second),
+        source_digest="b" * 64,
+        stale=False,
+    )
+
+
+def source_notes() -> NotesData:
+    return NotesData(
+        notes=[
+            HumanNoteData(comment="Use Python 3.10", id="note-" + "1" * 64, path="src"),
+            HumanNoteData(
+                comment="Keep the retry policy public", id="note-" + "2" * 64, path="src/service.py"
+            ),
+            HumanNoteData(
+                comment="unselected-note-canary", id="note-" + "3" * 64, path="src/second.py"
+            ),
+        ],
+        notes_version=1,
+    )
+
+
+APPROVED_INPUT = "1\nsrc/direct.py\n\nsrc/direct.py\n\ny\ny\ny\ny\ny\n"
+
+
+def disclosure_counts(rendered: RenderedBrief) -> tuple[int, int, int, int, int]:
+    value = rendered.disclosure
+    return (
+        value.relative_paths,
+        value.symbol_names,
+        value.public_dependencies,
+        value.human_notes,
+        value.boundary_aliases,
+    )
+
+
+class ChatReviewTests(unittest.TestCase):
+    def test_reviews_one_step_and_renders_only_approved_context(self) -> None:
+        index = source_index()
+        output = TtyBuffer()
+
+        rendered = review_brief(
+            "retry",
+            index,
+            source_notes(),
+            input_stream=TtyBuffer(APPROVED_INPUT),
+            output_stream=output,
+        )
+        reordered = review_brief(
+            "retry",
+            replace(index, nodes=tuple(reversed(index.nodes)), edges=tuple(reversed(index.edges))),
+            source_notes(),
+            input_stream=TtyBuffer(APPROVED_INPUT),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(rendered, reordered)
+        self.assertEqual(disclosure_counts(rendered), (2, 2, 2, 2, 1))
+        for approved in (
+            "src/service.py",
+            "src/helper.py",
+            "helper.run",
+            "urllib3",
+            "json",
+            "Use Python 3.10",
+            "Keep the retry policy public",
+            "transport",
+            "Public transport adapter",
+        ):
+            self.assertIn(approved, rendered.markdown)
+
+        visible = output.getvalue()
+        self.assertIn("src/service.py", visible)
+        self.assertIn("src/helper.py", visible)
+        self.assertIn("path=1", visible)
+        self.assertIn("connected=1", visible)
+        for hidden in (
+            "source-body-canary",
+            "internal-real-name",
+            "src/direct.py",
+            "src/second.py",
+            "second-hop-canary",
+            "unselected-note-canary",
+            "root-id",
+        ):
+            self.assertNotIn(hidden, visible + rendered.markdown)
+
+    def test_allows_every_disclosure_field_to_be_declined(self) -> None:
+        rendered = review_brief(
+            "retry",
+            source_index(),
+            source_notes(),
+            input_stream=TtyBuffer("1\n\n\nn\nn\nn\nn\nn\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(disclosure_counts(rendered), (0, 0, 0, 0, 0))
+        self.assertEqual(rendered.markdown.count("- 없음"), 5)
+
+    def test_rejects_invalid_or_empty_review_input(self) -> None:
+        cases = (
+            (" ", "", "request"),
+            ("absent", "", "candidate"),
+            ("retry", "2\n\n\n", "candidate number"),
+            ("retry", "1\nmissing-id\n\n\n", "selector"),
+            ("retry", "1\n\nroot-id\n\n", "start selection"),
+            ("retry", "1\n\n\nY\n", "y or n"),
+        )
+        for prompt, input_text, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ChatReviewError, message):
+                    review_brief(
+                        prompt,
+                        source_index(),
+                        source_notes(),
+                        input_stream=TtyBuffer(input_text),
+                        output_stream=TtyBuffer(),
+                    )
+
+    def test_requires_interactive_input_and_output(self) -> None:
+        for input_tty, output_tty in ((False, True), (True, False)):
+            with self.subTest(input_tty=input_tty, output_tty=output_tty):
+                with self.assertRaisesRegex(ChatReviewError, "interactive terminal"):
+                    review_brief(
+                        "retry",
+                        source_index(),
+                        source_notes(),
+                        input_stream=TtyBuffer(APPROVED_INPUT, tty=input_tty),
+                        output_stream=TtyBuffer(tty=output_tty),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 사항

- TTY에서 lexical 후보의 상대 경로, 심볼과 수치화된 점수 근거를 표시합니다.
- 후보 번호와 직접 path·node ID 추가·제외 입력을 기존 review 계층에 연결합니다.
- 선택 결과와 정확히 1단계 확장 결과를 공개 필드 확인 전에 표시합니다.
- 상대 경로, 심볼, 공개 라이브러리, 사람 메모, boundary placeholder를 각각 `y/n`으로 확인합니다.
- 선택·확장된 node의 unresolved import, 적용 가능한 note와 공개 boundary 설명만 `BriefInput`에 조립합니다.
- renderer 결과는 메모리에서 반환하며 source token, node ID와 선택되지 않은 문맥은 표시하지 않습니다.

## 이유

ranking, review와 whitelist renderer는 각각 구현되어 있었지만 사용자의 터미널 입력을 안전한 renderer 입력으로 연결하는 단계가 없었습니다. `sb chat` CLI와 파일 출력을 추가하기 전에 이 대화형 검토 경계를 독립적으로 검증합니다.

## 영향

새 내부 모듈 `silobrief.chat_review`가 추가됩니다. 공개 CLI, 상태 schema, 프로젝트 파일, 출력 승인 흐름과 런타임 의존성은 바뀌지 않습니다. 전체 Issue 변경량은 398줄이며 후속 CLI 연결은 별도 Issue로 남깁니다.

## 검증

- 구현 전 `silobrief.chat_review` 부재로 targeted acceptance test 실패 확인
- `python -m unittest discover -s ../tests -p test_chat_review.py -v` — 4개 성공
- `python -m unittest discover -s ../tests -v` — 89개 성공, 로컬 Windows symlink 권한으로 5개 제외
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- `python -m build --no-isolation --outdir build/verify-33-implementation`

Refs #33