### PR TITLE
feat(chat): connect public command flow

### DIFF
--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -7,9 +7,20 @@ from pathlib import Path
 
 from silobrief import __version__
 from silobrief.boundaries import register_boundary
+from silobrief.chat_review import ChatReviewError, review_brief
+from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
 from silobrief.notes import add_note
-from silobrief.state import SetupError, setup_project
+from silobrief.output import OutputBlockedError, approve_and_write
+from silobrief.sources import SourceCollectionError
+from silobrief.state import (
+    IndexStateError,
+    SetupError,
+    find_project_root,
+    load_notes,
+    setup_project,
+)
+from silobrief.stored_index import StoredIndexError
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -29,6 +40,9 @@ def _build_parser() -> argparse.ArgumentParser:
     log = subcommands.add_parser("log", help="Record public project context.")
     log.add_argument("path")
     log.add_argument("--comment", required=True)
+    chat = subcommands.add_parser("chat", help="Create a reviewed research brief.")
+    chat.add_argument("prompt")
+    chat.add_argument("--out", dest="output", required=True)
     return parser
 
 
@@ -97,5 +111,53 @@ def main(argv: Sequence[str] | None = None) -> int:
         except SetupError as error:
             parser.error(str(error))
         print(f"recorded note {note['id']} for {note['path']}; updated .silobrief/notes.json")
+
+    if arguments.command == "chat":
+        prompt = arguments.prompt
+        output_text = arguments.output
+        if not isinstance(prompt, str) or not prompt.strip():
+            parser.error("request must not be empty")
+        if not isinstance(output_text, str) or not output_text.strip():
+            parser.error("output path must not be empty")
+
+        start = Path.cwd()
+        try:
+            root = find_project_root(start)
+            index, warnings = load_current_index(root)
+            notes = load_notes(root)
+        except IndexStateError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 3
+        except SetupError as error:
+            parser.error(str(error))
+        except StoredIndexError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 3
+        except (CurrentIndexError, SourceCollectionError) as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 4
+
+        for warning in warnings:
+            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
+        try:
+            rendered = review_brief(
+                prompt,
+                index,
+                notes,
+                input_stream=sys.stdin,
+                output_stream=sys.stdout,
+            )
+            approve_and_write(
+                root,
+                output_text,
+                rendered,
+                start=start,
+                input_stream=sys.stdin,
+                output_stream=sys.stdout,
+            )
+        except (ChatReviewError, OutputBlockedError) as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 4
+        print(f"\nwrote {output_text}")
 
     return 0

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -26,6 +26,10 @@ class SetupError(Exception):
     pass
 
 
+class IndexStateError(SetupError):
+    pass
+
+
 class BoundaryData(TypedDict):
     alias: str
     description: str
@@ -196,9 +200,12 @@ def _validate_state(state: Path) -> ConfigData:
 
     index = state / "index.json"
     if index.exists() or index.is_symlink():
-        index_data = _read_object(index)
+        try:
+            index_data = _read_object(index)
+        except SetupError as error:
+            raise IndexStateError(str(error)) from error
         if not _is_version_one(index_data.get("index_version")):
-            raise SetupError("index.json is not compatible with version 1")
+            raise IndexStateError("index.json is not compatible with version 1")
     return config
 
 

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -179,9 +179,29 @@ class ChatCommandTests(unittest.TestCase):
             self.assertEqual(caught.exception.code, 2)
             self.assertIn("request", stderr.getvalue())
 
+            stderr = io.StringIO()
+            with (
+                contextlib.redirect_stderr(stderr),
+                self.assertRaises(SystemExit) as caught,
+            ):
+                main(["chat", "request", "--out", " "])
+            self.assertEqual(caught.exception.code, 2)
+            self.assertIn("output path", stderr.getvalue())
+
             result, _, _, stderr_text = run_chat(project, ".silobrief/exports/missing.md", "")
             self.assertEqual(result, 3)
             self.assertIn("run sb init", stderr_text)
