### PR TITLE
feat(source): extract selected Python definitions

### DIFF
--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -44,6 +44,8 @@ class Definition:
     is_async: bool
     line: int
     column: int
+    start_line: int
+    end_line: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,12 +78,12 @@ class ModuleStructure:
 
 def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
     return tuple(
-        _extract_module(source)
+        extract_module_structure(source)
         for source in sorted(snapshot.files, key=lambda candidate: candidate.path)
     )
 
 
-def _extract_module(source: SourceFile) -> ModuleStructure:
+def extract_module_structure(source: SourceFile) -> ModuleStructure:
     try:
         tree = ast.parse(source.content, filename=source.path, mode="exec")
     except SyntaxError as error:
@@ -186,7 +188,20 @@ class _StructureVisitor(ast.NodeVisitor):
     ) -> None:
         qualified_name = f"{self._context}.{node.name}" if self._context else node.name
         line, column = _location(node)
-        self.definitions.append(Definition(kind, node.name, qualified_name, is_async, line, column))
+        start_line = min((node.lineno, *(item.lineno for item in node.decorator_list)))
+        end_line = node.end_lineno if node.end_lineno is not None else node.lineno
+        self.definitions.append(
+            Definition(
+                kind,
+                node.name,
+                qualified_name,
+                is_async,
+                line,
+                column,
+                start_line,
+                end_line,
+            )
+        )
         self._contexts.append(qualified_name)
         try:
             self.generic_visit(node)

