### PR TITLE
feat(setup): warn about source disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Explicit review of selected function and class source excerpts with optional paired
+  `.sources.md` output.
+- Additional `EXPOSE` approval for boundary identifiers visible in approved source.
+
+### Changed
+
+- `sb setup` and the public guides now warn that approved source is copied verbatim and that
+  siloBrief does not detect secrets or provide security approval.
+
 ## [0.1.0] - 2026-08-04
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,11 +2,13 @@
 
 [English](README.md)
 
-siloBrief는 검토한 Python 프로젝트 맥락을 Markdown 조사 브리프 한 파일로 만드는 로컬
-CLI입니다. 소스가 있는 개발 환경과 인터넷 검색 환경이 분리된 상황을 대상으로 합니다.
+siloBrief는 검토한 Python 프로젝트 맥락을 Markdown 브리프로 만들고, 명시적으로 승인한
+경우 선택한 source excerpt를 동반 파일로 만드는 로컬 CLI입니다. 소스가 있는 개발 환경과
+인터넷 검색 환경이 분리된 상황을 대상으로 합니다.
 
 현재 공개 버전은 v0.1.0입니다. 해당 동작은
-[`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md)에 고정되어 있습니다.
+[`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md)에 고정되어 있습니다. `develop` 브랜치는
+[`docs/V0_2_CONTRACT.md`](docs/V0_2_CONTRACT.md)에 따른 v0.2 출시 전 개발 단계입니다.
 
 ## 요구사항과 설치
 
@@ -41,8 +43,11 @@ sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
 sb chat "retry request" --out .silobrief/exports/retry-brief.md
 ```
 
-이 fixture에서는 후보 `1`을 선택하고, 추가·제외 입력은 빈 줄로 끝낸 뒤 다섯 필드 그룹을
-승인합니다. 전체 미리보기를 확인하고 정확히 `WRITE`를 입력해야 Markdown 파일이 생성됩니다.
+이 fixture에서는 먼저 요청을 `y`로 확인하고 후보 `1`을 선택합니다. 추가·제외 입력은 빈
+줄로 끝내고 다섯 맥락 필드를 승인합니다. 이어서 표시되는 함수 원문을 직접 확인한 뒤에만
+`y`를 입력하고, 보이는 경계 식별자는 정확한 `EXPOSE`로 승인합니다. 두 파일의 전체
+미리보기를 확인하고 `WRITE`를 입력하면 `retry-brief.md`와 `retry-brief.sources.md`가
+생성됩니다. source를 거부하면 main 브리프만 생성됩니다.
 
 ## 유용한 입력 작성
 
@@ -51,9 +56,13 @@ sb chat "retry request" --out .silobrief/exports/retry-brief.md
 
 `sb log`에는 코드 구조만으로 알 수 없고 외부 공개를 승인한 맥락만 기록하십시오. 검토하고
 비식별화한 제어 흐름 제약이 한 예입니다. 비공개 source body, 비밀값 또는 무시한 경계의 실제
-이름을 메모에 복사하지 마십시오. 생성 Markdown은 source body를 자동으로 포함하지 않습니다.
-따라서 생략된 코드 세부사항이 필요한 작업에는 브리프만으로 충분하지 않을 수 있습니다.
-파일을 쓰기 전에 전체 미리보기를 항상 확인하십시오.
+이름을 메모에 복사하지 마십시오.
+
+무시하지 않은 Python 파일은 로컬 분석 대상입니다. 직접 선택하고 승인한 함수·클래스 조각만
+원문으로 공개될 수 있으며 source의 기본값은 거부입니다. 원문에는 주석, docstring, 문자열과
+내부 식별자가 포함될 수 있습니다. 경계 참조에는 정확한 `EXPOSE`가 추가로 필요하지만,
+siloBrief는 비밀정보를 탐지하지 않으며 결과의 안전성을 보장하지 않습니다. main과 모든
+`.sources.md` 동반 파일을 공유 전에 직접 확인하십시오.
 
 ## 명령
 
@@ -63,7 +72,7 @@ sb chat "retry request" --out .silobrief/exports/retry-brief.md
 | `sb ignore PATH --as TEXT [--alias NAME]` | 기존 경로를 제외하고 공개용 경계 설명을 등록합니다. |
 | `sb init` | 허용된 Python 파일에서 결정적인 구조 index를 만듭니다. |
 | `sb log PATH --comment TEXT` | 브리프에 포함될 수 있는 사용자 작성 메모를 저장합니다. |
-| `sb chat "PROMPT" --out FILE` | 후보 맥락을 검토하고 승인된 Markdown 한 파일을 만듭니다. |
+| `sb chat "PROMPT" --out FILE` | 검토한 main 브리프와 선택적인 `.sources.md` 동반 파일을 만듭니다. |
 | `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
 
 `setup` 외 명령은 현재 디렉터리에서 프로젝트 루트를 찾습니다. `chat`에는 대화형 터미널,