+
+            index = project / ".silobrief/index.json"
+            index.write_text("{", encoding="utf-8")
+            result, _, _, stderr_text = run_chat(project, ".silobrief/exports/corrupt.md", "")
+            self.assertEqual(result, 3)
+            self.assertIn("cannot read index.json", stderr_text)
+
+            index.write_text('{"index_version": 2}\n', encoding="utf-8", newline="\n")
+            result, _, _, stderr_text = run_chat(project, ".silobrief/exports/incompatible.md", "")
+            self.assertEqual(result, 3)
+            self.assertIn("not compatible", stderr_text)
 
         with tempfile.TemporaryDirectory() as directory:
             project = Path(directory)

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+from silobrief.cli import main
+
+
+class TtyBuffer(io.StringIO):
+    def __init__(self, value: str = "", *, tty: bool = True) -> None:
+        super().__init__(value)
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+class ScriptedInput:
+    def __init__(self, value: str, target: Path, *, tty: bool = True) -> None:
+        self._stream = io.StringIO(value)
+        self.target = target
+        self.tty = tty
+        self.output_absent_before_write: bool | None = None
+
+    def isatty(self) -> bool:
+        return self.tty
+
+    def readline(self, size: int = -1) -> str:
+        value = self._stream.readline(size)
+        if value.rstrip("\r\n") == "WRITE":
+            self.output_absent_before_write = not self.target.exists()
+        return value
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def source_bytes(project: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(project).as_posix(): path.read_bytes()
+        for path in sorted(project.rglob("*.py"))
+    }
+
+
+def prepare_project(project: Path) -> Path:
+    package = project / "package"
+    private = project / "private"
+    package.mkdir()
+    private.mkdir()
+    service = package / "service.py"
+    service.write_text(
+        "import urllib3\n"
+        "from private.secret import send\n\n"
+        "SOURCE_CANARY = 'allowed-source-canary'\n\n"
+        "def run():\n"
+        "    send()\n"
+        "    return urllib3\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    (private / "secret.py").write_text(
+        "PRIVATE_CANARY = 'private-boundary-canary'\n\ndef send():\n    return None\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    if main(["setup", str(project)]) != 0:
+        raise AssertionError("setup failed")
+    with (
+        working_directory(project),
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        results = (
+            main(
+                [
+                    "ignore",
+                    "private",
+                    "--as",
+                    "External delivery adapter",
+                    "--alias",
+                    "delivery-boundary",
+                ]
+            ),
+            main(["init"]),
+            main(["log", "package/service.py", "--comment", "Python 3.10 is required"]),
+        )
+    if results != (0, 0, 0):
+        raise AssertionError(f"project preparation failed: {results}")
+    return service
+
+
+REVIEW_INPUT = "1\n\n\ny\ny\ny\ny\ny\n"
+
+
+def run_chat(
+    project: Path,
+    output: str,
+    input_text: str,
+    *,
+    tty: bool = True,
+) -> tuple[int, ScriptedInput, str, str]:
+    input_stream = ScriptedInput(input_text, project / output, tty=tty)
+    stdout = TtyBuffer()
+    stderr = io.StringIO()
+    with (
+        working_directory(project),
+        mock.patch.object(sys, "stdin", input_stream),
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        result = main(["chat", "run official docs", "--out", output])
+    return result, input_stream, stdout.getvalue(), stderr.getvalue()
+
+
+class ChatCommandTests(unittest.TestCase):
+    def test_runs_the_full_cli_flow_and_writes_only_after_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            before = source_bytes(project)
+            output = ".silobrief/exports/run.md"
+
+            result, input_stream, stdout, stderr = run_chat(
+                project, output, REVIEW_INPUT + "WRITE\n"
+            )
+
+            destination = project / output
+            self.assertEqual(result, 0)
+            self.assertIs(input_stream.output_absent_before_write, True)
+            self.assertTrue(destination.is_file())
+            self.assertEqual(source_bytes(project), before)
+            self.assertEqual(stderr, "")
+            self.assertIn("Candidates:", stdout)
+            self.assertIn("wrote .silobrief/exports/run.md", stdout)
+            markdown = destination.read_text(encoding="utf-8")
+            for approved in (
+                "package/service.py",
+                "function: run",
+                "urllib3",
+                "Python 3.10 is required",
+                "delivery-boundary",
+                "External delivery adapter",
+            ):
+                self.assertIn(approved, markdown)
+            for hidden in (
+                "allowed-source-canary",
+                "private-boundary-canary",
+                "private.secret",
+                str(project),
+            ):
+                self.assertNotIn(hidden, stdout + markdown)
+
+    def test_maps_invalid_input_and_index_state_to_contract_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(main(["setup", str(project)]), 0)
+            stderr = io.StringIO()
+            with (
+                working_directory(project),
+                contextlib.redirect_stderr(stderr),
+                self.assertRaises(SystemExit) as caught,
+            ):
+                main(["chat", " ", "--out", ".silobrief/exports/blank.md"])
+            self.assertEqual(caught.exception.code, 2)
+            self.assertIn("request", stderr.getvalue())
+
+            result, _, _, stderr_text = run_chat(project, ".silobrief/exports/missing.md", "")
+            self.assertEqual(result, 3)
+            self.assertIn("run sb init", stderr_text)
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            service = prepare_project(project)
+            service.write_text("def changed():\n    return 1\n", encoding="utf-8")
+            result, _, _, stderr_text = run_chat(project, ".silobrief/exports/changed.md", "")
+            self.assertEqual(result, 4)
+            self.assertIn("sources changed", stderr_text)
+            self.assertFalse((project / ".silobrief/exports/changed.md").exists())
+
+    def test_blocks_non_tty_refusal_and_existing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+
+            result, _, _, stderr = run_chat(
+                project,
+                ".silobrief/exports/non-tty.md",
+                REVIEW_INPUT + "WRITE\n",
+                tty=False,
+            )
+            self.assertEqual(result, 4)
+            self.assertIn("interactive terminal", stderr)
+
+            refused = ".silobrief/exports/refused.md"
+            result, _, _, stderr = run_chat(project, refused, REVIEW_INPUT + "NO\n")
+            self.assertEqual(result, 4)
+            self.assertIn("exact WRITE", stderr)
+            self.assertFalse((project / refused).exists())
+
+            existing = project / ".silobrief/exports/existing.md"
+            existing.write_text("keep", encoding="utf-8")
+            result, _, _, stderr = run_chat(
+                project, ".silobrief/exports/existing.md", REVIEW_INPUT + "WRITE\n"
+            )
+            self.assertEqual(result, 4)
+            self.assertIn("already exists", stderr)
+            self.assertEqual(existing.read_text(encoding="utf-8"), "keep")


### PR DESCRIPTION
## 변경 사항

- `sb chat "PROMPT" --out FILE` 공개 명령을 기존 ranking·review·renderer·approval 계층에 연결합니다.
- 현재 프로젝트 root, canonical index, source·config currentness와 사람 메모를 순서대로 검증합니다.
- source warning을 stderr에 결정적 순서로 표시합니다.
- 전체 Markdown preview 뒤 정확한 `WRITE` 입력에서만 새 파일을 생성합니다.
- 빈 입력은 코드 2, 저장 index 오류는 코드 3, stale·source mismatch·검토·출력 차단은 코드 4로 처리합니다.
- 손상되거나 비호환인 index를 다른 설정 오류와 구분하는 typed state error를 추가합니다.

## 이유

내부 브리프 생성 계층은 준비됐지만 공개 CLI 진입점이 없어 사용자가 `setup → ignore → init → log → chat` 전체 흐름을 실행할 수 없었습니다. 이번 변경은 새 상태 schema나 동작을 추가하지 않고 기존 계층을 하나의 수동 검토 흐름으로 연결합니다.

## 영향

공개 CLI에 계획된 `chat` 하위 명령이 활성화됩니다. 런타임 의존성, 상태 schema, renderer·ranking 규칙, 네트워크 정책은 바뀌지 않습니다. 전체 변경은 314줄이며 제품 코드는 72줄 증가합니다.

## 검증

- 구현 전 새 인수 테스트 3개가 미지원 `chat` 명령으로 RED인 상태 확인
- `python -m unittest discover -s ../tests -p test_chat_command.py -v` — 3개 성공
- `python -m unittest discover -s ../tests -v` — 92개 성공, 로컬 Windows symlink 권한으로 5개 제외
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy --strict src tests`
- wheel·sdist 빌드 성공
- 격리 venv에 wheel 설치 후 `sb --version`과 `sb --help` 성공

Refs #35