### PR TITLE
test(demo): add public parcel fixture

### DIFF
--- a/examples/parcel-sync-fixture/README.md
+++ b/examples/parcel-sync-fixture/README.md
@@ -1,0 +1,28 @@
+# parcel-sync fixture
+
+This is a synthetic Python project for the public siloBrief demo. It contains no real
+organization, repository, or operational data. Run the demo on a disposable copy because
+the commands create a local `.silobrief/` directory.
+
+The allowed package imports `urllib3` as documentation context and references a separately
+provided adapter. The adapter directory is registered as a boundary before indexing. The
+source also contains known canaries used only to verify what the generated brief omits.
+
+From the fixture root, run:
+
+```text
+sb setup .
+sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
+sb init
+sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
+sb chat "retry request" --out .silobrief/exports/retry-brief.md
+```
+
+For the bundled fixture, select candidate `1`, finish both add and exclude prompts with a
+blank line, answer `y` to each of the five disclosure questions, review the complete
+Markdown preview, and type exactly `WRITE` to create the file.
+
+The expected brief includes the relative service path, `retry_request`, `urllib3`, the human
+note, and the `delivery-boundary` description. It must not include the adapter's real path,
+symbol, or private canary. This verifies the published technical contract only; it is not a
+security certification or evidence of user demand.

--- a/examples/parcel-sync-fixture/private_adapter/__init__.py
+++ b/examples/parcel-sync-fixture/private_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Excluded synthetic adapter."""

--- a/examples/parcel-sync-fixture/private_adapter/client.py
+++ b/examples/parcel-sync-fixture/private_adapter/client.py
@@ -1,0 +1,5 @@
+PRIVATE_BOUNDARY_CANARY = "not for the generated brief"
+
+
+def deliver_internal(parcel: object) -> None:
+    del parcel

--- a/examples/parcel-sync-fixture/src/parcel_sync/__init__.py
+++ b/examples/parcel-sync-fixture/src/parcel_sync/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic parcel synchronization package."""

--- a/examples/parcel-sync-fixture/src/parcel_sync/models.py
+++ b/examples/parcel-sync-fixture/src/parcel_sync/models.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Parcel:
+    reference: str

--- a/examples/parcel-sync-fixture/src/parcel_sync/service.py
+++ b/examples/parcel-sync-fixture/src/parcel_sync/service.py
@@ -1,0 +1,17 @@
+"""Retry request fixture. PUBLIC_DOCSTRING_CANARY."""
+
+from __future__ import annotations
+
+import urllib3
+from private_adapter.client import deliver_internal
+
+from parcel_sync.models import Parcel
+
+PUBLIC_STRING = "PUBLIC_STRING_CANARY"
+
+
+def retry_request(parcel: Parcel) -> object:
+    # PUBLIC_COMMENT_CANARY
+    PUBLIC_SOURCE_BODY_CANARY = urllib3.Retry(total=2)
+    deliver_internal(parcel)
+    return PUBLIC_SOURCE_BODY_CANARY

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -21,6 +21,8 @@ from silobrief.cli import main
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
+INDEX_SHA256 = "0b810f442ca84d26de891dd08e2b77ec0c645e1753943bf8643a7f3b4dc4185e"
+BRIEF_SHA256 = "6cfcf9b914dd318f6ae6f1b65f0bef44ac3453a3f7f77d3d61596275ca1ed661"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",
     "PUBLIC_COMMENT_CANARY",
@@ -109,28 +111,31 @@ def run_demo(project: Path) -> DemoResult:
     ):
         setup_result = main(["setup", str(project)])
         with working_directory(project):