@@ -80,8 +89,8 @@ sb chat "retry request" --out .silobrief/exports/retry-brief.md
 └─ exports/
 ```
 
-상태 파일은 로컬 구현 데이터이며 외부 전달용 결과가 아닙니다. 생성된 Markdown만 의도한
-산출물이며, 이동하기 전에 사람이 전체 내용을 다시 확인해야 합니다.
+상태 파일은 로컬 구현 데이터이며 외부 전달용 결과가 아닙니다. 생성된 main 브리프와 선택적인
+source 동반 파일만 의도한 산출물이며, 이동하기 전에 사람이 둘 다 전체 확인해야 합니다.
 
 ## 종료 코드
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 [한국어](README.ko.md)
 
-siloBrief is a local command-line tool that turns reviewed Python project context into one
-Markdown research brief. It is intended for development environments where source code and
-internet access are separated.
+siloBrief is a local command-line tool that turns reviewed Python project context into a
+Markdown brief and, when explicitly approved, a companion containing selected source excerpts.
+It is intended for development environments where source code and internet access are separated.
 
 The current release is v0.1.0. Its frozen behavior is documented in
-[`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md).
+[`docs/V0_1_CONTRACT.md`](docs/V0_1_CONTRACT.md). v0.2 pre-release development is on the
+`develop` branch and is governed by [`docs/V0_2_CONTRACT.md`](docs/V0_2_CONTRACT.md).
 
 ## Requirements and installation
 
@@ -41,9 +42,11 @@ sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
 sb chat "retry request" --out .silobrief/exports/retry-brief.md
 ```
 
-For this fixture, select candidate `1`, submit blank add and exclude prompts, approve the five
-field groups, and inspect the complete preview. The Markdown file is created only after you
-type exactly `WRITE`.
+For this fixture, confirm the request with `y`, select candidate `1`, submit blank add and exclude
+prompts, and approve the five context field groups. The selected function is then shown in full.
+Answer `y` only after reviewing it, type `EXPOSE` to approve the visible boundary identifier, and
+inspect both complete previews. Exact `WRITE` creates `retry-brief.md` and
+`retry-brief.sources.md`. Declining the source excerpt creates only the main brief.
 
 ## Writing useful input
 
@@ -53,9 +56,12 @@ and acceptance criteria so the recipient can tell what a useful answer must cont
 Use `sb log` only for context that project structure cannot show. Record only context that you
 have approved for external disclosure, such as a reviewed, de-identified control-flow constraint.
 Do not copy private source bodies, secrets, or real names from ignored boundaries into a note.
-The generated Markdown does not automatically include source bodies, so it may be insufficient
-when a task depends on omitted code details. Always review the complete preview before writing
-the file.
+
+Non-ignored Python files are analyzed locally. Only selected and approved function or class
+excerpts can be exported verbatim; the source default is no. Verbatim source may contain
+comments, docstrings, strings, and internal identifiers. A boundary reference additionally needs
+exact `EXPOSE`, but siloBrief does not detect secrets or certify the result as safe. Review both
+the main file and any `.sources.md` companion before sharing them.
 
 ## Commands
 
@@ -65,7 +71,7 @@ the file.
 | `sb ignore PATH --as TEXT [--alias NAME]` | Excludes an existing path and registers its public boundary description. |
 | `sb init` | Builds a deterministic structure index from allowed Python files. |
 | `sb log PATH --comment TEXT` | Stores a user-authored note that may appear in a brief. |
-| `sb chat "PROMPT" --out FILE` | Reviews ranked context and writes one approved Markdown file. |
+| `sb chat "PROMPT" --out FILE` | Writes a reviewed main brief and optional approved `.sources.md` companion. |
 | `sb --version` | Prints the installed siloBrief version. |
 
 Commands other than `setup` discover the project root from the current directory. `chat`
@@ -82,8 +88,9 @@ the project must be below `.silobrief/exports/`; existing files are never overwr
 └─ exports/
 ```
 
-State files are local implementation data, not transfer-ready output. The generated Markdown
-is the only intended artifact, and it still requires a complete human review before moving it.
+State files are local implementation data, not transfer-ready output. Only the generated main
+brief and optional source companion are intended artifacts, and both still require a complete
+human review before moving them.
 
 ## Exit codes
 