--- a/src/silobrief/source_excerpts.py
+++ b/src/silobrief/source_excerpts.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import io
+import tokenize
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from silobrief.index import NodeKind
+from silobrief.python_structure import (
+    Definition,
+    DefinitionKind,
+    PythonParseError,
+    extract_module_structure,
+)
+from silobrief.sources import SourceFile, SourceSnapshot
+
+MAX_SOURCE_LINES = 4_000
+MAX_SOURCE_UTF8_BYTES = 256 * 1024
+
+
+class SourceExcerptError(Exception):
+    pass
+
+
+class SourceExcerptLimitError(SourceExcerptError):
+    lines: int
+    utf8_bytes: int
+
+    def __init__(self, lines: int, utf8_bytes: int) -> None:
+        self.lines = lines
+        self.utf8_bytes = utf8_bytes
+        super().__init__(
+            f"source excerpts exceed the disclosure limit: {lines} lines, {utf8_bytes} UTF-8 bytes"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSelection:
+    path: str
+    kind: NodeKind
+    qualified_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class SourceExcerpt:
+    path: str
+    kind: DefinitionKind
+    qualified_name: str
+    start_line: int
+    end_line: int
+    content: str
+
+    @property
+    def line_count(self) -> int:
+        return self.end_line - self.start_line + 1
+
+    @property
+    def utf8_bytes(self) -> int:
+        return len(self.content.encode("utf-8"))
+
+
+def extract_source_excerpts(
+    snapshot: SourceSnapshot,
+    selections: Iterable[SourceSelection],
+    *,
+    max_lines: int = MAX_SOURCE_LINES,
+    max_utf8_bytes: int = MAX_SOURCE_UTF8_BYTES,
+) -> tuple[SourceExcerpt, ...]:
+    if max_lines < 0 or max_utf8_bytes < 0:
+        raise ValueError("source excerpt limits cannot be negative")
+
+    sources = {source.path: source for source in snapshot.files}
+    definitions: dict[str, dict[tuple[DefinitionKind, str], Definition]] = {}
+    decoded: dict[str, str] = {}
+    excerpts: list[SourceExcerpt] = []
+
+    for selection in sorted(set(selections), key=_selection_key):
+        if selection.kind == "module":
+            raise SourceExcerptError("module source excerpts are not supported")
+        source = sources.get(selection.path)
+        if source is None:
+            raise SourceExcerptError(
+                f"source file is not in the current snapshot: {selection.path}"
+            )
+
+        if selection.path not in definitions:
+            definitions[selection.path] = _definition_map(source)
+            decoded[selection.path] = _decode_source(source)
+        definition = definitions[selection.path].get((selection.kind, selection.qualified_name))
+        if definition is None:
+            raise SourceExcerptError(
+                "source definition is not in the current snapshot: "
+                f"{selection.path} {selection.qualified_name}"
+            )
+        excerpts.append(_excerpt(selection, definition, decoded[selection.path]))
+
+    result = _remove_enclosed_excerpts(excerpts)
+    lines = sum(item.line_count for item in result)
+    utf8_bytes = sum(item.utf8_bytes for item in result)
+    if lines > max_lines or utf8_bytes > max_utf8_bytes:
+        raise SourceExcerptLimitError(lines, utf8_bytes)
+    return result
+
+
+def _definition_map(source: SourceFile) -> dict[tuple[DefinitionKind, str], Definition]:
+    try:
+        structure = extract_module_structure(source)
+    except PythonParseError as error:
+        raise SourceExcerptError(str(error)) from error
+    return {
+        (definition.kind, definition.qualified_name): definition
+        for definition in structure.definitions
+    }
+
+
+def _decode_source(source: SourceFile) -> str:
+    try:
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(source.content).readline)
+        text = source.content.decode(encoding)
+    except (LookupError, SyntaxError, UnicodeDecodeError) as error:
+        raise SourceExcerptError(f"cannot decode source file: {source.path}") from error
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _excerpt(
+    selection: SourceSelection,
+    definition: Definition,
+    source: str,
+) -> SourceExcerpt:
+    return SourceExcerpt(
+        path=selection.path,
+        kind=definition.kind,
+        qualified_name=definition.qualified_name,
+        start_line=definition.start_line,
+        end_line=definition.end_line,
+        content=_source_lines(source, definition.start_line, definition.end_line),
+    )
+
+
+def _source_lines(source: str, start_line: int, end_line: int) -> str:
+    lines = source.split("\n")
+    content = "\n".join(lines[start_line - 1 : end_line])
+    if end_line < len(lines):
+        content += "\n"
+    return content
+
+
+def _remove_enclosed_excerpts(excerpts: list[SourceExcerpt]) -> tuple[SourceExcerpt, ...]:
+    ordered = sorted(excerpts, key=_excerpt_span_key)
+    result: list[SourceExcerpt] = []
+    for candidate in ordered:
+        if any(_contains(existing, candidate) for existing in result):
+            continue
+        result.append(candidate)
+    return tuple(sorted(result, key=_excerpt_output_key))
+
+
+def _contains(outer: SourceExcerpt, inner: SourceExcerpt) -> bool:
+    return (
+        outer.path == inner.path
+        and outer.start_line <= inner.start_line
+        and outer.end_line >= inner.end_line
+    )
+
+
+def _selection_key(selection: SourceSelection) -> tuple[str, str, str]:
+    return selection.path, selection.kind, selection.qualified_name
+
+
+def _excerpt_span_key(excerpt: SourceExcerpt) -> tuple[str, int, int, str]:
+    return excerpt.path, excerpt.start_line, -excerpt.end_line, excerpt.qualified_name
+
+
+def _excerpt_output_key(excerpt: SourceExcerpt) -> tuple[str, int, int, str]:
+    return excerpt.path, excerpt.start_line, excerpt.end_line, excerpt.qualified_name

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -50,12 +50,12 @@ class PythonStructureTests(unittest.TestCase):
         self.assertEqual(
             module.definitions,
             (
-                Definition("class", "Outer", "Outer", False, 1, 1),
-                Definition("class", "Inner", "Outer.Inner", False, 2, 5),
-                Definition("function", "method", "Outer.method", False, 4, 5),
-                Definition("function", "fetch", "Outer.fetch", True, 6, 5),
-                Definition("function", "top", "top", False, 8, 1),
-                Definition("function", "nested", "top.nested", False, 9, 5),
+                Definition("class", "Outer", "Outer", False, 1, 1, 1, 7),
+                Definition("class", "Inner", "Outer.Inner", False, 2, 5, 2, 3),
+                Definition("function", "method", "Outer.method", False, 4, 5, 4, 5),
+                Definition("function", "fetch", "Outer.fetch", True, 6, 5, 6, 7),
+                Definition("function", "top", "top", False, 8, 1, 8, 10),
+                Definition("function", "nested", "top.nested", False, 9, 5, 9, 10),
             ),
         )
         self.assertEqual(module.imports, ())
