### PR TITLE
feat(output): write reviewed source companion

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -21,6 +21,12 @@ from silobrief.review import (
     candidate_options,
     review_selection,
 )
+from silobrief.source_review import (
+    ApprovedSourceExcerpt,
+    SourceReviewError,
+    review_source_disclosure,
+)
+from silobrief.sources import SourceSnapshot
 from silobrief.state import NotesData
 
 
@@ -38,6 +44,8 @@ def review_brief(
     *,
     input_stream: TextIO,
     output_stream: TextIO,
+    snapshot: SourceSnapshot | None = None,
+    source_companion: str | None = None,
 ) -> RenderedBrief:
     if not prompt.strip():
         raise ChatReviewError("request must not be empty")
@@ -72,8 +80,32 @@ def review_brief(
         selection.selected, selection.expanded, _read_fields(input_stream, output_stream)
     )
 
+    approved_sources: tuple[ApprovedSourceExcerpt, ...] = ()
+    if snapshot is not None:
+        try:
+            approved_sources = review_source_disclosure(
+                index,
+                snapshot,
+                reviewed,
+                input_stream=input_stream,
+                output_stream=output_stream,
+            )
+        except SourceReviewError as error:
+            raise ChatReviewError(str(error)) from error
+    if approved_sources and source_companion is None:
+        raise ChatReviewError("approved source requires a companion file name")
+
     try:
-        return render_brief(_brief_input(prompt, index, notes, reviewed))
+        return render_brief(
+            _brief_input(
+                prompt,
+                index,
+                notes,
+                reviewed,
+                source_companion=source_companion if approved_sources else None,
+                source_excerpts=approved_sources,
+            )
+        )
     except RenderError as error:
         raise ChatReviewError(str(error)) from error
 
@@ -178,6 +210,9 @@ def _brief_input(
     index: IndexData,
     notes: NotesData,
     selection: ReviewSelection,
+    *,
+    source_companion: str | None = None,
+    source_excerpts: tuple[ApprovedSourceExcerpt, ...] = (),
 ) -> BriefInput:
     nodes = (*selection.selected, *selection.expanded)
     node_ids = {node.id for node in nodes}
@@ -194,8 +229,8 @@ def _brief_input(
         public_imports=_public_imports(index, node_ids) if choices.public_libraries else (),
         human_notes=_human_notes(notes, paths) if choices.human_notes else (),
         boundaries=_boundaries(index, node_ids) if choices.boundary_placeholders else (),
-        source_companion=None,
-        source_excerpts=(),
+        source_companion=source_companion,
+        source_excerpts=source_excerpts,
     )
 
 

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -11,7 +11,7 @@ from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
 from silobrief.notes import add_note
-from silobrief.output import OutputBlockedError, approve_and_write
+from silobrief.output import OutputBlockedError, approve_and_write, source_companion_name
 from silobrief.sources import SourceCollectionError
 from silobrief.state import (
     IndexStateError,
@@ -127,7 +127,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         start = Path.cwd()
         try:
             root = find_project_root(start)
-            index, warnings = load_current_index(root)
+            index, snapshot = load_current_index(root)
             notes = load_notes(root)
         except IndexStateError as error:
             print(f"sb: error: {error}", file=sys.stderr)
@@ -141,27 +141,33 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"sb: error: {error}", file=sys.stderr)
             return 4
 
-        for warning in warnings:
+        for warning in snapshot.warnings:
             print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
         try:
+            companion_name = source_companion_name(output_text)
             rendered = review_brief(
                 prompt,
                 index,
                 notes,
                 input_stream=sys.stdin,
                 output_stream=sys.stdout,
+                snapshot=snapshot,
+                source_companion=companion_name,
             )