--- a/examples/parcel-sync-fixture/README.md
+++ b/examples/parcel-sync-fixture/README.md
@@ -18,11 +18,16 @@ sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
 sb chat "retry request" --out .silobrief/exports/retry-brief.md
 ```
 
-For the bundled fixture, select candidate `1`, finish both add and exclude prompts with a
-blank line, answer `y` to each of the five disclosure questions, review the complete
-Markdown preview, and type exactly `WRITE` to create the file.
+For the bundled fixture, confirm request completeness with `y`, select candidate `1`, and
+finish both add and exclude prompts with a blank line. Answer `y` to each of the five context
+questions. The complete `retry_request` excerpt is then shown; review it before answering `y`.
+Because that excerpt contains a boundary reference, type exactly `EXPOSE`. Review both full
+Markdown previews and type exactly `WRITE` to create `retry-brief.md` and
+`retry-brief.sources.md`.
 
-The expected brief includes the relative service path, `retry_request`, `urllib3`, the human
-note, and the `delivery-boundary` description. It must not include the adapter's real path,
-symbol, or private canary. This verifies the published technical contract only; it is not a
-security certification or evidence of user demand.
+The main brief includes the relative service path, `retry_request`, `urllib3`, the human note,
+and the `delivery-boundary` description. The companion includes only the approved function
+excerpt, including its visible boundary call after `EXPOSE`. Neither file may include the
+ignored adapter source or private canary. This verifies the published technical contract only;
+it is not a security certification or evidence of user demand. siloBrief does not detect
+secrets in allowed source, so both previews require a human disclosure decision.

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -22,6 +22,13 @@ from silobrief.state import (
 )
 from silobrief.stored_index import StoredIndexError
 
+_SOURCE_DISCLOSURE_WARNING = (
+    "warning: non-ignored Python files are analyzed locally; source excerpts you select and "
+    "approve may be exported verbatim with comments, docstrings, strings, and internal "
+    "identifiers. siloBrief does not detect secrets or provide security approval; review all "
+    "output yourself."
+)
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -62,6 +69,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/")
         else:
             print("validated existing .silobrief state")
+        print(_SOURCE_DISCLOSURE_WARNING)
 
     if arguments.command == "ignore":
         path_text = arguments.path

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -29,7 +29,11 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
         "private source bodies",
         "secrets",
         "real names from ignored boundaries",
-        "does not automatically include source bodies",
+        "selected and approved",
+        "exported verbatim",
+        "does not detect secrets",
+        "EXPOSE",
+        ".sources.md",
     ),
     "README.ko.md": (
         "구체적인 작업",
@@ -39,7 +43,11 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
         "비공개 source body",
         "비밀값",
         "무시한 경계의 실제",
-        "source body를 자동으로 포함하지 않습니다",
+        "선택하고 승인",
+        "원문으로 공개",
+        "비밀정보를 탐지하지",
+        "EXPOSE",
+        ".sources.md",
     ),
 }
 
@@ -68,16 +76,19 @@ class ReleaseDocumentationTests(unittest.TestCase):
 
     def test_v0_1_release_metadata_is_frozen(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-        self.assertIn(f"## [Unreleased]\n\n## [0.1.0] - {RELEASE_DATE}", changelog)
+        self.assertIn("## [Unreleased]", changelog)
+        self.assertIn(f"## [0.1.0] - {RELEASE_DATE}", changelog)
         for fragment in ("### Added", "### Fixed", "### Known limitations", "source bodies"):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn("The current release is v0.1.0.", readme)
-        self.assertNotIn("pre-release development", readme)
+        self.assertIn("v0.2 pre-release development", readme)
+        self.assertIn("docs/V0_2_CONTRACT.md", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
         self.assertIn("현재 공개 버전은 v0.1.0입니다.", readme_ko)
-        self.assertNotIn("출시 전 개발 단계", readme_ko)
+        self.assertIn("v0.2 출시 전 개발 단계", readme_ko)
+        self.assertIn("docs/V0_2_CONTRACT.md", readme_ko)
 
         security = (REPOSITORY_ROOT / "SECURITY.md").read_text(encoding="utf-8")
         self.assertIn("| 0.1.x | :white_check_mark: |", security)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -22,6 +22,12 @@ DEFAULT_EXCLUDES = [
     "build/",
     "dist/",
 ]
+SOURCE_DISCLOSURE_WARNING = (
+    "warning: non-ignored Python files are analyzed locally; source excerpts you select and "
+    "approve may be exported verbatim with comments, docstrings, strings, and internal "
+    "identifiers. siloBrief does not detect secrets or provide security approval; review all "
+    "output yourself.\n"
+)
 
 
 @contextlib.contextmanager
@@ -57,7 +63,8 @@ class SetupCommandTests(unittest.TestCase):
             self.assertEqual(result, 0)
             self.assertEqual(
                 stdout.getvalue(),
-                "created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/\n",
+                "created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/\n"
+                + SOURCE_DISCLOSURE_WARNING,
             )
             self.assertEqual(
                 json.loads((state / "config.json").read_text(encoding="utf-8")),
@@ -122,7 +129,10 @@ class SetupCommandTests(unittest.TestCase):
                 for path in tracked
             ]
             self.assertEqual(result, 0)
-            self.assertEqual(stdout.getvalue(), "validated existing .silobrief state\n")
+            self.assertEqual(
+                stdout.getvalue(),
+                "validated existing .silobrief state\n" + SOURCE_DISCLOSURE_WARNING,
+            )
             self.assertEqual(after, before)
 
     def test_setup_rejects_missing_path_and_regular_file(self) -> None:


### PR DESCRIPTION
## 요약

- `sb setup` 생성·재검증 메시지에 비무시 source와 원문 공개 경고를 추가했습니다.
- 영문·한국어 README와 public fixture 안내를 실제 v0.2 승인 순서에 맞췄습니다.
- source 기본 거부, `EXPOSE`, paired output과 비보장 범위를 문서화했습니다.
- Unreleased changelog에 현재 v0.2 source workflow를 기록했습니다.

## 검증

- 전체 unittest 123개 통과, 5개 skip
- Ruff lint·format 통과
- mypy strict 통과

Refs #69
