### PR TITLE
docs: document the complete public workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,10 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Installable `silobrief` package and `sb --version` command.
 - Deterministic and idempotent project initialization with `sb setup`.
 - Guarded project boundary registration with `sb ignore`.
+- Safe source traversal, parsing, and deterministic indexing with `sb init`.
+- Boundary placeholders that omit registered subtree names from stored indexes and briefs.
+- User-authored public project notes with `sb log`.
+- Explainable lexical ranking and interactive one-step context review.
+- Whitelist-based Markdown rendering through `sb chat`.
+- Full preview and exact `WRITE` approval before creating a new output file.
+- Synthetic `parcel-sync-fixture` and installed-wheel end-to-end acceptance coverage.

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,14 +2,19 @@
 
 [English](README.md)
 
-siloBrief는 Python 프로젝트에서 공개 가능한 맥락을 골라, 사람이 검토한 Markdown
-조사 브리프를 만드는 로컬 CLI입니다. 소스가 있는 개발 환경과 인터넷 검색 환경이
-분리된 상황을 대상으로 합니다.
+siloBrief는 검토한 Python 프로젝트 맥락을 Markdown 조사 브리프 한 파일로 만드는 로컬
+CLI입니다. 소스가 있는 개발 환경과 인터넷 검색 환경이 분리된 상황을 대상으로 합니다.
 
 현재는 출시 전 개발 단계입니다. v0.1 동작은
 [`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md)에 고정되어 있습니다.
 
-현재 개발 빌드는 로컬 설치 후 버전 명령을 제공합니다.
+## 요구사항과 설치
+
+- Python 3.10 이상
+- Windows 또는 Ubuntu
+- 런타임 외부 의존성 없음
+
+현재 checkout을 설치하고 명령을 확인합니다.
 
 ```console
 python -m pip install .
@@ -22,43 +27,70 @@ sb --version
 siloBrief 0.1.0
 ```
 
-현재 디렉터리 또는 지정한 기존 프로젝트 디렉터리에 로컬 상태를 초기화합니다.
+## 빠른 시작
+
+합성 프로젝트인
+[`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md)를 일회용 위치에 복사합니다.
+fixture 루트에서 다음을 실행합니다.
 
 ```console
-sb setup [PATH]
-```
-
-이 명령은 `.silobrief/config.json`, `.silobrief/notes.json`, `.silobrief/exports/`를
-만듭니다. 다시 실행하면 기존 상태를 덮어쓰지 않고 호환 여부만 검사합니다.
-
-기존 프로젝트 파일이나 디렉터리를 제외 경계로 등록합니다.
-
-```console
-sb ignore PATH --as "공개 가능한 설명" [--alias NAME]
-```
-
-프로젝트 루트 또는 하위 디렉터리에서 실행해야 합니다. `PATH`는 현재 디렉터리 기준
-상대경로여야 하며 `..`를 포함하거나 symbolic link를 통과할 수 없습니다. 저장 경로는
-`/` 구분자를 사용합니다. `--alias`를 생략하면 실제 경로명과 무관한 `boundary-N`이
-부여됩니다. 설명은 공개 가능한 문장으로 간주합니다.
-
-경계를 등록한 다음 로컬 소스 인덱스를 생성하거나 갱신합니다.
-
-```console
+sb setup .
+sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
+sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
+sb chat "retry request" --out .silobrief/exports/retry-brief.md
 ```
 
