### PR TITLE
feat(review): require explicit source disclosure

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -43,6 +43,7 @@ def review_brief(
         raise ChatReviewError("request must not be empty")
     if not input_stream.isatty() or not output_stream.isatty():
         raise ChatReviewError("review requires an interactive terminal")
+    _confirm_request(input_stream, output_stream)
 
     try:
         options = candidate_options(rank_candidates(prompt, index, notes))
@@ -91,6 +92,21 @@ def _show_candidates(options: tuple[CandidateOption, ...], output: TextIO) -> No
             f"comment={evidence.comment_matches} note={note} "
             f"connected={evidence.connected_nodes}\n",
         )
+
+
+def _confirm_request(input_stream: TextIO, output_stream: TextIO) -> None:
+    _write(
+        output_stream,
+        "Request completeness:\n"
+        "- work goal\n"
+        "- required deliverables\n"
+        "- completion or acceptance criteria\n",
+    )
+    if (
+        _read_line("Continue with this complete request? [y/N]: ", input_stream, output_stream)
+        != "y"
+    ):
+        raise ChatReviewError("request completeness was not confirmed")
 
 
 def _read_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[int, ...]:

--- a/src/silobrief/source_excerpts.py
+++ b/src/silobrief/source_excerpts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import sys
 import tokenize
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -94,7 +95,34 @@ def extract_source_excerpts(
             )
         excerpts.append(_excerpt(selection, definition, decoded[selection.path]))
 
-    result = _remove_enclosed_excerpts(excerpts)
+    return prepare_source_excerpts(
+        excerpts,
+        max_lines=max_lines,
+        max_utf8_bytes=max_utf8_bytes,
+    )
+
+
+def extract_source_excerpt(
+    snapshot: SourceSnapshot,
+    selection: SourceSelection,
+) -> SourceExcerpt:
+    return extract_source_excerpts(
+        snapshot,
+        (selection,),
+        max_lines=sys.maxsize,
+        max_utf8_bytes=sys.maxsize,
+    )[0]
+
+
+def prepare_source_excerpts(
+    excerpts: Iterable[SourceExcerpt],
+    *,
+    max_lines: int = MAX_SOURCE_LINES,
+    max_utf8_bytes: int = MAX_SOURCE_UTF8_BYTES,
+) -> tuple[SourceExcerpt, ...]:
+    if max_lines < 0 or max_utf8_bytes < 0:
+        raise ValueError("source excerpt limits cannot be negative")
+    result = _remove_enclosed_excerpts(list(excerpts))
     lines = sum(item.line_count for item in result)
     utf8_bytes = sum(item.utf8_bytes for item in result)
     if lines > max_lines or utf8_bytes > max_utf8_bytes:

--- a/src/silobrief/source_review.py
+++ b/src/silobrief/source_review.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import TextIO
+
+from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.index import IndexData
+from silobrief.python_structure import DefinitionKind
+from silobrief.review import ReviewNode, ReviewSelection
+from silobrief.source_excerpts import (
+    SourceExcerpt,
+    SourceExcerptError,
+    SourceExcerptLimitError,
+    SourceSelection,
+    extract_source_excerpt,
+    prepare_source_excerpts,
+)
+from silobrief.sources import SourceSnapshot
+
+
+class SourceReviewError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovedSourceExcerpt:
+    path: str
+    kind: DefinitionKind
+    qualified_name: str
+    start_line: int
+    end_line: int
+    content: str
+    boundary_aliases: tuple[str, ...]
+
+    @property
+    def line_count(self) -> int:
+        return self.end_line - self.start_line + 1
+
+    @property
+    def utf8_bytes(self) -> int:
+        return len(self.content.encode("utf-8"))
+
+
+def review_source_disclosure(
+    index: IndexData,
+    snapshot: SourceSnapshot,
+    selection: ReviewSelection,
+    *,
+    input_stream: TextIO,
+    output_stream: TextIO,
+) -> tuple[ApprovedSourceExcerpt, ...]:
+    if not input_stream.isatty() or not output_stream.isatty():
+        raise SourceReviewError("source review requires an interactive terminal")
+
+    selected_nodes = {
+        (node.path, node.kind, node.qualified_name): node
+        for node in selection.selected
+        if node.kind != "module"
+    }
+    candidates: list[SourceExcerpt] = []
+    for node in sorted(selected_nodes.values(), key=_node_key):
+        try:
+            candidates.append(
+                extract_source_excerpt(
+                    snapshot,
+                    SourceSelection(node.path, node.kind, node.qualified_name),
+                )
+            )
+        except SourceExcerptError as error:
+            _write(
+                output_stream,
+                f"Source excerpt unavailable: {node.path} {node.qualified_name}: {error}\n",
+            )
+
+    candidates = list(
+        prepare_source_excerpts(
+            candidates,
+            max_lines=sys.maxsize,
+            max_utf8_bytes=sys.maxsize,
+        )
+    )
+    if candidates:
+        _write(
+            output_stream,
+            "Source disclosure warning: approved excerpts are copied verbatim and may contain "
+            "identifiers, paths, URLs, strings, or secrets that are not classified "
+            "automatically.\n",
+        )
+
+    aliases = {
+        _excerpt_key(excerpt): _boundary_aliases(
+            index,
+            selected_nodes[_excerpt_key(excerpt)].id,
+        )
+        for excerpt in candidates
+    }
+    approved: tuple[SourceExcerpt, ...] = ()
+    for candidate in candidates:
+        _show_candidate(candidate, aliases[_excerpt_key(candidate)], output_stream)
+        answer = _read_line("Include this source excerpt? [y/N]: ", input_stream, output_stream)
+        if answer not in {"", "n", "y"}:
+            raise SourceReviewError("source answer must be y, n, or blank")
+        if answer != "y":
+            continue
+        try:
+            approved = prepare_source_excerpts((*approved, candidate))
+        except SourceExcerptLimitError as error:
+            _write(output_stream, f"Source excerpt skipped: {error}\n")
+
+    exposed = tuple(
+        sorted({alias for excerpt in approved for alias in aliases[_excerpt_key(excerpt)]})
+    )
+    if exposed:
+        _write(
+            output_stream, f"Boundary aliases exposed in approved source: {', '.join(exposed)}\n"
+        )
+        if (
+            _read_line(
+                "Type exactly EXPOSE to include boundary identifiers: ",
+                input_stream,
+                output_stream,
+            )
+            != "EXPOSE"
+        ):
+            approved = tuple(excerpt for excerpt in approved if not aliases[_excerpt_key(excerpt)])
+
+    return tuple(_approved_excerpt(excerpt, aliases[_excerpt_key(excerpt)]) for excerpt in approved)
+
+
+def _approved_excerpt(
+    excerpt: SourceExcerpt,
+    aliases: tuple[str, ...],
+) -> ApprovedSourceExcerpt:
+    return ApprovedSourceExcerpt(
+        path=excerpt.path,
+        kind=excerpt.kind,
+        qualified_name=excerpt.qualified_name,
+        start_line=excerpt.start_line,
+        end_line=excerpt.end_line,
+        content=excerpt.content,
+        boundary_aliases=aliases,
+    )
+
+
+def _boundary_aliases(index: IndexData, node_id: str) -> tuple[str, ...]:
+    included = {node_id}
+    changed = True
+    while changed:
+        changed = False
+        for edge in index.edges:
+            if edge.kind != "contains" or edge.source_id not in included or edge.target_id is None:
+                continue
+            if edge.target_id not in included:
+                included.add(edge.target_id)
+                changed = True
+    return tuple(
+        sorted(
+            {
+                edge.target.alias
+                for edge in index.edges
+                if edge.source_id in included and isinstance(edge.target, BoundaryPlaceholder)
+            }
+        )
+    )
+
+
+def _show_candidate(
+    excerpt: SourceExcerpt,
+    aliases: tuple[str, ...],
+    output: TextIO,
+) -> None:
+    _write(
+        output,
+        f"Source candidate: {excerpt.path} | {excerpt.kind} {excerpt.qualified_name} | "
+        f"lines {excerpt.start_line}-{excerpt.end_line}\n"
+        f"Boundary aliases: {', '.join(aliases) if aliases else 'none'}\n"
+        "```python\n",
+    )
+    _write(output, excerpt.content)
+    if not excerpt.content.endswith("\n"):
+        _write(output, "\n")
+    _write(output, "```\n")
+
+
+def _read_line(label: str, input_stream: TextIO, output_stream: TextIO) -> str:
+    _write(output_stream, label)
+    try:
+        output_stream.flush()
+        return input_stream.readline().rstrip("\r\n")
+    except OSError as error:
+        raise SourceReviewError("interactive terminal input failed") from error
+
+
+def _write(output: TextIO, value: str) -> None:
+    try:
+        output.write(value)
+    except OSError as error:
+        raise SourceReviewError("interactive terminal output failed") from error
+
+
+def _node_key(node: ReviewNode) -> tuple[str, str, str, str]:
+    return node.path, node.kind, node.qualified_name, node.id
+
+
+def _excerpt_key(excerpt: SourceExcerpt) -> tuple[str, DefinitionKind, str]:
+    return excerpt.path, excerpt.kind, excerpt.qualified_name

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -104,7 +104,7 @@ def prepare_project(project: Path) -> Path:
     return service
 
 