-            results = (
-                main(
-                    [
-                        "ignore",
-                        "private_adapter",
-                        "--as",
-                        "External delivery adapter",
-                        "--alias",
-                        "delivery-boundary",
-                    ]
-                ),
-                main(["init"]),
-                main(
-                    [
-                        "log",
-                        "src/parcel_sync/service.py",
-                        "--comment",
-                        "HTTP 503 responses may be retried.",
-                    ]
-                ),
-                main(["chat", "retry request", "--out", OUTPUT_PATH]),
+            ignore_result = main(
+                [
+                    "ignore",
+                    "private_adapter",
+                    "--as",
+                    "External delivery adapter",
+                    "--alias",
+                    "delivery-boundary",
+                ]
             )
+            init_result = main(["init"])
+            log_result = main(
+                [
+                    "log",
+                    "src/parcel_sync/service.py",
+                    "--comment",
+                    "HTTP 503 responses may be retried.",
+                ]
+            )
+            stdout.seek(0)
+            stdout.truncate(0)
+            stderr.seek(0)
+            stderr.truncate(0)
+            chat_result = main(["chat", "retry request", "--out", OUTPUT_PATH])
+            results = (ignore_result, init_result, log_result, chat_result)
 
     if (setup_result, *results) != (0, 0, 0, 0, 0):
         raise AssertionError(f"public demo failed: {(setup_result, *results)}\n{stderr.getvalue()}")
@@ -179,6 +184,8 @@ class PublicDemoTests(unittest.TestCase):
         self.assertIs(second.output_absent_before_write, True)
         self.assertEqual(first.index, second.index)
         self.assertEqual(first.brief, second.brief)
+        self.assertEqual(hashlib.sha256(first.index).hexdigest(), INDEX_SHA256)
+        self.assertEqual(hashlib.sha256(first.brief).hexdigest(), BRIEF_SHA256)
         self.assertEqual(
             first.scanned_directories,
             (".", "src", "src/parcel_sync"),

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import unittest
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+from unittest import mock
+
+import silobrief.sources as sources
+from silobrief.cli import main
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
+OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
+REVIEW_INPUT = "1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
+PUBLIC_CANARIES = (
+    "PUBLIC_SOURCE_BODY_CANARY",
+    "PUBLIC_COMMENT_CANARY",
+    "PUBLIC_DOCSTRING_CANARY",
+    "PUBLIC_STRING_CANARY",
+)
+PRIVATE_VALUES = (
+    "PRIVATE_BOUNDARY_CANARY",
+    "private_adapter",
+    "deliver_internal",
+)
+
+
+class TtyOutput(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class ScriptedInput:
+    def __init__(self, value: str, target: Path) -> None:
+        self._stream = io.StringIO(value)
+        self.target = target
+        self.output_absent_before_write: bool | None = None
+
+    def isatty(self) -> bool:
+        return True
+
+    def readline(self, size: int = -1) -> str:
+        value = self._stream.readline(size)
+        if value.rstrip("\r\n") == "WRITE":
+            self.output_absent_before_write = not self.target.exists()
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class DemoResult:
+    root: str
+    source_before: tuple[tuple[str, str], ...]
+    source_after: tuple[tuple[str, str], ...]
+    scanned_directories: tuple[str, ...]
+    opened_sources: tuple[str, ...]
+    index: bytes
+    brief: bytes
+    terminal: str
+    output_absent_before_write: bool | None
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def source_manifest(root: Path) -> tuple[tuple[str, str], ...]:
+    entries: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if path.is_file() and ".silobrief" not in relative.parts:
+            entries.append((relative.as_posix(), hashlib.sha256(path.read_bytes()).hexdigest()))
+    return tuple(entries)
+
+
+def run_demo(project: Path) -> DemoResult:
+    shutil.copytree(FIXTURE_ROOT, project)
+    before = source_manifest(project)
+    input_stream = ScriptedInput(REVIEW_INPUT, project / OUTPUT_PATH)
+    stdout = TtyOutput()
+    stderr = io.StringIO()
+
+    with (
+        mock.patch.object(socket, "socket") as socket_constructor,
+        mock.patch.object(socket, "create_connection") as create_connection,
+        mock.patch.object(
+            sources,
+            "_read_regular_source",
+            wraps=sources._read_regular_source,
+        ) as read_source,
+        mock.patch("silobrief.sources.os.scandir", wraps=os.scandir) as scan_directory,
+        mock.patch.object(sys, "stdin", input_stream),
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        setup_result = main(["setup", str(project)])
+        with working_directory(project):
+            results = (
+                main(
+                    [
+                        "ignore",
+                        "private_adapter",
+                        "--as",
+                        "External delivery adapter",
+                        "--alias",
+                        "delivery-boundary",
+                    ]
+                ),
+                main(["init"]),
+                main(
+                    [
+                        "log",
+                        "src/parcel_sync/service.py",
+                        "--comment",
+                        "HTTP 503 responses may be retried.",
+                    ]
+                ),
+                main(["chat", "retry request", "--out", OUTPUT_PATH]),
+            )
+
+    if (setup_result, *results) != (0, 0, 0, 0, 0):
+        raise AssertionError(f"public demo failed: {(setup_result, *results)}\n{stderr.getvalue()}")
+    socket_constructor.assert_not_called()
+    create_connection.assert_not_called()
+
+    resolved_project = project.resolve()
+    scanned = tuple(
+        sorted(
+            {
+                Path(cast(str | os.PathLike[str], call.args[0]))
+                .resolve()
+                .relative_to(resolved_project)
+                .as_posix()
+                or "."
+                for call in scan_directory.call_args_list
+            }
+        )
+    )
+    opened = tuple(sorted({cast(str, call.args[1]) for call in read_source.call_args_list}))
+    return DemoResult(
+        root=str(project.resolve()),
+        source_before=before,
+        source_after=source_manifest(project),
+        scanned_directories=scanned,
+        opened_sources=opened,
+        index=(project / ".silobrief/index.json").read_bytes(),
+        brief=(project / OUTPUT_PATH).read_bytes(),
+        terminal=stdout.getvalue() + stderr.getvalue(),
+        output_absent_before_write=input_stream.output_absent_before_write,
+    )
+
+
+class PublicDemoTests(unittest.TestCase):
+    def test_public_fixture_is_deterministic_offline_and_boundary_safe(self) -> None:
+        self.assertTrue(FIXTURE_ROOT.is_dir(), f"public fixture is missing: {FIXTURE_ROOT}")
+
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            first = run_demo(temporary / "first-project")
+            second = run_demo(temporary / "second-project")
+
+        self.assertEqual(first.source_before, first.source_after)
+        self.assertEqual(second.source_before, second.source_after)
+        self.assertIs(first.output_absent_before_write, True)
+        self.assertIs(second.output_absent_before_write, True)
+        self.assertEqual(first.index, second.index)
+        self.assertEqual(first.brief, second.brief)
+        self.assertEqual(
+            first.scanned_directories,
+            (".", "src", "src/parcel_sync"),
+        )
+        self.assertEqual(first.scanned_directories, second.scanned_directories)
+        self.assertEqual(
+            first.opened_sources,
+            (
+                "src/parcel_sync/__init__.py",
+                "src/parcel_sync/models.py",
+                "src/parcel_sync/service.py",
+            ),
+        )
+        self.assertEqual(first.opened_sources, second.opened_sources)
+
+        brief_text = first.brief.decode("utf-8")
+        for expected in (
+            "src/parcel_sync/service.py",
+            "function: retry_request",
+            "urllib3",
+            "HTTP 503 responses may be retried.",
+            "delivery-boundary",
+            "External delivery adapter",
+        ):
+            self.assertIn(expected, brief_text)
+        for result in (first, second):
+            index_text = result.index.decode("utf-8")
+            public_output = result.terminal + result.brief.decode("utf-8")
+            for canary in PUBLIC_CANARIES:
+                self.assertNotIn(canary.casefold(), public_output.casefold())
+            for private in PRIVATE_VALUES:
+                self.assertNotIn(private.casefold(), (index_text + public_output).casefold())
+            self.assertNotIn(result.root, index_text + public_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용

- 실제 조직 정보가 없는 `parcel-sync-fixture`를 추가했습니다.
- `setup → ignore → init → log → chat` 전체 흐름을 동일 입력으로 두 번 실행하는 acceptance test를 완성했습니다.
- 제외 subtree 접근, canary 노출, 소스 변경, 네트워크 시도와 승인 전 쓰기를 계측합니다.
- Windows·Ubuntu에서 같은 결과를 확인할 수 있도록 index와 Markdown SHA-256을 고정했습니다.

## 목적

소스 checkout과 설치된 wheel에서 동일한 공개 fixture 데모를 재현하고, v0.1 기능명세의 AC-01~05, AC-08~09, AC-11을 한 흐름으로 검증합니다. 이 결과는 기술 계약의 재현만 의미하며 사람 검색 효과나 시장 수요를 검증하지 않습니다.

## 영향

제품 모듈과 공개 CLI 계약은 변경하지 않습니다. 공개 fixture와 acceptance test만 추가합니다.

## 검증

- `python -m ruff check src tests examples`
- `python -m ruff format --check src tests examples`
- `python -m mypy --strict src tests`
- 전체 unittest 93개 통과, Windows symlink 권한 테스트 5개 제외
- wheel·sdist 빌드 성공
- 격리 환경 wheel 설치 후 `sb --version` 및 공개 fixture E2E 통과

Refs #37