-이 명령은 symbolic link를 따라가지 않고 허용된 Python 파일만 읽습니다. 파싱에 성공하고
-소스 snapshot이 바뀌지 않은 경우에만 `.silobrief/index.json`을 교체합니다.
+이 fixture에서는 후보 `1`을 선택하고, 추가·제외 입력은 빈 줄로 끝낸 뒤 다섯 필드 그룹을
+승인합니다. 전체 미리보기를 확인하고 정확히 `WRITE`를 입력해야 Markdown 파일이 생성됩니다.
+
+## 명령
+
+| 명령 | 동작 |
+|---|---|
+| `sb setup [PATH]` | 기존 프로젝트에 `.silobrief/` 상태를 만들거나 검증합니다. |
+| `sb ignore PATH --as TEXT [--alias NAME]` | 기존 경로를 제외하고 공개용 경계 설명을 등록합니다. |
+| `sb init` | 허용된 Python 파일에서 결정적인 구조 index를 만듭니다. |
+| `sb log PATH --comment TEXT` | 브리프에 포함될 수 있는 사용자 작성 메모를 저장합니다. |
+| `sb chat "PROMPT" --out FILE` | 후보 맥락을 검토하고 승인된 Markdown 한 파일을 만듭니다. |
+| `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
+
+`setup` 외 명령은 현재 디렉터리에서 프로젝트 루트를 찾습니다. `chat`에는 대화형 터미널,
+현재 설정과 일치하는 index, 새로운 `.md` 출력 경로가 필요합니다. 프로젝트 안의 출력은
+`.silobrief/exports/` 아래만 허용되며 기존 파일을 덮어쓰지 않습니다.
+
+## 로컬 상태
+
+```text
+.silobrief/
+├─ config.json
+├─ index.json
+├─ notes.json
+└─ exports/
+```
+
+상태 파일은 로컬 구현 데이터이며 외부 전달용 결과가 아닙니다. 생성된 Markdown만 의도한
+산출물이며, 이동하기 전에 사람이 전체 내용을 다시 확인해야 합니다.
+
+## 종료 코드
+
+| 코드 | 의미 |
+|---:|---|
+| `0` | 성공 |
+| `1` | 예상하지 못한 내부 오류 |
+| `2` | 입력, 경로 또는 설정 오류 |
+| `3` | 인덱싱 또는 Python 파싱 오류 |
+| `4` | 경계 검증, 승인 또는 출력 차단 |
 
 ## 범위와 한계
 
-- Python 3.10 이상, Windows와 Ubuntu
-- 런타임 외부 의존성, 네트워크, 언어 모델, 자동 전송 없음
-- 요청 한 건마다 사람의 명시적 승인 후 Markdown 한 파일 생성
-- 경로 단위 제외는 허용된 파일 안의 민감한 이름을 판별하지 못함
+- 인덱싱은 symbolic link를 따라가지 않고 등록한 제외 subtree를 열지 않습니다.
+- 경계 참조는 실제 제외 이름 대신 승인된 alias와 설명으로 저장합니다.
+- 네트워크 연결, 언어 모델 또는 자동 전송을 사용하지 않습니다.
+- 경로 단위 제외는 허용된 파일 안의 민감한 이름을 판별하지 못합니다.
 
 siloBrief는 보안 검사기, 반출 승인 시스템 또는 정보 누출 방지 보장 도구가 아닙니다.
+검색 시간 개선 효과와 사용자 수요도 아직 검증되지 않았습니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@
 
 [한국어](README.ko.md)
 
-siloBrief is a local command-line tool for preparing a reviewed Markdown research brief
-from a Python project. It is intended for development environments where source code and
+siloBrief is a local command-line tool that turns reviewed Python project context into one
+Markdown research brief. It is intended for development environments where source code and
 internet access are separated.
 
 The project is in pre-release development. Its frozen v0.1 behavior is documented in
 [`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md).
 
-The current development build exposes its version command after a local install:
+## Requirements and installation
+
+- Python 3.10 or newer
+- Windows or Ubuntu
+- no runtime dependencies
+
+Install the current checkout and verify the command:
 
 ```console
 python -m pip install .
@@ -22,45 +28,71 @@ Expected output:
 siloBrief 0.1.0
 ```
 
