### PR TITLE
fix(setup): report created or validated state

### DIFF
--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -55,9 +55,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         if not isinstance(project, Path):
             parser.error("setup path must be a filesystem path")
         try:
-            setup_project(project)
+            created = setup_project(project)
         except SetupError as error:
             parser.error(str(error))
+        if created:
+            print("created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/")
+        else:
+            print("validated existing .silobrief state")
 
     if arguments.command == "ignore":
         path_text = arguments.path

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -53,19 +53,19 @@ class NotesData(TypedDict):
     notes_version: int
 
 
-def setup_project(project: Path) -> None:
+def setup_project(project: Path) -> bool:
     root = _project_root(project)
     state = root / STATE_DIRECTORY
 
     if state.exists() or state.is_symlink():
         _validate_state(state)
-        return
+        return False
 
     try:
         state.mkdir()
     except FileExistsError:
         _validate_state(state)
-        return
+        return False
     except OSError as error:
         raise SetupError(f"cannot create {STATE_DIRECTORY}: {error}") from error
 
@@ -83,6 +83,7 @@ def setup_project(project: Path) -> None:
     except OSError as error:
         shutil.rmtree(state, ignore_errors=True)
         raise SetupError(f"cannot initialize {STATE_DIRECTORY}: {error}") from error
+    return True
 
 
 def _project_root(project: Path) -> Path:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -49,10 +49,16 @@ class SetupCommandTests(unittest.TestCase):
             source.write_text("VALUE = 1\n", encoding="utf-8", newline="\n")
             source_digest = hashlib.sha256(source.read_bytes()).digest()
 
-            result = main(["setup", str(project)])
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                result = main(["setup", str(project)])
 
             state = project / ".silobrief"
             self.assertEqual(result, 0)
+            self.assertEqual(
+                stdout.getvalue(),
+                "created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/\n",
+            )
             self.assertEqual(
                 json.loads((state / "config.json").read_text(encoding="utf-8")),
                 {
@@ -107,13 +113,16 @@ class SetupCommandTests(unittest.TestCase):
                 for path in tracked
             ]
 
-            result = main(["setup", str(project)])
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                result = main(["setup", str(project)])
 
             after = [
                 (path.read_bytes() if path.is_file() else b"", path.stat().st_mtime_ns)
                 for path in tracked
             ]
             self.assertEqual(result, 0)
+            self.assertEqual(stdout.getvalue(), "validated existing .silobrief state\n")
             self.assertEqual(after, before)
 
     def test_setup_rejects_missing_path_and_regular_file(self) -> None:


### PR DESCRIPTION
## 관련 Issue

Refs #50

## 변경 이유

`sb setup`이 새 상태를 만들거나 기존 상태를 검증해도 아무 출력 없이 종료돼 사용자가 수행 결과를 구분할 수 없었다.

## 변경 내용

- 첫 setup과 반복 setup의 stdout acceptance를 먼저 고정했다.
- `setup_project(Path) -> bool`로 새 상태 생성 여부만 반환한다.
- 새 상태 생성 시 생성된 config, notes, exports 경로를 출력한다.
- 기존 유효 상태에서는 변경 없이 검증했다는 메시지를 출력한다.

## 검증

- Windows 전체 unittest: 97 passed, 5 expected symlink skips
- Ubuntu/WSL setup 및 공개 fixture E2E: 10 passed
- Ruff lint/format: passed
- mypy strict (`src`, `tests`): passed
- fresh wheel 설치 후 두 번의 실제 `sb setup`: exit 0, 기대 출력 일치
- 반복 실행 전후 상태 파일 SHA-256 집합 동일

## 제외 범위와 한계

- 상태 schema, 파일 내용, 공개 명령과 종료 코드는 변경하지 않는다.
- progress bar, 다국어 출력, 다른 명령 메시지 개편, #42~#44는 포함하지 않는다.