-            approve_and_write(
+            written = approve_and_write(
                 root,
                 output_text,
                 rendered,
                 start=start,
                 input_stream=sys.stdin,
                 output_stream=sys.stdout,
+                source_snapshot=snapshot,
             )
         except (ChatReviewError, OutputBlockedError) as error:
             print(f"sb: error: {error}", file=sys.stderr)
             return 4
         print(f"\nwrote {output_text}")
+        if written.source is not None:
+            print(f"wrote source companion {written.source.name}")
 
     return 0

--- a/src/silobrief/current_index.py
+++ b/src/silobrief/current_index.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from silobrief.index import IndexData, config_digest
-from silobrief.sources import SourceWarning, snapshot_sources
+from silobrief.sources import SourceSnapshot, snapshot_sources
 from silobrief.state import load_config
 from silobrief.stored_index import load_stored_index
 
@@ -12,7 +12,7 @@ class CurrentIndexError(Exception):
     pass
 
 
-def load_current_index(root: Path) -> tuple[IndexData, tuple[SourceWarning, ...]]:
+def load_current_index(root: Path) -> tuple[IndexData, SourceSnapshot]:
     index = load_stored_index(root)
     if index.stale:
         raise CurrentIndexError("index is stale; run sb init")
@@ -24,4 +24,4 @@ def load_current_index(root: Path) -> tuple[IndexData, tuple[SourceWarning, ...]
     snapshot = snapshot_sources(root, config)
     if index.source_digest != snapshot.digest:
         raise CurrentIndexError("project sources changed; run sb init")
-    return index, snapshot.warnings
+    return index, snapshot

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -1,17 +1,46 @@
 from __future__ import annotations
 
 import os
+import stat
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TextIO
 
 from silobrief.renderer import RenderedBrief
-from silobrief.state import STATE_DIRECTORY
+from silobrief.sources import SourceCollectionError, SourceSnapshot, snapshot_sources
+from silobrief.state import STATE_DIRECTORY, SetupError, load_config
 
-_APPROVAL_PROMPT = "Type exactly WRITE to create the Markdown file: "
+_APPROVAL_PROMPT = "Type exactly WRITE to create the Markdown file(s): "
 
 
 class OutputBlockedError(Exception):
     pass
+
+
+@dataclass(frozen=True, slots=True)
+class WrittenBrief:
+    main: Path
+    source: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class _FileIdentity:
+    device: int
+    inode: int
+
+
+def source_companion_name(output_text: str) -> str:
+    if not isinstance(output_text, str) or not output_text:
+        raise OutputBlockedError("output path must not be empty")
+    if "/" in output_text and "\\" in output_text:
+        raise OutputBlockedError("output path must not mix path separators")
+
+    path = PureWindowsPath(output_text) if "\\" in output_text else PurePosixPath(output_text)
+    if path.suffix != ".md":
+        raise OutputBlockedError("output path must use the .md extension")
+    if path.name.endswith(".sources.md"):
+        raise OutputBlockedError("main output path must not end with .sources.md")
+    return f"{path.name[:-3]}.sources.md"
 
 
 def approve_and_write(
@@ -22,15 +51,28 @@ def approve_and_write(
     start: Path,
     input_stream: TextIO,
     output_stream: TextIO,
-) -> Path:
+    source_snapshot: SourceSnapshot | None = None,
+) -> WrittenBrief:
     if not input_stream.isatty() or not output_stream.isatty():
         raise OutputBlockedError("approval requires interactive input and output")
     if type(rendered) is not RenderedBrief:
         raise OutputBlockedError("output requires a rendered brief")
 
+    companion_name = source_companion_name(output_text)
     destination = _output_path(root, start, output_text)
+    source_destination = (
+        _available_path(destination.with_name(companion_name), root)
+        if rendered.source_markdown is not None
+        else None
+    )
+    _validate_rendered_pair(rendered, companion_name)
+    baseline = source_snapshot if source_snapshot is not None else _snapshot(root)
+
     try:
         output_stream.write(rendered.main_markdown)
+        if rendered.source_markdown is not None:
+            output_stream.write(f"\n--- Source companion: {companion_name} ---\n\n")
+            output_stream.write(rendered.source_markdown)
         output_stream.write(f"\n{_APPROVAL_PROMPT}")
         output_stream.flush()
         approval = input_stream.readline()
@@ -39,8 +81,33 @@ def approve_and_write(
     if _without_line_ending(approval) != "WRITE":
         raise OutputBlockedError("output was not approved with exact WRITE")
 
-    _write_new_file(destination, rendered.main_markdown)
-    return destination
+    current = _snapshot(root)
+    if current.digest != baseline.digest:
+        raise OutputBlockedError("project sources changed during review; run sb init")
+
+    if rendered.source_markdown is None:
+        _write_new_file(destination, rendered.main_markdown)
+        return WrittenBrief(destination, None)
+
+    if source_destination is None:
+        raise OutputBlockedError("source companion destination is missing")
+    source_identity = _write_new_file(source_destination, rendered.source_markdown)
+    try:
+        _write_new_file(destination, rendered.main_markdown)
+    except OutputBlockedError:
+        _remove_created_file(source_destination, source_identity)
+        raise
+    return WrittenBrief(destination, source_destination)
+
+
+def _validate_rendered_pair(rendered: RenderedBrief, companion_name: str) -> None:
+    disclosed = rendered.disclosure.source_companion
+    if rendered.source_markdown is None:
+        if disclosed != "none":
+            raise OutputBlockedError("rendered source disclosure is inconsistent")
+        return
+    if disclosed != companion_name:
+        raise OutputBlockedError("rendered source companion does not match the output path")
 
 
 def _output_path(root: Path, start: Path, output_text: str) -> Path:
@@ -78,12 +145,15 @@ def _output_path(root: Path, start: Path, output_text: str) -> Path:
         raise OutputBlockedError("output path already exists")
 
     parent = _real_parent(candidate.parent)
-    destination = parent / candidate.name
+    return _available_path(parent / candidate.name, resolved_root)
+
+
+def _available_path(destination: Path, root: Path) -> Path:
     if destination.is_symlink():
         raise OutputBlockedError("output path must not be a symbolic link")
     if destination.exists():
         raise OutputBlockedError("output path already exists")
-    _require_allowed_location(destination, resolved_root)
+    _require_allowed_location(destination, root)
     return destination
 
 
@@ -141,23 +211,44 @@ def _without_line_ending(value: str) -> str:
     return value
 
 
-def _write_new_file(path: Path, content: str) -> None:
+def _snapshot(root: Path) -> SourceSnapshot:
+    try:
+        return snapshot_sources(root, load_config(root))
+    except (SetupError, SourceCollectionError) as error:
+        raise OutputBlockedError(f"cannot revalidate project sources: {error}") from error
+
+
+def _write_new_file(path: Path, content: str) -> _FileIdentity:
     try:
         encoded = content.encode("utf-8")
     except UnicodeError as error:
         raise OutputBlockedError("rendered brief is not valid UTF-8 text") from error
 
-    created = False
+    identity: _FileIdentity | None = None
     try:
         with path.open("xb") as stream:
-            created = True
+            metadata = os.fstat(stream.fileno())
+            identity = _FileIdentity(metadata.st_dev, metadata.st_ino)
             stream.write(encoded)
     except FileExistsError as error:
         raise OutputBlockedError("output path already exists") from error
     except OSError as error:
-        if created:
-            try:
-                path.unlink()
-            except OSError:
-                pass
+        if identity is not None:
+            _remove_created_file(path, identity)
         raise OutputBlockedError(f"cannot create output file: {error}") from error
+    if identity is None:
+        raise OutputBlockedError("cannot identify the created output file")
+    return identity
+
+
+def _remove_created_file(path: Path, identity: _FileIdentity) -> None:
+    try:
+        metadata = path.stat(follow_symlinks=False)
+        if (
+            stat.S_ISREG(metadata.st_mode)
+            and metadata.st_dev == identity.device
+            and metadata.st_ino == identity.inode
+        ):
+            path.unlink()
+    except OSError:
+        pass

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -26,8 +26,10 @@ class ScriptedInput:
     def __init__(self, value: str, target: Path, *, tty: bool = True) -> None:
         self._stream = io.StringIO(value)
         self.target = target
+        self.source_target = target.with_name(f"{target.stem}.sources.md")
         self.tty = tty
         self.output_absent_before_write: bool | None = None
+        self.source_output_absent_before_write: bool | None = None
 
     def isatty(self) -> bool:
         return self.tty
@@ -36,6 +38,7 @@ class ScriptedInput:
         value = self._stream.readline(size)
         if value.rstrip("\r\n") == "WRITE":
             self.output_absent_before_write = not self.target.exists()
+            self.source_output_absent_before_write = not self.source_target.exists()
         return value
 
 
@@ -104,7 +107,8 @@ def prepare_project(project: Path) -> Path:
     return service
 
 
-REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\n"
+REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\n"
+NO_SOURCE_REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\nn\n"
 
 
 def run_chat(
@@ -140,14 +144,18 @@ class ChatCommandTests(unittest.TestCase):
             )
 
             destination = project / output
+            source_destination = destination.with_name(f"{destination.stem}.sources.md")
             self.assertEqual(result, 0)
             self.assertIs(input_stream.output_absent_before_write, True)
+            self.assertIs(input_stream.source_output_absent_before_write, True)
             self.assertTrue(destination.is_file())
+            self.assertTrue(source_destination.is_file())
             self.assertEqual(source_bytes(project), before)
             self.assertEqual(stderr, "")
             self.assertIn("Candidates:", stdout)
             self.assertIn("wrote .silobrief/exports/run.md", stdout)
             markdown = destination.read_text(encoding="utf-8")
+            source_markdown = source_destination.read_text(encoding="utf-8")
             for approved in (
                 "package/service.py",
                 "function: run",
@@ -157,13 +165,34 @@ class ChatCommandTests(unittest.TestCase):
                 "External delivery adapter",
             ):
                 self.assertIn(approved, markdown)
+            self.assertIn("def run():", source_markdown)
+            self.assertIn("send()", source_markdown)
             for hidden in (
                 "allowed-source-canary",
                 "private-boundary-canary",
                 "private.secret",
                 str(project),
             ):
-                self.assertNotIn(hidden, stdout + markdown)
+                self.assertNotIn(hidden, stdout + markdown + source_markdown)
+
+    def test_writes_only_the_main_brief_when_source_is_declined(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            output = ".silobrief/exports/context-only.md"
+
+            result, _, _, stderr = run_chat(
+                project,
+                output,
+                NO_SOURCE_REVIEW_INPUT + "WRITE\n",
+            )
+
+            destination = project / output
+            self.assertEqual(result, 0)
+            self.assertEqual(stderr, "")
+            self.assertTrue(destination.is_file())
+            self.assertFalse(destination.with_name("context-only.sources.md").exists())
+            self.assertIn('source_companion: "none"', destination.read_text(encoding="utf-8"))
 
     def test_maps_invalid_input_and_index_state_to_contract_codes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -231,6 +260,7 @@ class ChatCommandTests(unittest.TestCase):
             self.assertEqual(result, 4)
             self.assertIn("exact WRITE", stderr)
             self.assertFalse((project / refused).exists())
+            self.assertFalse((project / ".silobrief/exports/refused.sources.md").exists())
 
             existing = project / ".silobrief/exports/existing.md"
             existing.write_text("keep", encoding="utf-8")

--- a/tests/test_current_index.py
+++ b/tests/test_current_index.py
@@ -89,10 +89,10 @@ class CurrentIndexTests(unittest.TestCase):
                 "snapshot_sources",
                 return_value=replace(snapshot, warnings=(warning,)),
             ):
-                loaded, warnings = load_current_index(project)
+                loaded, current_snapshot = load_current_index(project)
 
             self.assertEqual(loaded, expected)
-            self.assertEqual(warnings, (warning,))
+            self.assertEqual(current_snapshot, replace(snapshot, warnings=(warning,)))
             self.assertEqual(file_state(project), before)
 
     def test_stale_and_config_mismatch_stop_before_source_collection(self) -> None:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -8,11 +8,15 @@ from typing import TextIO, cast
 
 from silobrief.output import (
     OutputBlockedError,
+    WrittenBrief,
     _uses_foreign_windows_path,
     approve_and_write,
+    source_companion_name,
 )
 from silobrief.renderer import BriefInput, RenderedBrief, render_brief
-from silobrief.state import setup_project
+from silobrief.source_review import ApprovedSourceExcerpt
+from silobrief.sources import snapshot_sources
+from silobrief.state import load_config, setup_project
 
 
 class TtyBuffer(io.StringIO):
@@ -41,6 +45,32 @@ class RacingInput:
         return "WRITE\n" if size != 0 else ""
 
 
+class SourceChangingInput:
+    def __init__(self, source: Path) -> None:
+        self.source = source
+
+    def isatty(self) -> bool:
+        return True
+
+    def readline(self, size: int = -1) -> str:
+        self.source.write_text("VALUE = 2\n", encoding="utf-8")
+        return "WRITE\n" if size != 0 else ""
+
+
+class PairTrackingInput:
+    def __init__(self, main: Path, source: Path) -> None:
+        self.main = main
+        self.source = source
+        self.both_absent: bool | None = None
+
+    def isatty(self) -> bool:
+        return True
+
+    def readline(self, size: int = -1) -> str:
+        self.both_absent = not self.main.exists() and not self.source.exists()
+        return "WRITE\n" if size != 0 else ""
+
+
 def rendered_brief() -> RenderedBrief:
     return render_brief(
         BriefInput(
@@ -56,6 +86,30 @@ def rendered_brief() -> RenderedBrief:
     )
 
 
+def rendered_source_brief(companion: str) -> RenderedBrief:
+    excerpt = ApprovedSourceExcerpt(
+        path="src/api.py",
+        kind="function",
+        qualified_name="run",
+        start_line=1,
+        end_line=2,
+        content="def run():\n    return 1\n",
+        boundary_aliases=(),
+    )
+    return render_brief(
+        BriefInput(
+            user_prompt="코드를 수정해줘",
+            relative_paths=("src/api.py",),
+            symbols=(),
+            public_imports=(),
+            human_notes=(),
+            boundaries=(),
+            source_companion=companion,
+            source_excerpts=(excerpt,),
+        )
+    )
+
+
 def project_in(directory: str) -> Path:
     project = Path(directory) / "project"
     project.mkdir()
@@ -64,6 +118,15 @@ def project_in(directory: str) -> Path:
 
 
 class ApprovedOutputTests(unittest.TestCase):
+    def test_derives_source_companion_name_and_rejects_reserved_main_name(self) -> None:
+        self.assertEqual(source_companion_name("brief.md"), "brief.sources.md")
+        self.assertEqual(
+            source_companion_name(".silobrief/exports/retry-brief.md"),
+            "retry-brief.sources.md",
+        )
+        with self.assertRaisesRegex(OutputBlockedError, "sources.md"):
+            source_companion_name("brief.sources.md")
+
     def test_distinguishes_posix_absolute_paths_from_windows_syntax(self) -> None:
         self.assertFalse(_uses_foreign_windows_path("/tmp/brief.md", platform="posix"))
         self.assertTrue(_uses_foreign_windows_path("C:\\temp\\brief.md", platform="posix"))
@@ -87,7 +150,7 @@ class ApprovedOutputTests(unittest.TestCase):
             )
 
             destination = project / ".silobrief" / "exports" / "result.md"
-            self.assertEqual(result, destination.resolve())
+            self.assertEqual(result, WrittenBrief(destination.resolve(), None))
             self.assertEqual(destination.read_bytes(), rendered.main_markdown.encode("utf-8"))
             self.assertTrue(stdout.getvalue().startswith(rendered.main_markdown))
             self.assertIn("exactly WRITE", stdout.getvalue())
@@ -110,8 +173,125 @@ class ApprovedOutputTests(unittest.TestCase):
                 output_stream=TtyBuffer(),
             )
 
-            self.assertEqual(result, destination.resolve())
+            self.assertEqual(result, WrittenBrief(destination.resolve(), None))
             self.assertTrue(destination.is_file())
+
+    def test_previews_and_writes_paired_files_after_one_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            (project / "src").mkdir()
+            (project / "src" / "api.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+            main = project / ".silobrief" / "exports" / "result.md"
+            source = main.with_name("result.sources.md")
+            stdin = PairTrackingInput(main, source)
+            stdout = TtyBuffer()
+
+            result = approve_and_write(
+                project,
+                ".silobrief/exports/result.md",
+                rendered_source_brief("result.sources.md"),
+                start=project,
+                input_stream=cast(TextIO, stdin),
+                output_stream=stdout,
+            )
+
+            self.assertEqual(result, WrittenBrief(main.resolve(), source.resolve()))
+            self.assertIs(stdin.both_absent, True)
+            self.assertIn("코드를 수정해줘", main.read_text(encoding="utf-8"))
+            self.assertIn("def run():", source.read_text(encoding="utf-8"))
+            self.assertIn("Source companion", stdout.getvalue())
+
+    def test_source_change_after_write_approval_blocks_both_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            source_file = project / "service.py"
+            source_file.write_text("VALUE = 1\n", encoding="utf-8")
+            baseline = snapshot_sources(project, load_config(project))
+            main = project / ".silobrief" / "exports" / "changed.md"
+            companion = main.with_name("changed.sources.md")
+
+            with self.assertRaisesRegex(OutputBlockedError, "sources changed"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/changed.md",
+                    rendered_source_brief("changed.sources.md"),
+                    start=project,
+                    source_snapshot=baseline,
+                    input_stream=cast(TextIO, SourceChangingInput(source_file)),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertFalse(main.exists())
+            self.assertFalse(companion.exists())
+
+    def test_main_race_rolls_back_only_created_companion(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            main = project / ".silobrief" / "exports" / "race.md"
+            companion = main.with_name("race.sources.md")
+
+            with self.assertRaisesRegex(OutputBlockedError, "already exists"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/race.md",
+                    rendered_source_brief("race.sources.md"),
+                    start=project,
+                    input_stream=cast(TextIO, RacingInput(main)),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertEqual(main.read_text(encoding="utf-8"), "rival content")
+            self.assertFalse(companion.exists())
+
+    def test_companion_race_preserves_rival_and_does_not_write_main(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            main = project / ".silobrief" / "exports" / "race.md"
+            companion = main.with_name("race.sources.md")
+
+            with self.assertRaisesRegex(OutputBlockedError, "already exists"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/race.md",
+                    rendered_source_brief("race.sources.md"),
+                    start=project,
+                    input_stream=cast(TextIO, RacingInput(companion)),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertFalse(main.exists())
+            self.assertEqual(companion.read_text(encoding="utf-8"), "rival content")
+
+    def test_blocks_existing_or_mismatched_source_companion_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            exports = project / ".silobrief" / "exports"
+            companion = exports / "result.sources.md"
+            companion.write_text("keep", encoding="utf-8")
+
+            with self.assertRaisesRegex(OutputBlockedError, "already exists"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/result.md",
+                    rendered_source_brief("result.sources.md"),
+                    start=project,
+                    input_stream=TtyBuffer("WRITE\n"),
+                    output_stream=TtyBuffer(),
+                )
+            with self.assertRaisesRegex(OutputBlockedError, "does not match"):
+                approve_and_write(
+                    project,
+                    ".silobrief/exports/other.md",
+                    rendered_source_brief("wrong.sources.md"),
+                    start=project,
+                    input_stream=TtyBuffer("WRITE\n"),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertEqual(companion.read_text(encoding="utf-8"), "keep")
+            self.assertFalse((exports / "result.md").exists())
+            self.assertFalse((exports / "other.md").exists())
+            self.assertFalse((exports / "other.sources.md").exists())
 
     def test_requires_both_ttys_and_an_exact_approval(self) -> None:
         cases = (
@@ -195,7 +375,7 @@ class ApprovedOutputTests(unittest.TestCase):
 
             self.assertEqual(destination.read_text(encoding="utf-8"), "rival content")
 
-    def test_rejects_output_and_parent_symbolic_links(self) -> None:
+    def test_rejects_output_parent_and_companion_symbolic_links(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             project = project_in(directory)
             exports = project / ".silobrief" / "exports"
@@ -204,23 +384,29 @@ class ApprovedOutputTests(unittest.TestCase):
             target = outside / "target.md"
             target.write_text("target content", encoding="utf-8")
             output_link = exports / "linked.md"
+            companion_link = exports / "paired.sources.md"
             parent_link = exports / "linked-parent"
             try:
                 output_link.symlink_to(target)
+                companion_link.symlink_to(target)
                 parent_link.symlink_to(outside, target_is_directory=True)
             except OSError as error:
                 self.skipTest(f"symbolic links are unavailable: {error}")
 
-            for output in (
-                ".silobrief/exports/linked.md",
-                ".silobrief/exports/linked-parent/result.md",
+            for output, rendered in (
+                (".silobrief/exports/linked.md", rendered_brief()),
+                (".silobrief/exports/linked-parent/result.md", rendered_brief()),
+                (
+                    ".silobrief/exports/paired.md",
+                    rendered_source_brief("paired.sources.md"),
+                ),
             ):
                 with self.subTest(output=output):
                     with self.assertRaisesRegex(OutputBlockedError, "symbolic link"):
                         approve_and_write(
                             project,
                             output,
-                            rendered_brief(),
+                            rendered,
                             start=project,
                             input_stream=TtyBuffer("WRITE\n"),
                             output_stream=TtyBuffer(),

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -20,19 +20,20 @@ from silobrief.cli import main
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
-REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\nWRITE\n"
+SOURCE_OUTPUT_PATH = ".silobrief/exports/retry-brief.sources.md"
+REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
 INDEX_SHA256 = "0b810f442ca84d26de891dd08e2b77ec0c645e1753943bf8643a7f3b4dc4185e"
-BRIEF_SHA256 = "790b1c7af5b9cf083654480c3213014f0a04450671b4e8b290059484e6a9c4c2"
+BRIEF_SHA256 = "311327ad8e27120d867b7559b33216c6d9deb2ce8c9c160ed6afd763329e39a5"
+SOURCE_BRIEF_SHA256 = "3035173c36872cb7853ec590bc9acb59b69adff63ad23eee446c6b3b86a66d88"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",
     "PUBLIC_COMMENT_CANARY",
     "PUBLIC_DOCSTRING_CANARY",
     "PUBLIC_STRING_CANARY",
 )
-PRIVATE_VALUES = (
+STRICT_PRIVATE_VALUES = (
     "PRIVATE_BOUNDARY_CANARY",
     "private_adapter",
-    "deliver_internal",
 )
 
 
@@ -45,7 +46,9 @@ class ScriptedInput:
     def __init__(self, value: str, target: Path) -> None:
         self._stream = io.StringIO(value)
         self.target = target
+        self.source_target = target.with_name(f"{target.stem}.sources.md")
         self.output_absent_before_write: bool | None = None
+        self.source_output_absent_before_write: bool | None = None
 
     def isatty(self) -> bool:
         return True
@@ -54,6 +57,7 @@ class ScriptedInput:
         value = self._stream.readline(size)
         if value.rstrip("\r\n") == "WRITE":
             self.output_absent_before_write = not self.target.exists()
+            self.source_output_absent_before_write = not self.source_target.exists()
         return value
 
 
@@ -66,8 +70,10 @@ class DemoResult:
     opened_sources: tuple[str, ...]
     index: bytes
     brief: bytes
+    source_brief: bytes
     terminal: str
     output_absent_before_write: bool | None
+    source_output_absent_before_write: bool | None
 
 
 @contextlib.contextmanager
@@ -164,8 +170,10 @@ def run_demo(project: Path) -> DemoResult:
         opened_sources=opened,
         index=(project / ".silobrief/index.json").read_bytes(),
         brief=(project / OUTPUT_PATH).read_bytes(),
+        source_brief=(project / SOURCE_OUTPUT_PATH).read_bytes(),
         terminal=stdout.getvalue() + stderr.getvalue(),
         output_absent_before_write=input_stream.output_absent_before_write,
+        source_output_absent_before_write=input_stream.source_output_absent_before_write,
     )
 
 
@@ -182,10 +190,14 @@ class PublicDemoTests(unittest.TestCase):
         self.assertEqual(second.source_before, second.source_after)
         self.assertIs(first.output_absent_before_write, True)
         self.assertIs(second.output_absent_before_write, True)
+        self.assertIs(first.source_output_absent_before_write, True)
+        self.assertIs(second.source_output_absent_before_write, True)
         self.assertEqual(first.index, second.index)
         self.assertEqual(first.brief, second.brief)
+        self.assertEqual(first.source_brief, second.source_brief)
         self.assertEqual(hashlib.sha256(first.index).hexdigest(), INDEX_SHA256)
         self.assertEqual(hashlib.sha256(first.brief).hexdigest(), BRIEF_SHA256)
+        self.assertEqual(hashlib.sha256(first.source_brief).hexdigest(), SOURCE_BRIEF_SHA256)
         self.assertEqual(
             first.scanned_directories,
             (".", "src", "src/parcel_sync"),
@@ -202,6 +214,7 @@ class PublicDemoTests(unittest.TestCase):
         self.assertEqual(first.opened_sources, second.opened_sources)
 
         brief_text = first.brief.decode("utf-8")
+        source_brief_text = first.source_brief.decode("utf-8")
         for expected in (
             "src/parcel_sync/service.py",
             "function: retry_request",
@@ -211,14 +224,22 @@ class PublicDemoTests(unittest.TestCase):
             "External delivery adapter",
         ):
             self.assertIn(expected, brief_text)
+        self.assertNotIn("PUBLIC_SOURCE_BODY_CANARY", brief_text)
+        self.assertNotIn("PUBLIC_COMMENT_CANARY", brief_text)
+        self.assertIn("PUBLIC_SOURCE_BODY_CANARY", source_brief_text)
+        self.assertIn("PUBLIC_COMMENT_CANARY", source_brief_text)
+        self.assertIn("deliver_internal", source_brief_text)
+        self.assertNotIn("PUBLIC_DOCSTRING_CANARY", source_brief_text)
+        self.assertNotIn("PUBLIC_STRING_CANARY", source_brief_text)
         for result in (first, second):
             index_text = result.index.decode("utf-8")
-            public_output = result.terminal + result.brief.decode("utf-8")
+            main_output = result.brief.decode("utf-8")
+            all_output = result.terminal + main_output + result.source_brief.decode("utf-8")
             for canary in PUBLIC_CANARIES:
-                self.assertNotIn(canary.casefold(), public_output.casefold())
-            for private in PRIVATE_VALUES:
-                self.assertNotIn(private.casefold(), (index_text + public_output).casefold())
-            self.assertNotIn(result.root, index_text + public_output)
+                self.assertNotIn(canary.casefold(), main_output.casefold())
+            for private in STRICT_PRIVATE_VALUES:
+                self.assertNotIn(private.casefold(), (index_text + all_output).casefold())
+            self.assertNotIn(result.root, index_text + all_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

- 승인한 함수·클래스 source를 실제 `sb chat` renderer에 연결했습니다.
- source가 있으면 main과 `.sources.md`를 한 번의 preview 및 `WRITE` 승인으로 생성합니다.
- 승인 뒤 source 변경과 기존·경쟁·symlink 출력 파일을 차단합니다.
- main 생성 실패 시 이 명령이 만든 companion만 되돌립니다.
- source를 승인하지 않으면 기존 main-only 출력을 유지합니다.

## 검증

- `python -m unittest discover`: 123 tests passed, 5 skipped
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy --strict src tests`

Refs #67
