### PR TITLE
test(validation): freeze three model tasks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,5 @@ include README.ko.md
 include SECURITY.md
 recursive-include docs *.md
 recursive-include examples/parcel-sync-fixture *.md *.py
+recursive-include examples/model-validation-fixture *.md *.py
+recursive-include validation/v0.2 *.md

--- a/examples/model-validation-fixture/README.md
+++ b/examples/model-validation-fixture/README.md
@@ -1,0 +1,10 @@
+# model validation fixture
+
+This synthetic project supports the frozen siloBrief v0.2 manual model gate. It contains no
+real organization, repository, credential, or operational data. The three tasks cover a small
+modification, addition, and removal. Do not edit this fixture or its task prompts after model
+testing begins.
+
+`private_adapter/` is an ignored boundary. Its source and canary must never appear in an index
+or generated packet. Allowed modules may be analyzed locally, but only excerpts explicitly
+approved during `sb chat` may be copied into a source companion.

--- a/examples/model-validation-fixture/private_adapter/__init__.py
+++ b/examples/model-validation-fixture/private_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Ignored synthetic boundary."""

--- a/examples/model-validation-fixture/private_adapter/client.py
+++ b/examples/model-validation-fixture/private_adapter/client.py
@@ -1,0 +1,5 @@
+PRIVATE_MODEL_GATE_CANARY = "ignored-adapter-source"
+
+
+def deliver_internal(parcel: object, retry_policy: object) -> None:
+    del parcel, retry_policy

--- a/examples/model-validation-fixture/src/parcel_lab/__init__.py
+++ b/examples/model-validation-fixture/src/parcel_lab/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic parcel maintenance examples."""

--- a/examples/model-validation-fixture/src/parcel_lab/cleanup.py
+++ b/examples/model-validation-fixture/src/parcel_lab/cleanup.py
@@ -1,0 +1,11 @@
+"""Synthetic compatibility example. VALIDATION_MODULE_CANARY_CLEANUP."""
+
+from __future__ import annotations
+
+
+def choose_reference(primary: str | None, legacy: str | None) -> str:
+    if primary is not None and primary.strip():
+        return primary.strip()
+    if legacy is not None and legacy.strip():
+        return legacy.strip()
+    raise ValueError("a tracking reference is required")

