### PR TITLE
fix(package): include public files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include CHANGELOG.md
+include CODE_OF_CONDUCT.md
+include CONTRIBUTING.md
+include README.ko.md
+include SECURITY.md
+recursive-include docs *.md
+recursive-include examples/parcel-sync-fixture *.md *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "build>=1.2",
     "mypy>=1.15",
     "ruff>=0.11",
+    "setuptools>=77",
 ]
 
 [project.scripts]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+import tarfile
+import tempfile
 import unittest
 from importlib.metadata import distribution
 from pathlib import Path
 
 import silobrief
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class PackageMetadataTests(unittest.TestCase):
@@ -21,3 +27,43 @@ class PackageMetadataTests(unittest.TestCase):
         assert package_file is not None
 
         self.assertTrue(Path(package_file).with_name("py.typed").is_file())
+
+
+class SourceDistributionTests(unittest.TestCase):
+    def test_sdist_contains_public_documentation_and_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "build",
+                    "--sdist",
+                    "--no-isolation",
+                    "--outdir",
+                    directory,
+                    str(REPOSITORY_ROOT),
+                ],
+                cwd=directory,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            archives = tuple(Path(directory).glob("*.tar.gz"))
+            self.assertEqual(len(archives), 1, archives)
+            with tarfile.open(archives[0], mode="r:gz") as archive:
+                members = set(archive.getnames())
+
+        root = f"silobrief-{distribution('silobrief').version}"
+        required = {
+            f"{root}/CHANGELOG.md",
+            f"{root}/CODE_OF_CONDUCT.md",
+            f"{root}/CONTRIBUTING.md",
+            f"{root}/README.ko.md",
+            f"{root}/SECURITY.md",
+            f"{root}/docs/V0_1_CONTRACT.md",
+            f"{root}/examples/parcel-sync-fixture/README.md",
+            f"{root}/examples/parcel-sync-fixture/private_adapter/client.py",
+            f"{root}/examples/parcel-sync-fixture/src/parcel_sync/service.py",
+        }
+        self.assertFalse(required - members, required - members)


### PR DESCRIPTION
## 변경 사항

- source distribution에 공개 문서와 릴리스 기록을 포함합니다.
- `examples/parcel-sync-fixture/`의 Markdown과 Python 파일을 포함합니다.

## 원인과 영향

기본 sdist 파일 선택만으로는 감사에 필요한 `README.ko.md`, `CHANGELOG.md`와 공개 fixture가 빠졌습니다. 이 변경은 source distribution의 감사·재현 자료만 보완하며 wheel 내용과 런타임 동작은 바꾸지 않습니다.

## 검증

- `python -m unittest discover -s tests -v`: 97 passed, 5 skipped (Windows symlink 권한)
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy --strict src tests`
- 추출한 sdist에서 전체 테스트와 공개 fixture E2E 재현
- 새 가상환경에 wheel 무의존성 설치 후 `pip check`, `sb --version`, 공개 fixture E2E 재현
- Windows와 Ubuntu에서 symlink 방어 및 공개 fixture E2E 확인

Refs #41