-REVIEW_INPUT = "1\n\n\ny\ny\ny\ny\ny\n"
+REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\n"
 
 
 def run_chat(

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -89,7 +89,7 @@ def source_notes() -> NotesData:
     )
 
 
-APPROVED_INPUT = "1\nsrc/direct.py\n\nsrc/direct.py\n\ny\ny\ny\ny\ny\n"
+APPROVED_INPUT = "y\n1\nsrc/direct.py\n\nsrc/direct.py\n\ny\ny\ny\ny\ny\n"
 
 
 def disclosure_counts(rendered: RenderedBrief) -> tuple[int, int, int, int, int]:
@@ -149,7 +149,7 @@ class ChatReviewTests(unittest.TestCase):
             "retry",
             source_index(),
             source_notes(),
-            input_stream=TtyBuffer("1\n\n\nn\nn\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n1\n\n\nn\nn\nn\nn\nn\n"),
             output_stream=TtyBuffer(),
         )
 
@@ -159,9 +159,9 @@ class ChatReviewTests(unittest.TestCase):
     def test_rejects_invalid_or_empty_review_input(self) -> None:
         cases = (
             (" ", "", "request"),
-            ("absent", "", "candidate"),
-            ("retry", "2\n\n\n", "candidate number"),
-            ("retry", "1\n\n\nY\n", "y or n"),
+            ("absent", "y\n", "candidate"),
+            ("retry", "y\n2\n\n\n", "candidate number"),
+            ("retry", "y\n1\n\n\nY\n", "y or n"),
         )
         for prompt, input_text, message in cases:
             with self.subTest(message=message):
@@ -173,6 +173,20 @@ class ChatReviewTests(unittest.TestCase):
                         input_stream=TtyBuffer(input_text),
                         output_stream=TtyBuffer(),
                     )