-Initialize local state in the current directory or an existing project directory:
+## Quick start
+
+Use a disposable copy of the synthetic
+[`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md). From its root, run:
 
 ```console
-sb setup [PATH]
-```
-
-This creates `.silobrief/config.json`, `.silobrief/notes.json`, and
-`.silobrief/exports/`. Running the command again validates compatible state without
-overwriting it.
-
-Register an existing project file or directory as an excluded boundary:
-
-```console
-sb ignore PATH --as "Public description" [--alias NAME]
-```
-
-Run this command from the project root or one of its subdirectories. `PATH` must be relative
-to the current directory and cannot contain `..` or pass through a symbolic link. Stored paths
-use `/` separators. If `--alias` is omitted, siloBrief assigns a path-independent
-`boundary-N` name. The description is treated as public text.
-
-Build or refresh the local source index after registering boundaries:
-
-```console
+sb setup .
+sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
+sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
+sb chat "retry request" --out .silobrief/exports/retry-brief.md
 ```
 
-The command reads allowed Python files without following symbolic links and replaces
-`.silobrief/index.json` only after parsing succeeds and the source snapshot remains unchanged.
+For this fixture, select candidate `1`, submit blank add and exclude prompts, approve the five
+field groups, and inspect the complete preview. The Markdown file is created only after you
+type exactly `WRITE`.
+
+## Commands
+
+| Command | Behavior |
+|---|---|
+| `sb setup [PATH]` | Creates or validates `.silobrief/` state in an existing project. |
+| `sb ignore PATH --as TEXT [--alias NAME]` | Excludes an existing path and registers its public boundary description. |
+| `sb init` | Builds a deterministic structure index from allowed Python files. |
+| `sb log PATH --comment TEXT` | Stores a user-authored note that may appear in a brief. |
+| `sb chat "PROMPT" --out FILE` | Reviews ranked context and writes one approved Markdown file. |
+| `sb --version` | Prints the installed siloBrief version. |
+
+Commands other than `setup` discover the project root from the current directory. `chat`
+requires an interactive terminal, a current index, and a new `.md` output path. Output inside
+the project must be below `.silobrief/exports/`; existing files are never overwritten.
+
+## Local state
+
+```text
+.silobrief/
+├─ config.json
+├─ index.json
+├─ notes.json
+└─ exports/
+```
+
+State files are local implementation data, not transfer-ready output. The generated Markdown
+is the only intended artifact, and it still requires a complete human review before moving it.
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | Success |
+| `1` | Unexpected internal error |
+| `2` | Input, path, or configuration error |
+| `3` | Indexing or Python parsing error |
+| `4` | Boundary validation, approval, or output was blocked |
 
 ## Boundaries
 
-- Python 3.10 or newer on Windows and Ubuntu
-- no runtime dependencies, network access, language model, or automatic transfer
-- one request produces one Markdown file after explicit human review
-- path-based exclusions do not identify sensitive names inside otherwise allowed files
+- Indexing does not follow symbolic links or open registered excluded subtrees.
+- Boundary references are stored with an approved alias and description instead of their real
+  excluded names.
+- The tool does not use a network connection, language model, or automatic transfer.
+- Path-based exclusions do not identify sensitive names inside otherwise allowed files.
 
 siloBrief is not a security scanner, export-approval system, or guarantee against data
-disclosure.
+disclosure. Its effect on research speed and user demand has not been validated.
 
 ## Contributing
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_README = "examples/parcel-sync-fixture/README.md"
+PUBLIC_COMMANDS = (
+    "sb setup",
+    "sb ignore",
+    "sb init",
+    "sb log",
+    "sb chat",
+    "sb --version",
+)
+README_EXPECTATIONS = {
+    "README.md": ("## Exit codes", "not a security scanner"),
+    "README.ko.md": ("## 종료 코드", "보안 검사기"),
+}
+CHANGELOG_EXPECTATIONS = (*PUBLIC_COMMANDS[:-1], "WRITE", "parcel-sync-fixture")
+
+
+class ReleaseDocumentationTests(unittest.TestCase):
+    def test_readmes_cover_the_public_flow_and_limits(self) -> None:
+        for relative_path, specific_fragments in README_EXPECTATIONS.items():
+            with self.subTest(path=relative_path):
+                text = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+                for fragment in (*PUBLIC_COMMANDS, FIXTURE_README, "WRITE", *specific_fragments):
+                    self.assertIn(fragment, text)
+                for exit_code in (0, 2, 3, 4):
+                    self.assertIn(f"| `{exit_code}` |", text)
+
+    def test_changelog_covers_the_current_development_scope(self) -> None:
+        text = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        for fragment in CHANGELOG_EXPECTATIONS:
+            self.assertIn(fragment, text)
+
+    def test_public_fixture_link_points_to_an_existing_file(self) -> None:
+        self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 내용

- 영문·한국어 README에 공개 CLI 여섯 명령과 전체 fixture 흐름을 추가했습니다.
- 정확한 `WRITE` 승인, 로컬 상태, 출력 제한과 종료 코드를 문서화했습니다.
- 경로 기반 ignore와 수동 검토의 한계, 미검증된 검색 효과·수요를 명시했습니다.
- `CHANGELOG.md`를 현재 `develop` 구현 범위와 맞췄습니다.
- 두 README와 CHANGELOG의 필수 내용을 확인하는 문서 acceptance test를 추가했습니다.

## 목적

공개 문서가 실제 v0.1 CLI와 설치형 fixture 데모를 빠짐없이 설명하도록 맞춥니다. 제품 동작이나 공개 계약은 변경하지 않습니다.

## 영향

문서와 문서 검증 테스트만 변경합니다. 제품 모듈, 상태 schema, CLI, 릴리스 상태에는 영향이 없습니다.

## 검증

- 문서 acceptance test 3개 통과
- 전체 unittest 96개 통과, 로컬 Windows symlink 권한 테스트 5개 제외
- Ruff lint·format 통과
- `mypy --strict` 통과
- 실제 CLI `--help`와 문서 명령 형식 대조
- 전체 PR 165줄 추가로 400줄 제한 이하

Refs #39