### PR TITLE
feat(renderer): render v0.2 source companions

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -191,15 +191,15 @@ def _brief_input(
             if choices.symbols
             else ()
         ),
-        public_dependencies=_public_dependencies(index, node_ids)
-        if choices.public_libraries
-        else (),
+        public_imports=_public_imports(index, node_ids) if choices.public_libraries else (),
         human_notes=_human_notes(notes, paths) if choices.human_notes else (),
         boundaries=_boundaries(index, node_ids) if choices.boundary_placeholders else (),
+        source_companion=None,
+        source_excerpts=(),
     )
 
 
-def _public_dependencies(index: IndexData, node_ids: set[str]) -> tuple[str, ...]:
+def _public_imports(index: IndexData, node_ids: set[str]) -> tuple[str, ...]:
     return tuple(
         edge.target
         for edge in index.edges

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -30,7 +30,7 @@ def approve_and_write(
 
     destination = _output_path(root, start, output_text)
     try:
-        output_stream.write(rendered.markdown)
+        output_stream.write(rendered.main_markdown)
         output_stream.write(f"\n{_APPROVAL_PROMPT}")
         output_stream.flush()
         approval = input_stream.readline()
@@ -39,7 +39,7 @@ def approve_and_write(
     if _without_line_ending(approval) != "WRITE":
         raise OutputBlockedError("output was not approved with exact WRITE")
 
-    _write_new_file(destination, rendered.markdown)
+    _write_new_file(destination, rendered.main_markdown)
     return destination
 
 

--- a/src/silobrief/renderer.py
+++ b/src/silobrief/renderer.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Literal
 
 from silobrief.index import NodeKind
+from silobrief.source_excerpts import MAX_SOURCE_LINES, MAX_SOURCE_UTF8_BYTES
+from silobrief.source_review import ApprovedSourceExcerpt
 
 _KIND_ORDER = {"module": 0, "class": 1, "function": 2}
 _WARNING = (
-    "경로 단위 ignore는 허용된 파일 안에 있는 민감한 식별자를 보호하지 못합니다. "
-    "이 산출물은 자동 보안 검사를 통과한 문서가 아니며 이동 전에 사람이 전체 내용을 "
-    "확인해야 합니다."
+    "승인한 source 원문에는 자동으로 분류하지 못한 식별자, 경로, URL, 문자열 또는 "
+    "비밀정보가 포함될 수 있습니다. siloBrief는 보안 검사나 반출 승인을 보장하지 "
+    "않으므로 두 파일 전체를 직접 확인해야 합니다."
 )
 
 
@@ -35,31 +38,37 @@ class BriefInput:
     user_prompt: str
     relative_paths: tuple[str, ...]
     symbols: tuple[ApprovedSymbol, ...]
-    public_dependencies: tuple[str, ...]
+    public_imports: tuple[str, ...]
     human_notes: tuple[str, ...]
     boundaries: tuple[ApprovedBoundary, ...]
+    source_companion: str | None
+    source_excerpts: tuple[ApprovedSourceExcerpt, ...]
 
 
 @dataclass(frozen=True, slots=True)
 class DisclosureManifest:
+    schema_version: Literal[2]
     user_prompt: Literal["included"]
     relative_paths: int
     symbol_names: int
-    public_dependencies: int
+    public_imports: int
     human_notes: int
+    human_notes_content: Literal["user-supplied-unclassified"]
     boundary_aliases: int
-    source_bodies: int
-    comments: int
-    docstrings: int
-    string_literals: int
-    absolute_paths: int
-    git_remotes: int
-    ignored_real_names: int
+    source_companion: str
+    source_excerpts: int
+    source_lines: int
+    source_utf8_bytes: int
+    source_content_mode: Literal["verbatim", "none"]
+    boundary_aliases_exposed_in_source: int
+    renderer_added_absolute_paths: Literal[0]
+    renderer_added_git_remotes: Literal[0]
 
 
 @dataclass(frozen=True, slots=True)
 class RenderedBrief:
-    markdown: str
+    main_markdown: str
+    source_markdown: str | None
     disclosure: DisclosureManifest
 
 
@@ -68,21 +77,25 @@ def render_brief(source: BriefInput) -> RenderedBrief:
     disclosure = _disclosure(approved)
     sections = (
         _section(
-            "경고와 용도",
-            "이 브리프는 공식 문서 조사를 준비하는 보조 자료이며 보안 인증이나 반출 "
-            f"승인이 아닙니다.\n\n{_WARNING}",
+            "경고와 공개 범위",
+            "이 문서는 사용자가 승인한 프로젝트 맥락만 담습니다. 숨긴 구현을 추측하거나 "
+            f"공개 범위를 보안 보장으로 해석하면 안 됩니다.\n\n{_WARNING}",
         ),
-        _section("원래 작업 요청", _quote(approved.user_prompt)),
-        _section("선택한 프로젝트 맥락", _project_context(approved)),
+        _section("작업 요청", _quote(approved.user_prompt)),
+        _section("승인된 프로젝트 맥락", _project_context(approved)),
         _section("사용자 작성 메모", _quoted_list(approved.human_notes)),
-        _section("숨긴 경계", _boundary_list(approved.boundaries)),
-        _section("조사 질문", _research_questions()),
-        _section("추천 검색어", _quoted_list(_search_terms(approved))),
-        _section("외부 AI에 복사할 프롬프트", _copy_prompt(approved)),
+        _section("등록된 경계", _boundary_list(approved.boundaries)),
+        _section("소스 동반 파일", _source_companion_section(approved.source_companion)),
+        _section("외부 AI 응답 계약", _response_contract()),
+        _section("외부 AI에 전달할 요청", _copy_prompt(approved)),
         _section("Disclosure manifest", _manifest_yaml(disclosure)),
-        _section("수동 확인 체크리스트", _manual_checklist()),
+        _section("수동 확인 체크리스트", _manual_checklist(approved.source_companion)),
     )
-    return RenderedBrief(markdown="\n\n".join(sections) + "\n", disclosure=disclosure)
+    return RenderedBrief(
+        main_markdown="\n\n".join(sections) + "\n",
+        source_markdown=_source_markdown(approved.source_excerpts),
+        disclosure=disclosure,
+    )
 
 
 def _prepare(source: BriefInput) -> BriefInput:
@@ -91,12 +104,25 @@ def _prepare(source: BriefInput) -> BriefInput:
     prompt = _text(source.user_prompt, "user prompt")
     paths = tuple(sorted({_relative_path(value) for value in source.relative_paths}))
     symbols = _symbols(source.symbols)
-    dependencies = tuple(
-        sorted({_single_line(value, "public dependency") for value in source.public_dependencies})
+    public_imports = tuple(
+        sorted({_single_line(value, "public import") for value in source.public_imports})
     )
     notes = tuple(_text(value, "human note") for value in source.human_notes)
     boundaries = _boundaries(source.boundaries)
-    return BriefInput(prompt, paths, symbols, dependencies, notes, boundaries)
+    excerpts = _source_excerpts(source.source_excerpts)
+    companion = _source_companion(source.source_companion)
+    if bool(excerpts) != (companion is not None):
+        raise RenderError("source companion and source excerpts must be provided together")
+    return BriefInput(
+        prompt,
+        paths,
+        symbols,
+        public_imports,
+        notes,
+        boundaries,
+        companion,
+        excerpts,
+    )
 
 
 def _symbols(values: tuple[ApprovedSymbol, ...]) -> tuple[ApprovedSymbol, ...]:
@@ -122,6 +148,98 @@ def _boundaries(values: tuple[ApprovedBoundary, ...]) -> tuple[ApprovedBoundary,
             raise RenderError("boundary alias has conflicting descriptions")
         result[boundary.alias] = boundary
     return tuple(sorted(result.values(), key=lambda item: (item.alias, item.description)))
+
+
+def _source_excerpts(
+    values: tuple[ApprovedSourceExcerpt, ...],
+) -> tuple[ApprovedSourceExcerpt, ...]:
+    result: dict[tuple[str, int, int, str, str], ApprovedSourceExcerpt] = {}
+    for value in values:
+        if type(value) is not ApprovedSourceExcerpt or value.kind not in {"class", "function"}:
+            raise RenderError("source excerpt value is invalid")
+        path = _relative_path(value.path)
+        name = _single_line(value.qualified_name, "source qualified name")
+        if value.start_line < 1 or value.end_line < value.start_line:
+            raise RenderError("source span is invalid")
+        content = _source_content(value.content)
+        line_count = content.count("\n") + (0 if content.endswith("\n") else 1)
+        if line_count != value.end_line - value.start_line + 1:
+            raise RenderError("source span does not match source content")
+        aliases = tuple(
+            sorted({_single_line(alias, "boundary alias") for alias in value.boundary_aliases})
+        )
+        excerpt = ApprovedSourceExcerpt(
+            path,
+            value.kind,
+            name,
+            value.start_line,
+            value.end_line,
+            content,
+            aliases,
+        )
+        key = (path, value.start_line, value.end_line, value.kind, name)
+        existing = result.get(key)
+        if existing is not None and existing != excerpt:
+            raise RenderError("source excerpt has conflicting content")
+        result[key] = excerpt
+
+    ordered = tuple(
+        sorted(
+            result.values(),
+            key=lambda item: (
+                item.path,
+                item.start_line,
+                item.end_line,
+                item.qualified_name,
+            ),
+        )
+    )
+    _validate_source_totals(ordered)
+    _validate_source_overlaps(ordered)
+    return ordered
+
+
+def _source_content(value: object) -> str:
+    if not isinstance(value, str) or not value or "\r" in value:
+        raise RenderError("source content must be non-empty LF text")
+    try:
+        value.encode("utf-8")
+    except UnicodeError as error:
+        raise RenderError("source content must be valid UTF-8 text") from error
+    return value
+
+
+def _validate_source_totals(values: tuple[ApprovedSourceExcerpt, ...]) -> None:
+    lines = sum(value.line_count for value in values)
+    utf8_bytes = sum(value.utf8_bytes for value in values)
+    if lines > MAX_SOURCE_LINES or utf8_bytes > MAX_SOURCE_UTF8_BYTES:
+        raise RenderError("source excerpts exceed the disclosure limit")
+
+
+def _validate_source_overlaps(values: tuple[ApprovedSourceExcerpt, ...]) -> None:
+    previous: ApprovedSourceExcerpt | None = None
+    for value in values:
+        if (
+            previous is not None
+            and value.path == previous.path
+            and value.start_line <= previous.end_line
+        ):
+            raise RenderError("source excerpts overlap")
+        previous = value
+
+
+def _source_companion(value: object) -> str | None:
+    if value is None:
+        return None
+    name = _single_line(value, "source companion")
+    if (
+        "/" in name
+        or "\\" in name
+        or PurePosixPath(name).name != name
+        or not name.endswith(".sources.md")
+    ):
+        raise RenderError("source companion must be a .sources.md file name")
+    return name
 
 
 def _text(value: object, label: str) -> str:
@@ -157,20 +275,24 @@ def _relative_path(value: object) -> str:
 
 
 def _disclosure(source: BriefInput) -> DisclosureManifest:
+    aliases = {alias for excerpt in source.source_excerpts for alias in excerpt.boundary_aliases}
     return DisclosureManifest(
+        schema_version=2,
         user_prompt="included",
         relative_paths=len(source.relative_paths),
         symbol_names=len(source.symbols),
-        public_dependencies=len(source.public_dependencies),
+        public_imports=len(source.public_imports),
         human_notes=len(source.human_notes),
+        human_notes_content="user-supplied-unclassified",
         boundary_aliases=len(source.boundaries),
-        source_bodies=0,
-        comments=0,
-        docstrings=0,
-        string_literals=0,
-        absolute_paths=0,
-        git_remotes=0,
-        ignored_real_names=0,
+        source_companion=source.source_companion or "none",
+        source_excerpts=len(source.source_excerpts),
+        source_lines=sum(value.line_count for value in source.source_excerpts),
+        source_utf8_bytes=sum(value.utf8_bytes for value in source.source_excerpts),
+        source_content_mode="verbatim" if source.source_excerpts else "none",
+        boundary_aliases_exposed_in_source=len(aliases),
+        renderer_added_absolute_paths=0,
+        renderer_added_git_remotes=0,
     )
 
 
@@ -198,7 +320,7 @@ def _project_context(source: BriefInput) -> str:
         (
             f"### 상대 경로\n\n{_quoted_list(source.relative_paths)}",
             f"### 심볼\n\n{_quoted_list(symbols)}",
-            f"### 공개 라이브러리\n\n{_quoted_list(source.public_dependencies)}",
+            f"### 공개 import\n\n{_quoted_list(source.public_imports)}",
         )
     )
 
@@ -213,57 +335,58 @@ def _boundary_list(values: tuple[ApprovedBoundary, ...]) -> str:
     return "\n".join(lines)
 
 
-def _research_questions() -> str:
+def _source_companion_section(value: str | None) -> str:
+    if value is None:
+        return "- 없음"
+    return (
+        f"- 파일: {_code_span(value)}\n"
+        "- main brief와 이 파일을 함께 전달해야 합니다.\n"
+        "- 파일이 누락되면 숨은 코드를 추측하지 말고 누락 사실을 알려야 합니다."
+    )
+
+
+def _response_contract() -> str:
     return "\n".join(
         (
-            "1. 원래 작업 요청을 해결하려면 어떤 공식 문서 항목을 확인해야 하는가?",
-            "2. 선택한 프로젝트 맥락에 적용되는 공개 API와 제약은 무엇인가?",
-            "3. 답변의 근거가 되는 공식 문서 URL과 적용 조건은 무엇인가?",
+            "1. 긴 서론 없이 적용할 변경부터 제시합니다.",
+            "2. 첫 8개 비어 있지 않은 줄 안에 대상 파일과 변경 목적을 표시합니다.",
+            "3. 제공된 코드와 공개 맥락만 근거로 patch 또는 교체 코드를 작성합니다.",
+            "4. 숨긴 프로젝트 구조·필드·함수·호출 방식을 추측하지 않습니다.",
+            "5. 변경 동작을 검증하는 테스트를 함께 제시합니다.",
+            "6. 실제 실행하지 않은 테스트를 실행했다고 표현하지 않습니다.",
+            "7. 추가 확인은 최대 2개만 적습니다.",
+            "8. 외부 API 주장은 가능한 경우 버전 고정 공식 문서를 근거로 합니다.",
+            "9. 별도 요구가 없으면 비어 있지 않은 줄 80개 이내로 답합니다.",
+            "",
+            "권장 응답 제목:",
+            "",
+            "```text",
+            "## 바로 적용할 변경",
+            "## 패치 또는 교체 코드",
+            "## 테스트",
+            "## 확인 필요",
+            "```",
         )
     )
-
-
-def _search_terms(source: BriefInput) -> tuple[str, ...]:
-    seeds = (
-        source.user_prompt,
-        *source.relative_paths,
-        *(item.name for item in source.symbols),
-        *source.public_dependencies,
-    )
-    result: list[str] = []
-    seen: set[str] = set()
-    for seed in seeds:
-        term = f"{' '.join(seed.split())} official documentation"
-        if term not in seen:
-            seen.add(term)
-            result.append(term)
-    return tuple(result)
 
 
 def _copy_prompt(source: BriefInput) -> str:
-    symbols = tuple(f"{item.kind}: {item.name}" for item in source.symbols)
-    boundaries = tuple(f"{item.alias}: {item.description}" for item in source.boundaries)
+    companion = source.source_companion or "제공된 source companion 없음"
+    delivery = "두 Markdown 파일" if source.source_companion is not None else "이 Markdown 파일"
     text = "\n".join(
         (
-            "공식 문서만 사용해 아래 작업을 조사하세요.",
+            "아래 작업을 공개된 프로젝트 맥락과 source만 사용해 수행하세요.",
             "작업 요청:",
             source.user_prompt,
-            f"상대 경로: {_joined(source.relative_paths)}",
-            f"심볼: {_joined(symbols)}",
-            f"공개 라이브러리: {_joined(source.public_dependencies)}",
-            f"사용자 작성 메모: {_joined(source.human_notes)}",
-            f"숨긴 경계: {_joined(boundaries)}",
-            "확인하지 못한 내용은 추측하지 말고 공식 문서 URL을 제시하세요.",
+            f"source companion: {companion}",
+            "숨긴 구현을 추측하지 말고 위 응답 계약을 지키세요.",
+            "외부 API 사실은 가능한 경우 버전이 고정된 공식 문서 URL로 뒷받침하세요.",
         )
     )
     return (
-        "이 템플릿은 사용자가 선택적으로 복사하는 용도이며 siloBrief는 외부 AI를 "
-        f"호출하거나 전송하지 않습니다.\n\n{_quote(text)}"
+        f"이 요청은 사용자가 {delivery}과 함께 복사하는 용도입니다. siloBrief는 "
+        f"외부 AI를 호출하거나 전송하지 않습니다.\n\n{_quote(text)}"
     )
-
-
-def _joined(values: tuple[str, ...]) -> str:
-    return " | ".join(" ".join(value.split()) for value in values) or "제공된 항목 없음"
 
 
 def _manifest_yaml(value: DisclosureManifest) -> str:
@@ -271,31 +394,92 @@ def _manifest_yaml(value: DisclosureManifest) -> str:
         (
             "```yaml",
             "disclosure:",
+            f"  schema_version: {value.schema_version}",
             f"  user_prompt: {value.user_prompt}",
             f"  relative_paths: {value.relative_paths}",
             f"  symbol_names: {value.symbol_names}",
-            f"  public_dependencies: {value.public_dependencies}",
+            f"  public_imports: {value.public_imports}",
             f"  human_notes: {value.human_notes}",
+            f"  human_notes_content: {value.human_notes_content}",
             f"  boundary_aliases: {value.boundary_aliases}",
-            f"  source_bodies: {value.source_bodies}",
-            f"  comments: {value.comments}",
-            f"  docstrings: {value.docstrings}",
-            f"  string_literals: {value.string_literals}",
-            f"  absolute_paths: {value.absolute_paths}",
-            f"  git_remotes: {value.git_remotes}",
-            f"  ignored_real_names: {value.ignored_real_names}",
+            f"  source_companion: {_yaml_text(value.source_companion)}",
+            f"  source_excerpts: {value.source_excerpts}",
+            f"  source_lines: {value.source_lines}",
+            f"  source_utf8_bytes: {value.source_utf8_bytes}",
+            f"  source_content_mode: {value.source_content_mode}",
+            f"  boundary_aliases_exposed_in_source: {value.boundary_aliases_exposed_in_source}",
+            f"  renderer_added_absolute_paths: {value.renderer_added_absolute_paths}",
+            f"  renderer_added_git_remotes: {value.renderer_added_git_remotes}",
             "```",
         )
     )
 
 
-def _manual_checklist() -> str:
+def _manual_checklist(companion: str | None) -> str:
+    companion_item = (
+        "- [ ] main과 source companion을 함께 전달했습니다."
+        if companion is not None
+        else "- [ ] source companion이 없는 실행임을 확인했습니다."
+    )
     return "\n".join(
         (
-            "- [ ] 원래 작업 요청이 외부에 공개 가능한지 확인했습니다.",
-            "- [ ] 선택한 경로·심볼·메모·경계 설명을 모두 확인했습니다.",
-            "- [ ] 숨겨야 할 실제 이름이나 민감한 식별자가 없는지 확인했습니다.",
-            "- [ ] 조사 결과가 공식 문서에 근거하는지 직접 확인할 예정입니다.",
-            "- [ ] 이동 또는 공유 전에 이 Markdown 전체를 다시 검토합니다.",
+            "- [ ] 작업 요청이 외부에 공개 가능한지 확인했습니다.",
+            "- [ ] 승인한 경로·심볼·메모·경계 설명을 확인했습니다.",
+            companion_item,
+            "- [ ] source 원문에 의도하지 않은 정보가 없는지 확인했습니다.",
+            "- [ ] 외부 AI가 공개되지 않은 구현을 추측하지 않았는지 확인할 예정입니다.",
         )
     )
+
+
+def _source_markdown(values: tuple[ApprovedSourceExcerpt, ...]) -> str | None:
+    if not values:
+        return None
+    parts = [
+        "# Approved source excerpts",
+        "",
+        "이 파일에는 사용자가 외부 공개를 승인한 원문 코드가 포함되어 있습니다. "
+        "주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오.",
+    ]
+    for value in values:
+        aliases = ", ".join(value.boundary_aliases) or "none"
+        parts.extend(
+            (
+                "",
+                f"## {_code_span(value.path)} — "
+                f"{_code_span(f'{value.kind} {value.qualified_name}')} — "
+                f"lines {value.start_line}-{value.end_line}",
+                "",
+                f"Boundary exposure approval: {aliases}",
+                "",
+                _python_fence(value.content),
+            )
+        )
+    return "\n".join(parts) + "\n"
+
+
+def _python_fence(content: str) -> str:
+    fence = "`" * max(3, _longest_backtick_run(content) + 1)
+    separator = "" if content.endswith("\n") else "\n"
+    return f"{fence}python\n{content}{separator}{fence}"
+
+
+def _code_span(value: str) -> str:
+    fence = "`" * max(1, _longest_backtick_run(value) + 1)
+    return f"{fence}{value}{fence}"
+
+
+def _longest_backtick_run(value: str) -> int:
+    longest = 0
+    current = 0
+    for character in value:
+        if character == "`":
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _yaml_text(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -97,7 +97,7 @@ def disclosure_counts(rendered: RenderedBrief) -> tuple[int, int, int, int, int]
     return (
         value.relative_paths,
         value.symbol_names,
-        value.public_dependencies,
+        value.public_imports,
         value.human_notes,
         value.boundary_aliases,
     )
@@ -130,7 +130,7 @@ class ChatReviewTests(unittest.TestCase):
             "Keep the retry policy public|transport|Public transport adapter"
         )
         for approved in approved_values.split("|"):
-            self.assertIn(approved, rendered.markdown)
+            self.assertIn(approved, rendered.main_markdown)
 
         visible = output.getvalue()
         self.assertIn("src/service.py", visible)
@@ -142,7 +142,7 @@ class ChatReviewTests(unittest.TestCase):
             "second-hop-canary|unselected-note-canary|root-id"
         )
         for hidden in hidden_values.split("|"):
-            self.assertNotIn(hidden, visible + rendered.markdown)
+            self.assertNotIn(hidden, visible + rendered.main_markdown)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
         rendered = review_brief(
@@ -154,7 +154,7 @@ class ChatReviewTests(unittest.TestCase):
         )
 
         self.assertEqual(disclosure_counts(rendered), (0, 0, 0, 0, 0))
-        self.assertEqual(rendered.markdown.count("- 없음"), 5)
+        self.assertEqual(rendered.main_markdown.count("- 없음"), 6)
 
     def test_rejects_invalid_or_empty_review_input(self) -> None:
         cases = (

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -47,9 +47,11 @@ def rendered_brief() -> RenderedBrief:
             user_prompt="공식 문서를 확인해줘",
             relative_paths=("src/api.py",),
             symbols=(),
-            public_dependencies=("Python",),
+            public_imports=("Python",),
             human_notes=(),
             boundaries=(),
+            source_companion=None,
+            source_excerpts=(),
         )
     )
 
@@ -86,8 +88,8 @@ class ApprovedOutputTests(unittest.TestCase):
 
             destination = project / ".silobrief" / "exports" / "result.md"
             self.assertEqual(result, destination.resolve())
-            self.assertEqual(destination.read_bytes(), rendered.markdown.encode("utf-8"))
-            self.assertTrue(stdout.getvalue().startswith(rendered.markdown))
+            self.assertEqual(destination.read_bytes(), rendered.main_markdown.encode("utf-8"))
+            self.assertTrue(stdout.getvalue().startswith(rendered.main_markdown))
             self.assertIn("exactly WRITE", stdout.getvalue())
             self.assertGreaterEqual(stdout.flush_count, 1)
             self.assertEqual([path.name for path in destination.parent.iterdir()], ["result.md"])

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -22,7 +22,7 @@ FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-f
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
 INDEX_SHA256 = "0b810f442ca84d26de891dd08e2b77ec0c645e1753943bf8643a7f3b4dc4185e"
-BRIEF_SHA256 = "6cfcf9b914dd318f6ae6f1b65f0bef44ac3453a3f7f77d3d61596275ca1ed661"
+BRIEF_SHA256 = "790b1c7af5b9cf083654480c3213014f0a04450671b4e8b290059484e6a9c4c2"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",
     "PUBLIC_COMMENT_CANARY",

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -4,6 +4,7 @@ import unittest
 from dataclasses import FrozenInstanceError
 from typing import cast
 
+from silobrief.python_structure import DefinitionKind
 from silobrief.renderer import (
     ApprovedBoundary,
     ApprovedSymbol,
@@ -12,44 +13,81 @@ from silobrief.renderer import (
     RenderError,
     render_brief,
 )
+from silobrief.source_review import ApprovedSourceExcerpt
 
 SECTION_TITLES = (
-    "경고와 용도",
-    "원래 작업 요청",
-    "선택한 프로젝트 맥락",
+    "경고와 공개 범위",
+    "작업 요청",
+    "승인된 프로젝트 맥락",
     "사용자 작성 메모",
-    "숨긴 경계",
-    "조사 질문",
-    "추천 검색어",
-    "외부 AI에 복사할 프롬프트",
+    "등록된 경계",
+    "소스 동반 파일",
+    "외부 AI 응답 계약",
+    "외부 AI에 전달할 요청",
     "Disclosure manifest",
     "수동 확인 체크리스트",
 )
 
 
+def source_excerpt(**changes: object) -> ApprovedSourceExcerpt:
+    values: dict[str, object] = {
+        "path": "src/api.py",
+        "kind": "function",
+        "qualified_name": "RetryClient.send",
+        "start_line": 10,
+        "end_line": 12,
+        "content": "def send():\n    # PUBLIC_SOURCE_CANARY\n    return '```'\n",
+        "boundary_aliases": ("private-api",),
+    }
+    values.update(changes)
+    return ApprovedSourceExcerpt(
+        path=cast(str, values["path"]),
+        kind=cast(DefinitionKind, values["kind"]),
+        qualified_name=cast(str, values["qualified_name"]),
+        start_line=cast(int, values["start_line"]),
+        end_line=cast(int, values["end_line"]),
+        content=cast(str, values["content"]),
+        boundary_aliases=cast(tuple[str, ...], values["boundary_aliases"]),
+    )
+
+
 def brief_input(**changes: object) -> BriefInput:
     values: dict[str, object] = {
-        "user_prompt": "공식 재시도 동작을 확인해줘",
+        "user_prompt": "재시도 동작을 수정하고 테스트해줘",
         "relative_paths": ("src/api.py",),
         "symbols": (ApprovedSymbol("function", "RetryClient.send"),),
-        "public_dependencies": ("urllib3",),
-        "human_notes": ("Python 3.10을 지원해야 한다",),
+        "public_imports": ("urllib3",),
+        "human_notes": ("Python 3.10과 urllib3 2.7.0을 사용한다",),
         "boundaries": (ApprovedBoundary("private-api", "사내 전송 계층"),),
+        "source_companion": "retry-brief.sources.md",
+        "source_excerpts": (source_excerpt(),),
     }
     values.update(changes)
     return BriefInput(
         user_prompt=cast(str, values["user_prompt"]),
         relative_paths=cast(tuple[str, ...], values["relative_paths"]),
         symbols=cast(tuple[ApprovedSymbol, ...], values["symbols"]),
-        public_dependencies=cast(tuple[str, ...], values["public_dependencies"]),
+        public_imports=cast(tuple[str, ...], values["public_imports"]),
         human_notes=cast(tuple[str, ...], values["human_notes"]),
         boundaries=cast(tuple[ApprovedBoundary, ...], values["boundaries"]),
+        source_companion=cast(str | None, values["source_companion"]),
+        source_excerpts=cast(tuple[ApprovedSourceExcerpt, ...], values["source_excerpts"]),
     )
 
 
 class BriefRendererTests(unittest.TestCase):
-    def test_renders_exact_sections_manifest_and_only_approved_values(self) -> None:
-        source = BriefInput(
+    def test_renders_v2_main_companion_and_manifest_deterministically(self) -> None:
+        first_excerpt = source_excerpt()
+        second_excerpt = source_excerpt(
+            path="src/client.py",
+            qualified_name="RetryClient",
+            kind="class",
+            start_line=2,
+            end_line=3,
+            content="class RetryClient:\n    pass\n",
+            boundary_aliases=(),
+        )
+        source = brief_input(
             user_prompt="재시도 동작 확인\n## 삽입 제목",
             relative_paths=("src/z.py", "src/a.py", "src/z.py"),
             symbols=(
@@ -57,102 +95,87 @@ class BriefRendererTests(unittest.TestCase):
                 ApprovedSymbol("class", "RetryClient"),
                 ApprovedSymbol("function", "send"),
             ),
-            public_dependencies=("urllib3", "Python", "urllib3"),
+            public_imports=("urllib3", "Python", "urllib3"),
             human_notes=("첫 번째 메모", "두 번째 메모\n## 메모 제목"),
             boundaries=(
                 ApprovedBoundary("transport", "전송 구현"),
                 ApprovedBoundary("account", "계정 연동"),
                 ApprovedBoundary("transport", "전송 구현"),
             ),
+            source_excerpts=(first_excerpt, second_excerpt),
         )
 
         rendered = render_brief(source)
         reordered = render_brief(
-            BriefInput(
+            brief_input(
                 user_prompt=source.user_prompt,
                 relative_paths=tuple(reversed(source.relative_paths)),
                 symbols=tuple(reversed(source.symbols)),
-                public_dependencies=tuple(reversed(source.public_dependencies)),
+                public_imports=tuple(reversed(source.public_imports)),
                 human_notes=source.human_notes,
                 boundaries=tuple(reversed(source.boundaries)),
+                source_companion=source.source_companion,
+                source_excerpts=tuple(reversed(source.source_excerpts)),
             )
         )
 
-        headings = tuple(
-            line.removeprefix("## ")
-            for line in rendered.markdown.splitlines()
-            if line.startswith("## ")
-        )
+        headings: list[str] = []
+        in_fence = False
+        for line in rendered.main_markdown.splitlines():
+            if line.startswith("```"):
+                in_fence = not in_fence
+            elif not in_fence and line.startswith("## "):
+                headings.append(line.removeprefix("## "))
         self.assertEqual(rendered, reordered)
-        self.assertEqual(headings, SECTION_TITLES)
-        self.assertTrue(rendered.markdown.endswith("\n"))
-        self.assertNotIn("\r", rendered.markdown)
-        for approved in (
-            "재시도 동작 확인",
-            "src/a.py",
-            "src/z.py",
-            "RetryClient",
-            "send",
-            "Python",
-            "urllib3",
-            "첫 번째 메모",
-            "두 번째 메모",
-            "account",
-            "계정 연동",
-            "transport",
-            "전송 구현",
-        ):
-            self.assertIn(approved, rendered.markdown)
-        self.assertLess(
-            rendered.markdown.index("첫 번째 메모"), rendered.markdown.index("두 번째 메모")
-        )
-        self.assertIn("official documentation", rendered.markdown)
-        self.assertIn("AI를 호출하거나 전송하지 않습니다", rendered.markdown)
-        self.assertIn("사람이 전체 내용을 확인해야 합니다", rendered.markdown)
+        self.assertEqual(tuple(headings), SECTION_TITLES)
+        self.assertTrue(rendered.main_markdown.endswith("\n"))
+        self.assertIsNotNone(rendered.source_markdown)
+        self.assertNotIn("\r", rendered.main_markdown + cast(str, rendered.source_markdown))
+        self.assertNotIn("PUBLIC_SOURCE_CANARY", rendered.main_markdown)
+        self.assertIn("PUBLIC_SOURCE_CANARY", cast(str, rendered.source_markdown))
+        self.assertIn("````python", cast(str, rendered.source_markdown))
+        self.assertNotIn("조사 질문", rendered.main_markdown)
+        self.assertNotIn("추천 검색어", rendered.main_markdown)
+        self.assertIn("공개 import", rendered.main_markdown)
+        self.assertIn("## 바로 적용할 변경", rendered.main_markdown)
+        self.assertNotIn("TASK_ANSWER_CANARY", rendered.main_markdown)
         self.assertEqual(
             rendered.disclosure,
             DisclosureManifest(
+                schema_version=2,
                 user_prompt="included",
                 relative_paths=2,
                 symbol_names=2,
-                public_dependencies=2,
+                public_imports=2,
                 human_notes=2,
+                human_notes_content="user-supplied-unclassified",
                 boundary_aliases=2,
-                source_bodies=0,
-                comments=0,
-                docstrings=0,
-                string_literals=0,
-                absolute_paths=0,
-                git_remotes=0,
-                ignored_real_names=0,
+                source_companion="retry-brief.sources.md",
+                source_excerpts=2,
+                source_lines=5,
+                source_utf8_bytes=sum(
+                    len(item.content.encode("utf-8")) for item in (first_excerpt, second_excerpt)
+                ),
+                source_content_mode="verbatim",
+                boundary_aliases_exposed_in_source=1,
+                renderer_added_absolute_paths=0,
+                renderer_added_git_remotes=0,
             ),
         )
-        self.assertIn("  ignored_real_names: 0", rendered.markdown)
 
-    def test_renders_empty_approved_context_without_inventing_values(self) -> None:
-        rendered = render_brief(
-            BriefInput(
-                user_prompt="공식 문서를 확인해줘",
-                relative_paths=(),
-                symbols=(),
-                public_dependencies=(),
-                human_notes=(),
-                boundaries=(),
-            )
-        )
+    def test_renders_main_only_when_no_source_is_approved(self) -> None:
+        rendered = render_brief(brief_input(source_companion=None, source_excerpts=()))
 
-        self.assertEqual(rendered.markdown.count("- 없음"), 5)
-        self.assertEqual(rendered.disclosure.relative_paths, 0)
-        self.assertEqual(rendered.disclosure.symbol_names, 0)
-        self.assertEqual(rendered.disclosure.public_dependencies, 0)
-        self.assertEqual(rendered.disclosure.human_notes, 0)
-        self.assertEqual(rendered.disclosure.boundary_aliases, 0)
+        self.assertIsNone(rendered.source_markdown)
+        self.assertIn("- 없음", rendered.main_markdown)
+        self.assertIn("이 Markdown 파일과 함께", rendered.main_markdown)
+        self.assertNotIn("두 Markdown 파일과 함께", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.source_companion, "none")
+        self.assertEqual(rendered.disclosure.source_excerpts, 0)
+        self.assertEqual(rendered.disclosure.source_content_mode, "none")
 
     def test_rejects_objects_outside_the_renderer_whitelist(self) -> None:
-        unsafe: object = {
-            "user_prompt": "task",
-            "source_body": "SOURCE_BODY_CANARY",
-        }
+        unsafe: object = {"user_prompt": "task", "source_body": "SOURCE_BODY_CANARY"}
 
         with self.assertRaisesRegex(RenderError, "whitelist"):
             render_brief(cast(BriefInput, unsafe))
@@ -164,23 +187,35 @@ class BriefRendererTests(unittest.TestCase):
         with self.assertRaises(FrozenInstanceError):
             source.user_prompt = "changed"  # type: ignore[misc]
 
-    def test_rejects_empty_fields_and_unsafe_relative_paths(self) -> None:
+    def test_rejects_invalid_fields_source_spans_and_companion_pairs(self) -> None:
         invalid_inputs = (
             (brief_input(user_prompt="  \n"), "user prompt"),
-            (brief_input(relative_paths=("",)), "relative path"),
             (brief_input(relative_paths=("../secret.py",)), "relative path"),
             (brief_input(relative_paths=("C:/secret.py",)), "relative path"),
             (brief_input(relative_paths=("src\\secret.py",)), "relative path"),
             (brief_input(symbols=(ApprovedSymbol("function", "  "),)), "symbol name"),
-            (brief_input(public_dependencies=("",)), "public dependency"),
+            (brief_input(public_imports=("",)), "public import"),
             (brief_input(human_notes=("\n",)), "human note"),
             (
                 brief_input(boundaries=(ApprovedBoundary("", "public description"),)),
                 "boundary alias",
             ),
+            (brief_input(source_companion=None), "source companion"),
+            (brief_input(source_excerpts=()), "source companion"),
+            (brief_input(source_companion="folder/retry.sources.md"), "source companion"),
+            (brief_input(source_companion="retry.md"), "source companion"),
+            (brief_input(source_excerpts=(source_excerpt(path="../secret.py"),)), "relative path"),
+            (brief_input(source_excerpts=(source_excerpt(start_line=0),)), "source span"),
+            (brief_input(source_excerpts=(source_excerpt(end_line=11),)), "source span"),
             (
-                brief_input(boundaries=(ApprovedBoundary("private", "  "),)),
-                "boundary description",
+                brief_input(
+                    source_excerpts=(source_excerpt(content="def send():\r\n    pass\r\n"),)
+                ),
+                "source content",
+            ),
+            (
+                brief_input(source_excerpts=(source_excerpt(boundary_aliases=("bad\nalias",)),)),
+                "boundary alias",
             ),
         )
 


### PR DESCRIPTION
## 관련 Issue

Refs #65

## 변경 이유

v0.1 브리프는 공식 문서 조사 질문 중심이며 승인된 실제 source를 전달할 수 없습니다.
외부 AI가 바로 적용할 변경을 만들 수 있도록 main은 작업·응답 계약 중심으로 줄이고
승인된 원문은 별도 companion에만 기록해야 합니다.

## 변경 내용

- main brief를 v0.2 고정 10개 섹션으로 교체했습니다.
- 조사 질문과 추천 검색어를 제거했습니다.
- 공개 라이브러리 표현을 공개 import로 변경했습니다.
- 승인 source 전용 companion renderer를 추가했습니다.
- source 안의 backtick보다 긴 Python fence를 결정적으로 선택합니다.
- 범용 AI 응답 계약과 disclosure manifest schema 2를 추가했습니다.
- source 없는 기존 chat은 main-only v0.2 brief를 계속 생성합니다.

## 검증

- [x] 전체 unittest 116개 통과, 환경 의존 5개 skip
- [x] Ruff lint와 format check 통과
- [x] mypy strict 통과
- [x] public fixture의 새 결정적 brief SHA-256 고정

## 제외 범위와 남은 제한

- source 승인 UX를 CLI renderer에 연결하는 작업은 후속 Issue로 분리합니다.
- paired output, WRITE 후 source 재검증과 rollback은 후속 Issue로 분리합니다.
- 자동 비밀정보 탐지와 마스킹을 제공하지 않습니다.
