### PR TITLE
fix(chat): exclude relative imports from public libraries

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -191,6 +191,7 @@ def _public_dependencies(index: IndexData, node_ids: set[str]) -> tuple[str, ...
         and edge.kind == "import"
         and edge.target_id is None
         and isinstance(edge.target, str)
+        and not edge.target.startswith(".")
     )
 
 

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -55,7 +55,9 @@ def source_index() -> IndexData:
         edges=(
             IndexEdge("root-id", "call", "helper.run", "neighbor-id"),
             IndexEdge("neighbor-id", "call", "second", "second-id"),
+            IndexEdge("root-id", "import", "helper.run", "neighbor-id"),
             IndexEdge("root-id", "import", "urllib3", None),
+            IndexEdge("root-id", "import", ".models.SyncResult", None),
             IndexEdge("neighbor-id", "import", "json", None),
             IndexEdge("second-id", "import", "second-hop-canary", None),
             IndexEdge(
@@ -136,7 +138,7 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("path=1", visible)
         self.assertIn("connected=1", visible)
         hidden_values = (
-            "source-body-canary|internal-real-name|src/direct.py|src/second.py|"
+            "source-body-canary|internal-real-name|.models.SyncResult|src/direct.py|src/second.py|"
             "second-hop-canary|unselected-note-canary|root-id"
         )
         for hidden in hidden_values.split("|"):


### PR DESCRIPTION
## 관련 Issue

Refs #46

## 변경 이유

선택된 노드의 unresolved 상대 import가 외부 공개 라이브러리로 잘못 표시됐다. 실제 T4 fixture에서는 `.http_client.HttpClient`와 `.models.SyncResult`가 dependency처럼 노출됐다.

## 변경 내용

- 상대 import edge가 공개 라이브러리와 추천 검색어에 포함되지 않는 regression test를 먼저 추가했다.
- unresolved import target이 `.`로 시작하면 공개 dependency에서 제외한다.
- 절대 외부 import, 해석된 내부 import, boundary placeholder의 기존 동작은 유지한다.

## 검증

- Windows 전체 unittest: 97 passed, 5 expected symlink skips
- Ruff lint/format: passed
- mypy strict (`src`, `tests`): passed
- 실제 T4 fixture: 두 상대 import 미노출, `asyncio`와 `collections.abc.Iterable` 유지
- Ubuntu/WSL: 제품·보안 동작 96 passed; sdist 테스트 1개는 WSL의 개발용 `build` 모듈 미설치로 실행 불가

GitHub Actions의 Ubuntu·Windows × Python 3.10·3.14 matrix에서 sdist 포함 최종 검증한다.

## 제외 범위와 한계

- CLI, index schema, Markdown 섹션은 변경하지 않는다.
- import graph 해석 확대, source body 자동 발췌, #42~#44는 포함하지 않는다.
- T4는 단일 모델·합성 fixture probe이며 일반 AI 품질이나 보안성을 보장하지 않는다.