+
+    def test_requires_request_completeness_confirmation(self) -> None:
+        for answer in ("\n", "n\n"):
+            with self.subTest(answer=answer):
+                output = TtyBuffer()
+                with self.assertRaisesRegex(ChatReviewError, "completeness"):
+                    review_brief(
+                        "retry",
+                        source_index(),
+                        source_notes(),
+                        input_stream=TtyBuffer(answer),
+                        output_stream=output,
+                    )
+                self.assertNotIn("Candidates:", output.getvalue())
 
     def test_requires_interactive_input_and_output(self) -> None:
         for input_tty, output_tty in ((False, True), (True, False)):

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -20,7 +20,7 @@ from silobrief.cli import main
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
-REVIEW_INPUT = "1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
+REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
 INDEX_SHA256 = "0b810f442ca84d26de891dd08e2b77ec0c645e1753943bf8643a7f3b4dc4185e"
 BRIEF_SHA256 = "6cfcf9b914dd318f6ae6f1b65f0bef44ac3453a3f7f77d3d61596275ca1ed661"
 PUBLIC_CANARIES = (

--- a/tests/test_source_review.py
+++ b/tests/test_source_review.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import unittest
+
+from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.review import DisclosureChoices, ReviewNode, ReviewSelection
+from silobrief.source_review import SourceReviewError, review_source_disclosure
+from silobrief.sources import SourceFile, SourceSnapshot
+
+
+class TtyBuffer(io.StringIO):
+    def __init__(self, value: str = "", *, tty: bool = True) -> None:
+        super().__init__(value)
+        self.tty = tty
+
+    def isatty(self) -> bool:
+        return self.tty
+
+
+TOKENS = NodeTokens(path=(), symbol=(), imports=(), comments=(), docstrings=())
+FIELDS = DisclosureChoices(False, False, False, False, False)
+
+
+def node(node_id: str, path: str, kind: NodeKind, qualified_name: str) -> IndexNode:
+    return IndexNode(
+        id=node_id,
+        kind=kind,
+        name=qualified_name.rsplit(".", 1)[-1],
+        qualified_name=qualified_name,
+        path=path,
+        tokens=TOKENS,
+    )
+
+
+def review_node(value: IndexNode) -> ReviewNode:
+    return ReviewNode(value.id, value.path, value.kind, value.name, value.qualified_name)
+
+
+def source_file(path: str, content: bytes) -> SourceFile:
+    return SourceFile(path, content, hashlib.sha256(content).hexdigest())
+
+
+def snapshot(*files: SourceFile) -> SourceSnapshot:
+    return SourceSnapshot(files, (), "snapshot")
+
+
+def index(*nodes: IndexNode, edges: tuple[IndexEdge, ...] = ()) -> IndexData:
+    return IndexData("a" * 64, edges, 1, nodes, "b" * 64, False)
+
+
+class SourceReviewTests(unittest.TestCase):
+    def test_reviews_only_explicit_function_and_defaults_to_no(self) -> None:
+        module = node("module", "service.py", "module", "service")
+        selected = node("run", "service.py", "function", "run")
+        expanded = node("helper", "helper.py", "function", "helper")
+        source = snapshot(
+            source_file("service.py", b"def run():\n    return 1\n"),
+            source_file("helper.py", b"def helper():\n    return 2\n"),
+        )
+        selection = ReviewSelection(
+            (review_node(module), review_node(selected)),
+            (review_node(expanded),),
+            FIELDS,
+        )
+        output = TtyBuffer()
+
+        approved = review_source_disclosure(
+            index(module, selected, expanded),
+            source,
+            selection,
+            input_stream=TtyBuffer("\n"),
+            output_stream=output,
+        )
+
+        self.assertEqual(approved, ())
+        visible = output.getvalue()
+        self.assertIn("def run", visible)
+        self.assertNotIn("def helper", visible)
+        self.assertNotIn("module service", visible)
+
+    def test_requires_expose_for_static_boundary_reference(self) -> None:
+        function = node("run", "service.py", "function", "run")
+        placeholder = BoundaryPlaceholder("delivery-boundary", "Private delivery adapter")
+        source = snapshot(
+            source_file(
+                "service.py",
+                b"def run():\n    return deliver_internal()\n",
+            )
+        )
+        selection = ReviewSelection((review_node(function),), (), FIELDS)
+        source_index = index(
+            function,
+            edges=(IndexEdge("run", "call", placeholder, None),),
+        )
+
+        declined = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nnot-expose\n"),
+            output_stream=TtyBuffer(),
+        )
+        approved = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nEXPOSE\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(declined, ())
+        self.assertEqual(len(approved), 1)
+        self.assertEqual(approved[0].boundary_aliases, ("delivery-boundary",))
+        self.assertIn("deliver_internal", approved[0].content)
+
+    def test_class_approval_absorbs_method_and_its_boundary_alias(self) -> None:
+        owner = node("owner", "service.py", "class", "Service")
+        method = node("method", "service.py", "function", "Service.run")
+        placeholder = BoundaryPlaceholder("delivery-boundary", "Private delivery adapter")
+        source = snapshot(
+            source_file(
+                "service.py",
+                b"class Service:\n    def run(self):\n        return deliver_internal()\n",
+            )
+        )
+        selection = ReviewSelection((review_node(owner), review_node(method)), (), FIELDS)
+        source_index = index(
+            owner,
+            method,
+            edges=(
+                IndexEdge("owner", "contains", "Service.run", "method"),
+                IndexEdge("method", "call", placeholder, None),
+            ),
+        )
+
+        approved = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nEXPOSE\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(len(approved), 1)
+        self.assertEqual(approved[0].qualified_name, "Service")
+        self.assertEqual(approved[0].boundary_aliases, ("delivery-boundary",))
+
+    def test_parse_failure_does_not_remove_valid_candidate(self) -> None:
+        broken = node("broken", "bad.py", "function", "broken")
+        valid = node("valid", "good.py", "function", "valid")
+        source = snapshot(
+            source_file("bad.py", b"def broken(:  # PARSE_CANARY\n"),
+            source_file("good.py", b"def valid():\n    return 1\n"),
+        )
+        output = TtyBuffer()
+
+        approved = review_source_disclosure(
+            index(broken, valid),
+            source,
+            ReviewSelection((review_node(broken), review_node(valid)), (), FIELDS),
+            input_stream=TtyBuffer("y\n"),
+            output_stream=output,
+        )
+
+        self.assertEqual([item.qualified_name for item in approved], ["valid"])
+        self.assertIn("bad.py", output.getvalue())
+        self.assertNotIn("PARSE_CANARY", output.getvalue())
+
+    def test_skips_approved_excerpt_that_exceeds_limit(self) -> None:
+        function = node("huge", "huge.py", "function", "huge")
+        content = b"def huge():\n" + (b"    value = 1\n" * 4_000)
+        output = TtyBuffer()
+
+        approved = review_source_disclosure(
+            index(function),
+            snapshot(source_file("huge.py", content)),
+            ReviewSelection((review_node(function),), (), FIELDS),
+            input_stream=TtyBuffer("y\n"),
+            output_stream=output,
+        )
+
+        self.assertEqual(approved, ())
+        self.assertIn("skipped", output.getvalue())
+        self.assertIn("4001 lines", output.getvalue())
+
+    def test_rejects_non_interactive_streams(self) -> None:
+        function = node("run", "service.py", "function", "run")
+        source = snapshot(source_file("service.py", b"def run():\n    pass\n"))
+        selection = ReviewSelection((review_node(function),), (), FIELDS)
+
+        for input_tty, output_tty in ((False, True), (True, False)):
+            with self.subTest(input_tty=input_tty, output_tty=output_tty):
+                with self.assertRaisesRegex(SourceReviewError, "interactive terminal"):
+                    review_source_disclosure(
+                        index(function),
+                        source,
+                        selection,
+                        input_stream=TtyBuffer(tty=input_tty),
+                        output_stream=TtyBuffer(tty=output_tty),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 Issue

Refs #63

## 변경 이유

추출된 원문은 사용자의 명시적인 검토 없이 외부 공개물로 전달되면 안 됩니다. 또한
허용 파일에 등록된 경계 식별자가 남아 있는 경우 일반 source 승인과 구분된 추가
승인이 필요합니다.

## 변경 내용

- 작업 요청에 목표·결과물·완료 조건이 있다는 y/N 확인을 추가했습니다.
- 직접 선택한 함수·클래스만 source 후보로 사용합니다.
- source 전체 preview와 조각별 기본 No 승인을 구현했습니다.
- 4000줄·256 KiB 초과 조각은 자르지 않고 건너뜁니다.
- parse 실패 후보가 다른 정상 후보를 막지 않도록 했습니다.
- class가 포함한 method 원문과 boundary alias를 중복 없이 처리합니다.
- boundary-linked source에 정확한 EXPOSE 승인을 추가했습니다.

## 검증

- [x] 전체 unittest 116개 통과, 환경 의존 5개 skip
- [x] Ruff lint와 format check 통과
- [x] mypy strict 통과
- [x] 실제 조직·저장소·자격 증명·제한 정보 미포함

## 제외 범위와 남은 제한

- v0.2 Markdown renderer는 후속 Issue로 분리합니다.
- paired output과 WRITE 후 source 재검증은 후속 Issue로 분리합니다.
- 자동 비밀정보 탐지와 마스킹을 제공하지 않습니다.
