### PR TITLE
fix(cli): require a subcommand

### DIFF
--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -29,7 +29,7 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Create a reviewed research brief from Python project context.",
     )
     parser.add_argument("--version", action="version", version=f"siloBrief {__version__}")
-    subcommands = parser.add_subparsers(dest="command")
+    subcommands = parser.add_subparsers(dest="command", required=True)
     setup = subcommands.add_parser("setup", help="Initialize local project state.")
     setup.add_argument("path", nargs="?", type=Path, default=Path.cwd())
     ignore = subcommands.add_parser("ignore", help="Register a project boundary.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,27 @@ from silobrief import __version__
 from silobrief.cli import main
 
 
+class CommandLineTests(unittest.TestCase):
+    def test_requires_a_subcommand(self) -> None:
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main([])
+
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("usage: sb", stderr.getvalue())
+        self.assertIn("{setup,ignore,init,log,chat}", stderr.getvalue())
+
+    def test_help_lists_commands_and_succeeds(self) -> None:
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), self.assertRaises(SystemExit) as caught:
+            main(["--help"])
+
+        self.assertEqual(caught.exception.code, 0)
+        self.assertIn("{setup,ignore,init,log,chat}", stdout.getvalue())
+
+
 class VersionCommandTests(unittest.TestCase):
     def test_version_uses_installed_package_metadata(self) -> None:
         self.assertEqual(__version__, version("silobrief"))


### PR DESCRIPTION
## 관련 Issue

Refs #51

## 변경 이유

인자 없는 `sb`가 아무 출력 없이 exit 0을 반환해 실제 작업 성공과 빈 호출을 구분할 수 없었다.

## 변경 내용

- 빈 인자 호출의 regression test를 먼저 추가했다.
- argparse subparser를 필수로 지정했다.
- `--help`와 `--version`의 성공 동작을 직접 고정했다.

## 검증

- Windows 전체 unittest: 99 passed, 5 expected symlink skips
- Ubuntu/WSL 직접 CLI 테스트: 4 passed
- Ruff lint/format: passed
- mypy strict (`src`, `tests`): passed
- 별도 프로세스 빈 호출: exit 2, stdout 0 bytes, usage와 명령 목록은 stderr
- 별도 프로세스 `--help`, `--version`: exit 0, stderr 0 bytes

## 제외 범위와 한계

- 기존 공개 명령, 명령 동작과 오류 코드 의미는 변경하지 않는다.
- 새 기본 동작, 대화형 메뉴, 다국어 출력, shell completion, #42~#44는 포함하지 않는다.