--- a/examples/model-validation-fixture/src/parcel_lab/labels.py
+++ b/examples/model-validation-fixture/src/parcel_lab/labels.py
@@ -1,0 +1,16 @@
+"""Synthetic label example. VALIDATION_MODULE_CANARY_LABELS."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LabelOptions:
+    prefix: str
+    uppercase: bool = False
+
+
+def format_label(reference: str, options: LabelOptions) -> str:
+    label = f"{options.prefix}{reference}"
+    return label.upper() if options.uppercase else label

--- a/examples/model-validation-fixture/src/parcel_lab/models.py
+++ b/examples/model-validation-fixture/src/parcel_lab/models.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Parcel:
+    reference: str

--- a/examples/model-validation-fixture/src/parcel_lab/retry.py
+++ b/examples/model-validation-fixture/src/parcel_lab/retry.py
@@ -1,0 +1,14 @@
+"""Synthetic retry example. VALIDATION_MODULE_CANARY_RETRY."""
+
+from __future__ import annotations
+
+import urllib3
+from private_adapter.client import deliver_internal
+
+from parcel_lab.models import Parcel
+
+
+def retry_request(parcel: Parcel) -> object:
+    retry_policy = urllib3.Retry(total=2)
+    deliver_internal(parcel, retry_policy)
+    return retry_policy

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+from silobrief.cli import main
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPOSITORY_ROOT / "examples" / "model-validation-fixture"
+PACKET_ROOT = REPOSITORY_ROOT / "validation" / "v0.2" / "packets"
+GUIDE = REPOSITORY_ROOT / "validation" / "v0.2" / "MANUAL_MODEL_GATE.md"
+PRIVATE_VALUES = ("PRIVATE_MODEL_GATE_CANARY", "ignored-adapter-source", "private_adapter")
+MODULE_CANARIES = (
+    "VALIDATION_MODULE_CANARY_RETRY",
+    "VALIDATION_MODULE_CANARY_LABELS",
+    "VALIDATION_MODULE_CANARY_CLEANUP",
+)
+FORBIDDEN_SOLUTION_SNIPPETS = (
+    b"status_forcelist=[503]",
+    b"status_forcelist = [503]",
+    b"separator: str =",
+    b"def choose_reference(primary: str) -> str",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Task:
+    id: str
+    output_stem: str
+    prompt: str
+    review_input: str
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedPacket:
+    task: Task
+    main: bytes
+    source: bytes
+    index: bytes
+    source_before: tuple[tuple[str, str], ...]
+    source_after: tuple[tuple[str, str], ...]
+
+
+TASKS = (
+    Task(
+        "T01-MODIFY",
+        "t01-modify",
+        "Update the retry policy in src/parcel_lab/retry.py so status-code retries apply to "
+        "HTTP 503 and not HTTP 500. Keep total=2 and preserve the delivery boundary call order. "
+        "Return a minimal patch and focused unittest. Do not claim you ran tests.",
+        "y\n2\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n",
+    ),
+    Task(
+        "T02-ADD",
+        "t02-add",
+        "Add an optional separator: str setting to LabelOptions. Existing callers that omit it "
+        "must keep current output. When both prefix and separator are non-empty, place the "
+        "separator between prefix and reference. Preserve uppercase behavior. Return a minimal "
+        "patch and focused unittests.",
+        "y\n1 2\n\n\ny\ny\ny\ny\ny\ny\ny\nWRITE\n",
+    ),
+    Task(
+        "T03-REMOVE",
+        "t03-remove",
+        "Remove the legacy fallback from choose_reference. The function must accept only primary, "
+        "return its stripped value, and raise ValueError when it is blank. Return a minimal patch "
+        "and focused unittests. State the interface impact without inventing call sites.",
+        "y\n1\n\n\ny\ny\ny\ny\ny\ny\nWRITE\n",
+    ),
+)
+
+PACKET_SHA256 = {
+    "T01-MODIFY": (
+        "0ef829e88a240c29ec62b0281015abec48b6f1b7476ada412059cdfef140dd30",
+        "26e81597f2edd4c65f226ddafc4a291e595e5fb75f5a133d5136ca94d106e698",
+    ),
+    "T02-ADD": (
+        "55bee4ae3e5e34f3570c908d88227d8c181b497db916def96669552b6826c744",
+        "7deb0e384fbf625f295ade605d6cb1da2d2bc4a9c68ebe83c6fb4e46b4ed6574",
+    ),
+    "T03-REMOVE": (
+        "75fb9d63c0023a3afee3132b2740b308db9ed5cf68cea5087ea890630acb83ce",
+        "4ad9d025d2027cc569499a0d42cbdaf6b0b650c5cc6cce09c0bbe74c0aa9c597",
+    ),
+}
+
+
+class TtyBuffer(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def source_manifest(project: Path) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (path.relative_to(project).as_posix(), hashlib.sha256(path.read_bytes()).hexdigest())
+        for path in sorted(project.rglob("*"))
+        if path.is_file() and ".silobrief" not in path.parts
+    )
+
+
+def generate_packets(destination_root: Path) -> tuple[GeneratedPacket, ...]:
+    with tempfile.TemporaryDirectory() as directory:
+        project = Path(directory) / "fixture"
+        shutil.copytree(FIXTURE_ROOT, project)
+        terminal = TtyBuffer()
+        with contextlib.redirect_stdout(terminal), contextlib.redirect_stderr(terminal):
+            if main(["setup", str(project)]) != 0:
+                raise AssertionError("fixture setup failed")
+            with working_directory(project):
+                results = (
+                    main(
+                        [
+                            "ignore",
+                            "private_adapter",
+                            "--as",
+                            "External delivery adapter",
+                            "--alias",
+                            "delivery-boundary",
+                        ]
+                    ),
+                    main(["init"]),
+                    main(
+                        [
+                            "log",
+                            "src/parcel_lab/retry.py",
+                            "--comment",
+                            "urllib3 version is 2.7.0.",
+                        ]
+                    ),
+                )
+        if results != (0, 0, 0):
+            raise AssertionError(f"fixture preparation failed: {results}")
+
+        before = source_manifest(project)
+        generated: list[GeneratedPacket] = []
+        for task in TASKS:
+            task_root = destination_root / task.id
+            task_root.mkdir(parents=True, exist_ok=True)
+            main_path = (task_root / f"{task.output_stem}.md").resolve()
+            source_path = main_path.with_name(f"{task.output_stem}.sources.md")
+            stdin = TtyBuffer(task.review_input)
+            stdout = TtyBuffer()
+            stderr = io.StringIO()
+            with (
+                working_directory(project),
+                mock.patch.object(sys, "stdin", stdin),
+                contextlib.redirect_stdout(stdout),
+                contextlib.redirect_stderr(stderr),
+                mock.patch(
+                    "socket.create_connection",
+                    side_effect=AssertionError("network access is forbidden"),
+                ),
+                mock.patch(
+                    "socket.socket.connect",
+                    side_effect=AssertionError("network access is forbidden"),
+                ),
+            ):
+                result = main(["chat", task.prompt, "--out", str(main_path)])
+            if result != 0 or stderr.getvalue():
+                raise AssertionError(f"{task.id} generation failed: {stderr.getvalue()}")
+            generated.append(
+                GeneratedPacket(
+                    task,
+                    main_path.read_bytes(),
+                    source_path.read_bytes(),
+                    (project / ".silobrief" / "index.json").read_bytes(),
+                    before,
+                    source_manifest(project),
+                )
+            )
+        return tuple(generated)
+
+
+class ModelValidationTests(unittest.TestCase):
+    def test_frozen_packets_match_current_cli_and_preserve_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as first_directory:
+            first = generate_packets(Path(first_directory))
+        with tempfile.TemporaryDirectory() as second_directory:
+            second = generate_packets(Path(second_directory))
+
+        self.assertEqual(first, second)
+        for packet in first:
+            with self.subTest(task=packet.task.id):
+                committed = PACKET_ROOT / packet.task.id
+                main = (committed / f"{packet.task.output_stem}.md").read_bytes()
+                source = (committed / f"{packet.task.output_stem}.sources.md").read_bytes()
+                self.assertEqual(packet.main, main)
+                self.assertEqual(packet.source, source)
+                self.assertEqual(packet.source_before, packet.source_after)
+                self.assertEqual(
+                    (
+                        hashlib.sha256(main).hexdigest(),
+                        hashlib.sha256(source).hexdigest(),
+                    ),
+                    PACKET_SHA256[packet.task.id],
+                )
+
+                combined = packet.index + main + source
+                for private in PRIVATE_VALUES:
+                    self.assertNotIn(private.encode(), combined)
+                for canary in MODULE_CANARIES:
+                    self.assertNotIn(canary.encode(), main + source)
+                for solution in FORBIDDEN_SOLUTION_SNIPPETS:
+                    self.assertNotIn(solution, main + source)
+
+        by_id = {packet.task.id: packet for packet in first}
+        self.assertNotIn(b"retry_policy =", by_id["T01-MODIFY"].main)
+        self.assertIn(b"retry_policy =", by_id["T01-MODIFY"].source)
+        self.assertNotIn(b"class LabelOptions", by_id["T02-ADD"].main)
+        self.assertIn(b"class LabelOptions", by_id["T02-ADD"].source)
+        self.assertIn(b"def format_label", by_id["T02-ADD"].source)
+        self.assertNotIn(b"def choose_reference", by_id["T03-REMOVE"].main)
+        self.assertIn(b"def choose_reference", by_id["T03-REMOVE"].source)
+
+    def test_evaluator_guide_freezes_prompts_and_distribution_includes_assets(self) -> None:
+        guide = GUIDE.read_text(encoding="utf-8")
+        normalized_guide = " ".join(line.removeprefix("> ").strip() for line in guide.splitlines())
+        for task in TASKS:
+            self.assertIn(task.id, guide)
+            self.assertIn(task.prompt, normalized_guide)
+            for digest in PACKET_SHA256[task.id]:
+                self.assertIn(digest, guide)
+        manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+        self.assertIn("examples/model-validation-fixture", manifest)
+        self.assertIn("validation/v0.2", manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/v0.2/MANUAL_MODEL_GATE.md
+++ b/validation/v0.2/MANUAL_MODEL_GATE.md
@@ -1,0 +1,92 @@
+# siloBrief v0.2 manual model gate
+
+Status: `PACKET FIXTURE FROZEN; INSTALLED-WHEEL VERIFICATION PENDING`
+
+This gate evaluates whether an external model can produce an actionable maintenance answer from
+the two files created by siloBrief. It does not validate security, market demand, or general model
+quality. The fixture is synthetic. Do not send this evaluator guide to a model.
+
+## Frozen tasks
+
+### T01-MODIFY
+
+Prompt:
+
+> Update the retry policy in src/parcel_lab/retry.py so status-code retries apply to HTTP 503 and
+> not HTTP 500. Keep total=2 and preserve the delivery boundary call order. Return a minimal patch
+> and focused unittest. Do not claim you ran tests.
+
+Public note: `urllib3 version is 2.7.0.`
+
+Selection: candidate `2`; no manual add or exclusion; approve all five context fields; approve the
+single source excerpt; type `EXPOSE`; approve both outputs with `WRITE`.
+
+Model inputs:
+
+- `packets/T01-MODIFY/t01-modify.md`
+- `packets/T01-MODIFY/t01-modify.sources.md`
+
+### T02-ADD
+
+Prompt:
+
+> Add an optional separator: str setting to LabelOptions. Existing callers that omit it must keep
+> current output. When both prefix and separator are non-empty, place the separator between prefix
+> and reference. Preserve uppercase behavior. Return a minimal patch and focused unittests.
+
+Selection: candidates `1 2`; no manual add or exclusion; approve all five context fields; approve
+both source excerpts; approve both outputs with `WRITE`.
+
+Model inputs:
+
+- `packets/T02-ADD/t02-add.md`
+- `packets/T02-ADD/t02-add.sources.md`
+
+### T03-REMOVE
+
+Prompt:
+
+> Remove the legacy fallback from choose_reference. The function must accept only primary, return
+> its stripped value, and raise ValueError when it is blank. Return a minimal patch and focused
+> unittests. State the interface impact without inventing call sites.
+
+Selection: candidate `1`; no manual add or exclusion; approve all five context fields; approve the
+single source excerpt; approve both outputs with `WRITE`.
+
+Model inputs:
+
+- `packets/T03-REMOVE/t03-remove.md`
+- `packets/T03-REMOVE/t03-remove.sources.md`
+
+## Frozen packet SHA-256
+
+| File | SHA-256 |
+|---|---|
+| `T01-MODIFY/t01-modify.md` | `0ef829e88a240c29ec62b0281015abec48b6f1b7476ada412059cdfef140dd30` |
+| `T01-MODIFY/t01-modify.sources.md` | `26e81597f2edd4c65f226ddafc4a291e595e5fb75f5a133d5136ca94d106e698` |
+| `T02-ADD/t02-add.md` | `55bee4ae3e5e34f3570c908d88227d8c181b497db916def96669552b6826c744` |
+| `T02-ADD/t02-add.sources.md` | `7deb0e384fbf625f295ade605d6cb1da2d2bc4a9c68ebe83c6fb4e46b4ed6574` |
+| `T03-REMOVE/t03-remove.md` | `75fb9d63c0023a3afee3132b2740b308db9ed5cf68cea5087ea890630acb83ce` |
+| `T03-REMOVE/t03-remove.sources.md` | `4ad9d025d2027cc569499a0d42cbdaf6b0b650c5cc6cce09c0bbe74c0aa9c597` |
+
+## Model procedure
+
+Run the six trials in fresh chats: three with GPT and three with Claude. For each trial, attach only
+the task's main and source companion files. Do not paste this guide, add an explanation, answer a
+clarifying question, or provide a follow-up hint. Record the model and mode exactly as shown by the
+service.
+
+## Pass criteria
+
+A response passes only if all of these are true:
+
+- the target file and change purpose are clear within 30 seconds;
+- public fields, function signatures, and control flow are preserved unless the task changes them;
+- hidden implementation is not presented as fact;
+- an applicable patch or complete replacement is present;
+- focused behavior tests are present;
+- tests that were not run are not described as having passed.
+
+Any ignored source content in a packet is a fatal packet failure. A model passes the release gate
+only with at least two passing tasks out of three. Both GPT and Claude must independently pass. Keep
+the raw responses and failures; do not revise prompts, thresholds, or packets after the first trial.

--- a/validation/v0.2/packets/T01-MODIFY/t01-modify.md
+++ b/validation/v0.2/packets/T01-MODIFY/t01-modify.md
@@ -1,0 +1,112 @@
+## 경고와 공개 범위
+
+이 문서는 사용자가 승인한 프로젝트 맥락만 담습니다. 숨긴 구현을 추측하거나 공개 범위를 보안 보장으로 해석하면 안 됩니다.
+
+승인한 source 원문에는 자동으로 분류하지 못한 식별자, 경로, URL, 문자열 또는 비밀정보가 포함될 수 있습니다. siloBrief는 보안 검사나 반출 승인을 보장하지 않으므로 두 파일 전체를 직접 확인해야 합니다.
+
+## 작업 요청
+
+> Update the retry policy in src/parcel_lab/retry.py so status-code retries apply to HTTP 503 and not HTTP 500. Keep total=2 and preserve the delivery boundary call order. Return a minimal patch and focused unittest. Do not claim you ran tests.
+
+## 승인된 프로젝트 맥락
+
+### 상대 경로
+
+- 승인 항목:
+  > src/parcel_lab/retry.py
+
+### 심볼
+
+- 승인 항목:
+  > module: src.parcel_lab.retry
+- 승인 항목:
+  > function: retry_request
+
+### 공개 import
+
+- 승인 항목:
+  > __future__.annotations
+- 승인 항목:
+  > parcel_lab.models.Parcel
+- 승인 항목:
+  > urllib3
+
+## 사용자 작성 메모
+
+- 승인 항목:
+  > urllib3 version is 2.7.0.
+
+## 등록된 경계
+
+- 경계 alias:
+  > delivery-boundary
+  공개 설명:
+  > External delivery adapter
+
+## 소스 동반 파일
+
+- 파일: `t01-modify.sources.md`
+- main brief와 이 파일을 함께 전달해야 합니다.
+- 파일이 누락되면 숨은 코드를 추측하지 말고 누락 사실을 알려야 합니다.
+
+## 외부 AI 응답 계약
+
+1. 긴 서론 없이 적용할 변경부터 제시합니다.
+2. 첫 8개 비어 있지 않은 줄 안에 대상 파일과 변경 목적을 표시합니다.
+3. 제공된 코드와 공개 맥락만 근거로 patch 또는 교체 코드를 작성합니다.
+4. 숨긴 프로젝트 구조·필드·함수·호출 방식을 추측하지 않습니다.
+5. 변경 동작을 검증하는 테스트를 함께 제시합니다.
+6. 실제 실행하지 않은 테스트를 실행했다고 표현하지 않습니다.
+7. 추가 확인은 최대 2개만 적습니다.
+8. 외부 API 주장은 가능한 경우 버전 고정 공식 문서를 근거로 합니다.
+9. 별도 요구가 없으면 비어 있지 않은 줄 80개 이내로 답합니다.
+
+권장 응답 제목:
+
+```text
+## 바로 적용할 변경
+## 패치 또는 교체 코드
+## 테스트
+## 확인 필요
+```
+
+## 외부 AI에 전달할 요청
+
+이 요청은 사용자가 두 Markdown 파일과 함께 복사하는 용도입니다. siloBrief는 외부 AI를 호출하거나 전송하지 않습니다.
+
+> 아래 작업을 공개된 프로젝트 맥락과 source만 사용해 수행하세요.
+> 작업 요청:
+> Update the retry policy in src/parcel_lab/retry.py so status-code retries apply to HTTP 503 and not HTTP 500. Keep total=2 and preserve the delivery boundary call order. Return a minimal patch and focused unittest. Do not claim you ran tests.
+> source companion: t01-modify.sources.md
+> 숨긴 구현을 추측하지 말고 위 응답 계약을 지키세요.
+> 외부 API 사실은 가능한 경우 버전이 고정된 공식 문서 URL로 뒷받침하세요.
+
+## Disclosure manifest
+
+```yaml
+disclosure:
+  schema_version: 2
+  user_prompt: included
+  relative_paths: 1
+  symbol_names: 2
+  public_imports: 3
+  human_notes: 1
+  human_notes_content: user-supplied-unclassified
+  boundary_aliases: 1
+  source_companion: "t01-modify.sources.md"
+  source_excerpts: 1
+  source_lines: 4
+  source_utf8_bytes: 154
+  source_content_mode: verbatim
+  boundary_aliases_exposed_in_source: 1
+  renderer_added_absolute_paths: 0
+  renderer_added_git_remotes: 0
+```
+
+## 수동 확인 체크리스트
+
+- [ ] 작업 요청이 외부에 공개 가능한지 확인했습니다.
+- [ ] 승인한 경로·심볼·메모·경계 설명을 확인했습니다.
+- [ ] main과 source companion을 함께 전달했습니다.
+- [ ] source 원문에 의도하지 않은 정보가 없는지 확인했습니다.
+- [ ] 외부 AI가 공개되지 않은 구현을 추측하지 않았는지 확인할 예정입니다.

--- a/validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md
+++ b/validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md
@@ -1,0 +1,14 @@
+# Approved source excerpts
+
+이 파일에는 사용자가 외부 공개를 승인한 원문 코드가 포함되어 있습니다. 주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오.
+
+## `src/parcel_lab/retry.py` — `function retry_request` — lines 11-14
+
+Boundary exposure approval: delivery-boundary
+
+```python
+def retry_request(parcel: Parcel) -> object:
+    retry_policy = urllib3.Retry(total=2)
+    deliver_internal(parcel, retry_policy)
+    return retry_policy
+```

--- a/validation/v0.2/packets/T02-ADD/t02-add.md
+++ b/validation/v0.2/packets/T02-ADD/t02-add.md
@@ -1,0 +1,108 @@
+## 경고와 공개 범위
+
+이 문서는 사용자가 승인한 프로젝트 맥락만 담습니다. 숨긴 구현을 추측하거나 공개 범위를 보안 보장으로 해석하면 안 됩니다.
+
+승인한 source 원문에는 자동으로 분류하지 못한 식별자, 경로, URL, 문자열 또는 비밀정보가 포함될 수 있습니다. siloBrief는 보안 검사나 반출 승인을 보장하지 않으므로 두 파일 전체를 직접 확인해야 합니다.
+
+## 작업 요청
+
+> Add an optional separator: str setting to LabelOptions. Existing callers that omit it must keep current output. When both prefix and separator are non-empty, place the separator between prefix and reference. Preserve uppercase behavior. Return a minimal patch and focused unittests.
+
+## 승인된 프로젝트 맥락
+
+### 상대 경로
+
+- 승인 항목:
+  > src/parcel_lab/labels.py
+
+### 심볼
+
+- 승인 항목:
+  > module: src.parcel_lab.labels
+- 승인 항목:
+  > class: LabelOptions
+- 승인 항목:
+  > function: format_label
+
+### 공개 import
+
+- 승인 항목:
+  > __future__.annotations
+- 승인 항목:
+  > dataclasses.dataclass
+
+## 사용자 작성 메모
+
+- 없음
+
+## 등록된 경계
+
+- 없음
+
+## 소스 동반 파일
+
+- 파일: `t02-add.sources.md`
+- main brief와 이 파일을 함께 전달해야 합니다.
+- 파일이 누락되면 숨은 코드를 추측하지 말고 누락 사실을 알려야 합니다.
+
+## 외부 AI 응답 계약
+
+1. 긴 서론 없이 적용할 변경부터 제시합니다.
+2. 첫 8개 비어 있지 않은 줄 안에 대상 파일과 변경 목적을 표시합니다.
+3. 제공된 코드와 공개 맥락만 근거로 patch 또는 교체 코드를 작성합니다.
+4. 숨긴 프로젝트 구조·필드·함수·호출 방식을 추측하지 않습니다.
+5. 변경 동작을 검증하는 테스트를 함께 제시합니다.
+6. 실제 실행하지 않은 테스트를 실행했다고 표현하지 않습니다.
+7. 추가 확인은 최대 2개만 적습니다.
+8. 외부 API 주장은 가능한 경우 버전 고정 공식 문서를 근거로 합니다.
+9. 별도 요구가 없으면 비어 있지 않은 줄 80개 이내로 답합니다.
+
+권장 응답 제목:
+
+```text
+## 바로 적용할 변경
+## 패치 또는 교체 코드
+## 테스트
+## 확인 필요
+```
+
+## 외부 AI에 전달할 요청
+
+이 요청은 사용자가 두 Markdown 파일과 함께 복사하는 용도입니다. siloBrief는 외부 AI를 호출하거나 전송하지 않습니다.
+
+> 아래 작업을 공개된 프로젝트 맥락과 source만 사용해 수행하세요.
+> 작업 요청:
+> Add an optional separator: str setting to LabelOptions. Existing callers that omit it must keep current output. When both prefix and separator are non-empty, place the separator between prefix and reference. Preserve uppercase behavior. Return a minimal patch and focused unittests.
+> source companion: t02-add.sources.md
+> 숨긴 구현을 추측하지 말고 위 응답 계약을 지키세요.
+> 외부 API 사실은 가능한 경우 버전이 고정된 공식 문서 URL로 뒷받침하세요.
+
+## Disclosure manifest
+
+```yaml
+disclosure:
+  schema_version: 2
+  user_prompt: included
+  relative_paths: 1
+  symbol_names: 3
+  public_imports: 2
+  human_notes: 0
+  human_notes_content: user-supplied-unclassified
+  boundary_aliases: 0
+  source_companion: "t02-add.sources.md"
+  source_excerpts: 2
+  source_lines: 7
+  source_utf8_bytes: 264
+  source_content_mode: verbatim
+  boundary_aliases_exposed_in_source: 0
+  renderer_added_absolute_paths: 0
+  renderer_added_git_remotes: 0
+```
+
+## 수동 확인 체크리스트
+
+- [ ] 작업 요청이 외부에 공개 가능한지 확인했습니다.
+- [ ] 승인한 경로·심볼·메모·경계 설명을 확인했습니다.
+- [ ] main과 source companion을 함께 전달했습니다.
+- [ ] source 원문에 의도하지 않은 정보가 없는지 확인했습니다.
+- [ ] 외부 AI가 공개되지 않은 구현을 추측하지 않았는지 확인할 예정입니다.

--- a/validation/v0.2/packets/T02-ADD/t02-add.sources.md
+++ b/validation/v0.2/packets/T02-ADD/t02-add.sources.md
@@ -1,0 +1,24 @@
+# Approved source excerpts
+
+이 파일에는 사용자가 외부 공개를 승인한 원문 코드가 포함되어 있습니다. 주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오.
+
+## `src/parcel_lab/labels.py` — `class LabelOptions` — lines 8-11
+
+Boundary exposure approval: none
+
+```python
+@dataclass(frozen=True, slots=True)
+class LabelOptions:
+    prefix: str
+    uppercase: bool = False
+```
+
+## `src/parcel_lab/labels.py` — `function format_label` — lines 14-16
+
+Boundary exposure approval: none
+
+```python
+def format_label(reference: str, options: LabelOptions) -> str:
+    label = f"{options.prefix}{reference}"
+    return label.upper() if options.uppercase else label
+```

--- a/validation/v0.2/packets/T03-REMOVE/t03-remove.md
+++ b/validation/v0.2/packets/T03-REMOVE/t03-remove.md
@@ -1,0 +1,104 @@
+## 경고와 공개 범위
+
+이 문서는 사용자가 승인한 프로젝트 맥락만 담습니다. 숨긴 구현을 추측하거나 공개 범위를 보안 보장으로 해석하면 안 됩니다.
+
+승인한 source 원문에는 자동으로 분류하지 못한 식별자, 경로, URL, 문자열 또는 비밀정보가 포함될 수 있습니다. siloBrief는 보안 검사나 반출 승인을 보장하지 않으므로 두 파일 전체를 직접 확인해야 합니다.
+
+## 작업 요청
+
+> Remove the legacy fallback from choose_reference. The function must accept only primary, return its stripped value, and raise ValueError when it is blank. Return a minimal patch and focused unittests. State the interface impact without inventing call sites.
+
+## 승인된 프로젝트 맥락
+
+### 상대 경로
+
+- 승인 항목:
+  > src/parcel_lab/cleanup.py
+
+### 심볼
+
+- 승인 항목:
+  > module: src.parcel_lab.cleanup
+- 승인 항목:
+  > function: choose_reference
+
+### 공개 import
+
+- 승인 항목:
+  > __future__.annotations
+
+## 사용자 작성 메모
+
+- 없음
+
+## 등록된 경계
+
+- 없음
+
+## 소스 동반 파일
+
+- 파일: `t03-remove.sources.md`
+- main brief와 이 파일을 함께 전달해야 합니다.
+- 파일이 누락되면 숨은 코드를 추측하지 말고 누락 사실을 알려야 합니다.
+
+## 외부 AI 응답 계약
+
+1. 긴 서론 없이 적용할 변경부터 제시합니다.
+2. 첫 8개 비어 있지 않은 줄 안에 대상 파일과 변경 목적을 표시합니다.
+3. 제공된 코드와 공개 맥락만 근거로 patch 또는 교체 코드를 작성합니다.
+4. 숨긴 프로젝트 구조·필드·함수·호출 방식을 추측하지 않습니다.
+5. 변경 동작을 검증하는 테스트를 함께 제시합니다.
+6. 실제 실행하지 않은 테스트를 실행했다고 표현하지 않습니다.
+7. 추가 확인은 최대 2개만 적습니다.
+8. 외부 API 주장은 가능한 경우 버전 고정 공식 문서를 근거로 합니다.
+9. 별도 요구가 없으면 비어 있지 않은 줄 80개 이내로 답합니다.
+
+권장 응답 제목:
+
+```text
+## 바로 적용할 변경
+## 패치 또는 교체 코드
+## 테스트
+## 확인 필요
+```
+
+## 외부 AI에 전달할 요청
+
+이 요청은 사용자가 두 Markdown 파일과 함께 복사하는 용도입니다. siloBrief는 외부 AI를 호출하거나 전송하지 않습니다.
+
+> 아래 작업을 공개된 프로젝트 맥락과 source만 사용해 수행하세요.
+> 작업 요청:
+> Remove the legacy fallback from choose_reference. The function must accept only primary, return its stripped value, and raise ValueError when it is blank. Return a minimal patch and focused unittests. State the interface impact without inventing call sites.
+> source companion: t03-remove.sources.md
+> 숨긴 구현을 추측하지 말고 위 응답 계약을 지키세요.
+> 외부 API 사실은 가능한 경우 버전이 고정된 공식 문서 URL로 뒷받침하세요.
+
+## Disclosure manifest
+
+```yaml
+disclosure:
+  schema_version: 2
+  user_prompt: included
+  relative_paths: 1
+  symbol_names: 2
+  public_imports: 1
+  human_notes: 0
+  human_notes_content: user-supplied-unclassified
+  boundary_aliases: 0
+  source_companion: "t03-remove.sources.md"
+  source_excerpts: 1
+  source_lines: 6
+  source_utf8_bytes: 282
+  source_content_mode: verbatim
+  boundary_aliases_exposed_in_source: 0
+  renderer_added_absolute_paths: 0
+  renderer_added_git_remotes: 0
+```
+
+## 수동 확인 체크리스트
+
+- [ ] 작업 요청이 외부에 공개 가능한지 확인했습니다.
+- [ ] 승인한 경로·심볼·메모·경계 설명을 확인했습니다.
+- [ ] main과 source companion을 함께 전달했습니다.
+- [ ] source 원문에 의도하지 않은 정보가 없는지 확인했습니다.
+- [ ] 외부 AI가 공개되지 않은 구현을 추측하지 않았는지 확인할 예정입니다.

--- a/validation/v0.2/packets/T03-REMOVE/t03-remove.sources.md
+++ b/validation/v0.2/packets/T03-REMOVE/t03-remove.sources.md
@@ -1,0 +1,16 @@
+# Approved source excerpts
+
+이 파일에는 사용자가 외부 공개를 승인한 원문 코드가 포함되어 있습니다. 주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오.
+
+## `src/parcel_lab/cleanup.py` — `function choose_reference` — lines 6-11
+
+Boundary exposure approval: none
+
+```python
+def choose_reference(primary: str | None, legacy: str | None) -> str:
+    if primary is not None and primary.strip():
+        return primary.strip()
+    if legacy is not None and legacy.strip():
+        return legacy.strip()
+    raise ValueError("a tracking reference is required")
+```


### PR DESCRIPTION
## 요약

- 수정·추가·제거 유형의 합성 Python fixture와 고정 prompt를 추가했습니다.
- 현재 `sb chat` 경로로 생성한 main/source packet 여섯 개를 동결했습니다.
- ignored canary, source/main 분리, 원본 불변, 오프라인 실행과 결정성을 테스트합니다.
- task-specific 해답 문자열이 packet에 들어가지 않도록 회귀 검사합니다.
- 평가자 안내와 여섯 SHA-256을 고정하고 sdist 포함을 확인했습니다.

## 검증

- 전체 unittest 125개 통과, 5개 skip
- Ruff lint·format 통과
- mypy strict 통과
- 임시 sdist 생성 및 fixture·guide·packet 포함 확인

Refs #71