@@ -136,7 +136,7 @@ class PythonStructureTests(unittest.TestCase):
 
         self.assertEqual(
             result[0].definitions,
-            (Definition("function", "run", "run", False, 4, 1),),
+            (Definition("function", "run", "run", False, 4, 1, 4, 6),),
         )
         for canary in (
             "DOCSTRING_CANARY",

--- a/tests/test_source_excerpts.py
+++ b/tests/test_source_excerpts.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import unittest
+
+from silobrief.source_excerpts import (
+    SourceExcerptError,
+    SourceExcerptLimitError,
+    SourceSelection,
+    extract_source_excerpts,
+)
+from silobrief.sources import SourceFile, SourceSnapshot
+
+
+def source_file(path: str, content: bytes) -> SourceFile:
+    return SourceFile(
+        path=path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def snapshot(*files: SourceFile) -> SourceSnapshot:
+    return SourceSnapshot(files=files, warnings=(), digest="test-snapshot")
+
+
+class SourceExcerptTests(unittest.TestCase):
+    def test_extracts_decorated_sync_async_and_nested_functions(self) -> None:
+        source = source_file(
+            "service.py",
+            (
+                b'@route("retry")\r\n'
+                b"def retry_request():\r\n"
+                b'    """PUBLIC_DOCSTRING."""\r\n'
+                b"    # PUBLIC_COMMENT\r\n"
+                b'    value = "PUBLIC_STRING"\r\n'
+                b"    def nested():\r\n"
+                b"        return value\r\n"
+                b"    return nested()\r\n"
+                b"\r\n"
+                b"async def fetch():\r\n"
+                b"    return None\r\n"
+            ),
+        )
+
+        excerpts = extract_source_excerpts(
+            snapshot(source),
+            (
+                SourceSelection("service.py", "function", "retry_request.nested"),
+                SourceSelection("service.py", "function", "fetch"),
+            ),
+        )
+
+        self.assertEqual(
+            [(item.qualified_name, item.start_line, item.end_line) for item in excerpts],
+            [("retry_request.nested", 6, 7), ("fetch", 10, 11)],
+        )
+        self.assertEqual(
+            excerpts[0].content,
+            "    def nested():\n        return value\n",
+        )
+        self.assertEqual(excerpts[1].content, "async def fetch():\n    return None\n")
+
+    def test_preserves_approved_comments_docstrings_and_strings(self) -> None:
+        source = source_file(
+            "service.py",
+            (
+                b'@route("retry")\n'
+                b"def retry_request():\n"
+                b'    """PUBLIC_DOCSTRING."""\n'
+                b"    # PUBLIC_COMMENT\n"
+                b'    return "PUBLIC_STRING"\n'
+            ),
+        )
+
+        (excerpt,) = extract_source_excerpts(
+            snapshot(source),
+            (SourceSelection("service.py", "function", "retry_request"),),
+        )
+
+        self.assertEqual(excerpt.start_line, 1)
+        self.assertEqual(excerpt.end_line, 5)
+        self.assertEqual(excerpt.line_count, 5)
+        self.assertIn('@route("retry")', excerpt.content)
+        self.assertIn("PUBLIC_DOCSTRING", excerpt.content)
+        self.assertIn("PUBLIC_COMMENT", excerpt.content)
+        self.assertIn("PUBLIC_STRING", excerpt.content)
+
+    def test_outer_class_replaces_overlapping_method(self) -> None:
+        source = source_file(
+            "models.py",
+            (
+                b"class Service:\n"
+                b"    def run(self):\n"
+                b"        return 1\n"
+                b"\n"
+                b"def other():\n"
+                b"    return 2\n"
+            ),
+        )
+
+        excerpts = extract_source_excerpts(
+            snapshot(source),
+            (
+                SourceSelection("models.py", "function", "Service.run"),
+                SourceSelection("models.py", "class", "Service"),
+                SourceSelection("models.py", "class", "Service"),
+                SourceSelection("models.py", "function", "other"),
+            ),
+        )
+
+        self.assertEqual(
+            [item.qualified_name for item in excerpts],
+            ["Service", "other"],
+        )
+        self.assertEqual(
+            excerpts[0].content, "class Service:\n    def run(self):\n        return 1\n"
+        )
+
+    def test_sorts_excerpts_by_path_and_source_location(self) -> None:
+        first = source_file("a.py", b"def zed():\n    pass\n\ndef alpha():\n    pass\n")
+        second = source_file("b.py", b"def beta():\n    pass\n")
+
+        excerpts = extract_source_excerpts(
+            snapshot(second, first),
+            (
+                SourceSelection("b.py", "function", "beta"),
+                SourceSelection("a.py", "function", "alpha"),
+                SourceSelection("a.py", "function", "zed"),
+            ),
+        )
+
+        self.assertEqual(
+            [(item.path, item.qualified_name) for item in excerpts],
+            [("a.py", "zed"), ("a.py", "alpha"), ("b.py", "beta")],
+        )
+
+    def test_decodes_source_encoding_and_emits_utf8_text(self) -> None:
+        source = source_file(
+            "legacy.py",
+            b'# -*- coding: latin-1 -*-\r\ndef label():\r\n    return "caf\xe9"\r\n',
+        )
+
+        (excerpt,) = extract_source_excerpts(
+            snapshot(source),
+            (SourceSelection("legacy.py", "function", "label"),),
+        )
+
+        self.assertEqual(excerpt.content, 'def label():\n    return "caf\u00e9"\n')
+        self.assertEqual(excerpt.utf8_bytes, len(excerpt.content.encode("utf-8")))
+
+    def test_does_not_parse_unselected_invalid_file(self) -> None:
+        selected = source_file("good.py", b"def run():\n    return 1\n")
+        unselected = source_file("bad.py", b"def broken(:  # PARSE_CANARY\n")
+
+        (excerpt,) = extract_source_excerpts(
+            snapshot(unselected, selected),
+            (SourceSelection("good.py", "function", "run"),),
+        )
+
+        self.assertEqual(excerpt.path, "good.py")
+
+        with self.assertRaises(SourceExcerptError) as caught:
+            extract_source_excerpts(
+                snapshot(unselected, selected),
+                (SourceSelection("bad.py", "function", "broken"),),
+            )
+        self.assertNotIn("PARSE_CANARY", str(caught.exception))
+
+    def test_rejects_unsupported_or_missing_selections(self) -> None:
+        source = source_file("service.py", b"def run():\n    return 1\n")
+        cases = (
+            SourceSelection("service.py", "module", "service"),
+            SourceSelection("missing.py", "function", "run"),
+            SourceSelection("service.py", "function", "missing"),
+        )
+
+        for selection in cases:
+            with self.subTest(selection=selection):
+                with self.assertRaises(SourceExcerptError):
+                    extract_source_excerpts(snapshot(source), (selection,))
+
+    def test_rejects_line_and_byte_limit_without_truncating(self) -> None:
+        source = source_file("service.py", b"def run():\n    return 'payload'\n")
+        selection = SourceSelection("service.py", "function", "run")
+
+        with self.assertRaises(SourceExcerptLimitError) as line_error:
+            extract_source_excerpts(snapshot(source), (selection,), max_lines=1)
+        self.assertEqual(line_error.exception.lines, 2)
+
+        full = extract_source_excerpts(snapshot(source), (selection,))[0]
+        with self.assertRaises(SourceExcerptLimitError) as byte_error:
+            extract_source_excerpts(
+                snapshot(source),
+                (selection,),
+                max_utf8_bytes=full.utf8_bytes - 1,
+            )
+        self.assertEqual(byte_error.exception.utf8_bytes, full.utf8_bytes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 Issue

Refs #61

## 변경 이유

v0.2 source companion은 사용자가 직접 선택한 함수와 클래스의 실제 원문 범위를
결정적으로 추출해야 합니다. 기존 index는 구조 검색에 필요한 위치만 보유하고 원문
excerpt 범위를 제공하지 않았습니다.

## 변경 내용

- Python definition에 decorator를 포함한 시작 줄과 본문 종료 줄을 기록합니다.
- 선택된 함수, 비동기 함수와 클래스만 snapshot bytes에서 다시 추출합니다.
- 중첩 qualified name과 class·method 중복 범위를 처리합니다.
- source encoding을 감지하고 UTF-8 text와 LF 줄바꿈으로 정규화합니다.
- 주석, docstring과 문자열을 원문으로 보존합니다.
- 4000줄과 UTF-8 256 KiB 제한을 넘으면 자르지 않고 거부합니다.
- 선택되지 않은 파일은 파싱하지 않습니다.

## 검증

- [x] acceptance와 regression test를 먼저 추가했습니다.
- [x] 전체 unittest를 실행했습니다.
- [x] Ruff lint와 format check를 통과했습니다.
- [x] mypy strict를 통과했습니다.
- [x] 실제 조직·저장소·자격 증명·제한 정보를 포함하지 않았습니다.

실행한 명령과 결과:

```text
ruff check .
All checks passed!

ruff format --check .
47 files already formatted

mypy
Success: no issues found in 42 source files

python -m unittest discover
Ran 109 tests: OK (skipped=5)
```

## 제외 범위와 남은 제한

- interactive source 승인과 기본값 No 처리는 후속 Issue로 분리합니다.
- boundary `EXPOSE` 승인은 후속 Issue로 분리합니다.
- Markdown renderer와 paired output은 변경하지 않습니다.
- config, index와 notes schema를 변경하지 않습니다.
