### PR TITLE
docs(readme): present the project for closed environments

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include CODE_OF_CONDUCT.md
 include CONTRIBUTING.md
 include README.ko.md
 include SECURITY.md
-recursive-include docs *.md
+recursive-include docs *.md *.svg
 recursive-include examples/parcel-sync-fixture *.md *.py
 recursive-include examples/model-validation-fixture *.md *.py
 recursive-include validation/v0.2 *.md

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,166 +1,219 @@
-# siloBrief
+<p align="center">
+  <img src="docs/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
 
-[English](README.md)
+---
 
-siloBrief는 Python 개발자가 외부 AI에 전달할 프로젝트 정보와 소스 코드를 직접 고르게
-도와주는 로컬 명령줄 도구입니다. 모든 내용을 파일로 쓰기 전에 보여주며, 사용자가 직접
-옮길 수 있는 Markdown 파일을 만듭니다.
+<p align="center">
+  <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-4f46e5" alt="릴리스 v0.2.0"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
+</p>
 
-AI가 저장소에 직접 접근할 수 없고, 일부 프로젝트 경로는 공유 자료에서 제외해야 할 때
-사용합니다.
+<p align="center">
+  <a href="#프로젝트-목표">프로젝트 목표</a> •
+  <a href="#설치">설치</a> •
+  <a href="#명령어">명령어</a> •
+  <a href="#사용법">사용법</a> •
+  <a href="#보호-범위와-한계">보호 범위</a> •
+  <a href="#문서">문서</a> •
+  <a href="README.md">English</a>
+</p>
 
-siloBrief는 AI 서비스에 접속하지 않고 파일을 네트워크로 전송하지 않습니다.
+폐쇄망이나 사내 개발 환경에서는 외부 AI가 저장소에 직접 접근할 수 없습니다. 이런 환경에서
+AI에게 코드 수정을 요청하려면 관련 코드와 프로젝트 배경을 따로 정리해야 하지만, 저장소 전체를
+외부로 넘길 수는 없는 경우가 많습니다.
 
-## 무엇이 만들어지나요?
+siloBrief는 **폐쇄 환경의 Python 프로젝트에서 필요한 정보와 공개해도 되는 소스 코드만 골라
+AI에 전달할 Markdown 파일로 만드는 로컬 CLI 도구**입니다. 어떤 내용을 넣을지 직접 선택하고,
+완성된 파일을 미리 확인한 뒤 조직의 반출 절차에 따라 원하는 AI에 직접 전달합니다.
 
-개발 작업을 입력하고 siloBrief가 찾은 프로젝트 항목을 검토하면 다음 두 파일이 만들어질 수
-있습니다.
+siloBrief가 AI에 접속하거나 파일을 자동으로 전송하는 일은 없습니다.
 
-```text
-retry-brief.md          작업 요청과 승인한 프로젝트 정보
-retry-brief.sources.md  사용자가 선택하고 승인한 소스 코드
-```
+- 라이선스: Apache License 2.0
+- 지원 운영체제: Windows, Ubuntu
+- 지원 Python: 3.10 이상
+- 런타임 외부 의존성: 없음
 
-`.sources.md` 파일이 만들어졌다면 두 파일을 함께 AI에 전달합니다. 소스 코드 공개를 모두
-거부하면 AI 요청 문서만 만들어집니다.
+## 프로젝트 목표
 
-실제로 생성한 [AI 요청 문서](validation/v0.2/packets/T01-MODIFY/t01-modify.md)와
-[코드 첨부 파일](validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md)을 확인할 수 있습니다.
+siloBrief의 목표는 외부 AI가 직접 접근할 수 없는 프로젝트에서도 저장소를 통째로 넘기지 않고
+작업에 필요한 정보를 전달할 수 있게 하는 것입니다.
 
-## 어떻게 동작하나요?
+- 색인을 만들기 전에 읽으면 안 되는 경로를 등록합니다.
+- 허용된 Python 파일 안에서 작업과 관련된 함수와 클래스를 찾습니다.
+- 포함할 프로젝트 정보와 소스 코드를 사용자가 하나씩 검토합니다.
+- 파일을 만들기 전에 전체 내용을 미리 보여줍니다.
+- 입력과 선택이 같으면 운영체제와 관계없이 같은 Markdown을 만듭니다.
 
-1. `setup`이 기존 프로젝트 안에 siloBrief의 로컬 작업 공간을 만듭니다.
-2. `ignore`로 siloBrief가 읽으면 안 되는 경로를 등록합니다.
-3. `init`이 나머지 Python 파일을 분석해 로컬 검색 목록을 만듭니다.
-4. 필요하다면 `log`로 코드 구조만으로 알 수 없는 프로젝트 정보를 기록합니다.
-5. `chat`이 관련 함수와 클래스를 찾고, 무엇을 포함할지 사용자에게 묻습니다.
-6. 전체 미리보기를 확인하고 정확히 `WRITE`를 입력하면 Markdown 파일을 만듭니다.
-
-생성된 파일은 다른 AI에 전달할 입력 자료입니다. siloBrief가 코드 수정안을 직접 생성하지는
-않습니다.
+siloBrief가 만드는 것은 AI에 전달할 입력 자료입니다. 코드 수정안 자체를 만들어 주는 도구는
+아닙니다.
 
 ## 설치
 
-요구사항:
-
-- Python 3.10 이상
-- Windows 또는 Ubuntu
-- 런타임 외부 의존성 없음
-
-현재 저장소를 설치하고 명령을 확인합니다.
+Python 3.10 이상이 필요합니다. 현재 저장소를 설치한 뒤 명령이 정상적으로 등록됐는지
+확인합니다.
 
 ```console
 python -m pip install .
 sb --version
 ```
 
-예상 출력:
+다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
 siloBrief 0.2.0
 ```
 
-## 전체 흐름 체험하기
+## 명령어
 
-합성 프로젝트인 [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md)를 일회용
-디렉터리에 복사합니다. 복사한 프로젝트의 최상위 디렉터리에서 다음 명령을 실행합니다.
+| 명령어 | 설명 |
+|---|---|
+| `sb setup [PATH]` | 기존 프로젝트에 siloBrief 작업 공간을 만듭니다. |
+| `sb ignore PATH --as TEXT [--alias NAME]` | 읽지 않을 경로와 그 영역을 대신할 공개용 이름을 등록합니다. |
+| `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
+| `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
+| `sb chat "PROMPT" --out FILE` | 전달할 내용을 검토하고 AI 요청 문서와 선택적 코드 첨부 파일을 만듭니다. |
+| `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
+
+`setup`을 제외한 명령은 현재 위치에서 프로젝트 루트를 자동으로 찾습니다. `chat`은 대화형
+터미널에서만 실행할 수 있으며, 현재 설정으로 만든 색인과 새로운 `.md` 출력 경로가 필요합니다.
+프로젝트 안에 파일을 만들 때는 `.silobrief/exports/` 아래만 사용할 수 있고 기존 파일은
+덮어쓰지 않습니다.
+
+## 생성되는 파일
+
+검토 결과에 따라 한 개 또는 두 개의 파일이 만들어집니다.
+
+```text
+retry-brief.md          작업 요청과 공개를 승인한 프로젝트 정보
+retry-brief.sources.md  사용자가 선택하고 승인한 소스 코드
+```
+
+`.sources.md` 파일이 만들어졌다면 두 파일을 함께 AI에 전달합니다. 소스 코드를 하나도 선택하지
+않았다면 기본 AI 요청 문서만 만들어집니다.
+
+저장소에는 siloBrief로 직접 만든 [AI 요청 문서](validation/v0.2/packets/T01-MODIFY/t01-modify.md)와
+[코드 첨부 파일](validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md)이 들어 있습니다.
+
+## 사용법
+
+### 빠르게 써 보기
+
+먼저 합성 예제 프로젝트인
+[`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md)를 작업용 디렉터리에 복사합니다.
+복사한 프로젝트의 루트에서 다음 명령을 실행하세요.
 
 ```console
 sb setup .
 sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
-sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
 sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
 ```
 
-`chat` 실행 중에는 다음 순서로 검토합니다.
+이 과정에서 `setup`은 작업 공간을 만들고, `ignore`는 읽으면 안 되는 경로를 등록합니다. `init`은
+나머지 Python 파일을 분석해 색인을 만들고, `chat`은 작업과 관련 있어 보이는 정보를 찾아
+검토 대상으로 보여줍니다.
 
-1. 작업 내용을 확인하고 관련 함수 또는 클래스를 고릅니다.
-2. 제안된 프로젝트 정보를 하나씩 확인합니다.
-3. 화면에 나온 소스 코드를 포함할지 결정합니다. 기본 선택은 거부입니다.
-4. 제외 영역의 실제 식별자가 보이면 내용을 확인한 뒤에만 `EXPOSE`를 입력합니다.
-5. AI 요청 문서와 코드 첨부 파일의 전체 미리보기를 확인합니다.
-6. `WRITE`를 입력해 파일을 만듭니다.
+### 프로젝트 정보 더하기
 
-생성된 두 파일은 다른 환경으로 옮기기 전에 직접 열어 확인하십시오.
+코드 구조만으로 드러나지 않는 규칙이나 배경 정보가 있다면 `sb log`로 메모를 남길 수 있습니다.
+외부에 공개해도 된다고 확인한 내용만 입력하세요.
 
-## 작업 요청을 잘 작성하는 방법
+```console
+sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
+sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-with-note.md
+```
 
-`PROMPT`에는 짧은 키워드 대신 구체적인 작업을 적습니다. AI 답변에 필요한 결과와 완료 조건도
-함께 적어야 어디까지 답해야 하는지 알 수 있습니다.
+`chat`을 실행하면 다음 순서로 진행됩니다.
 
-`sb log`에는 외부 공개를 승인한 정보만 입력합니다. 프로젝트 메모에 비공개 소스 코드,
-비밀값 또는 제외 영역의 실제 이름을 적지 마십시오. 사용자가 직접 선택하고 승인한 소스 코드만
-코드 첨부 파일에 원문 그대로 포함할 수 있으며, 기본 선택은 거부입니다.
+1. 요청한 작업이 맞는지 확인하고 관련 함수나 클래스를 고릅니다.
+2. AI 요청 문서에 넣을 프로젝트 정보를 하나씩 검토합니다.
+3. 화면에 표시된 소스 코드를 첨부할지 선택합니다. 기본값은 `아니요`입니다.
+4. 제외 영역의 실제 식별자가 노출될 때는 내용을 확인한 뒤 `EXPOSE`를 입력해야 합니다.
+5. AI 요청 문서와 코드 첨부 파일의 전체 내용을 미리 확인합니다.
+6. 문제가 없으면 정확히 `WRITE`를 입력해 파일을 만듭니다.
 
-## 이 프로젝트에서 사용하는 용어
+다른 환경으로 옮기기 전에는 생성된 파일을 직접 열어 마지막으로 확인하세요.
 
-| 용어 | 쉬운 설명 |
+### 좋은 요청을 작성하는 방법
+
+`PROMPT`에는 키워드만 나열하지 말고 구체적인 작업을 적으세요. AI가 무엇을 답해야 하는지
+판단할 수 있도록 필요한 결과와 완료 조건도 함께 적는 것이 좋습니다.
+
+`sb log`에는 외부 공개를 승인한 정보만 입력해야 합니다. 비공개 소스 코드, 비밀값 또는
+제외 영역의 실제 이름을 프로젝트 메모에 적지 마세요. 소스 코드는 사용자가 직접 선택하고
+승인한 경우에만 코드 첨부 파일에 원문 그대로 포함됩니다. 기본값은 포함하지 않는 것입니다.
+
+## 용어 정리
+
+| 용어 | 뜻 |
 |---|---|
-| AI 요청 문서 | 작업 요청과 승인한 프로젝트 정보가 들어 있는 기본 `.md` 파일입니다. 소스 코드 본문은 들어가지 않습니다. 기술 계약서에서는 main brief라고 부릅니다. |
-| 코드 첨부 파일 | 사용자가 선택하고 승인한 소스 코드가 들어 있는 선택적 `.sources.md` 파일입니다. 기술 계약서에서는 source companion이라고 부릅니다. |
-| 제외 경로 | `sb ignore`로 등록한 파일 또는 디렉터리입니다. siloBrief는 제외 디렉터리 아래의 파일을 분석하지 않습니다. |
-| 제외 영역의 공개용 이름 | 제외 경로의 실제 이름 대신 사용하는 별칭과 설명입니다. 기술 계약서에서는 boundary alias라고 부릅니다. |
-| 로컬 검색 목록 | 허용된 Python 파일, 함수와 클래스를 기록한 `.silobrief/index.json`입니다. 기술 계약서에서는 index라고 부릅니다. |
-| 프로젝트 메모 | `sb log`로 저장한 사용자 작성 정보입니다. 검토 과정에서 포함 후보로 제시될 수 있습니다. |
+| AI 요청 문서 | 작업 요청과 공개를 승인한 프로젝트 정보가 담긴 기본 `.md` 파일입니다. 소스 코드 본문은 포함하지 않습니다. 기술 문서에서는 main brief라고 부릅니다. |
+| 코드 첨부 파일 | 사용자가 선택한 소스 코드가 담기는 선택적 `.sources.md` 파일입니다. 기술 문서에서는 source companion이라고 부릅니다. |
+| 제외 경로 | `sb ignore`로 등록한 파일이나 디렉터리입니다. siloBrief는 제외한 디렉터리 아래를 분석하지 않습니다. |
+| 제외 영역의 공개용 이름 | 제외 경로의 실제 이름 대신 AI 요청 문서에 표시할 별칭과 설명입니다. 기술 문서에서는 boundary alias라고 부릅니다. |
+| 로컬 색인 | 허용된 Python 파일과 그 안의 함수·클래스를 기록한 `.silobrief/index.json` 파일입니다. |
+| 프로젝트 메모 | `sb log`로 저장한 정보입니다. `chat`에서 AI 요청 문서에 넣을 후보로 제시됩니다. |
 
-## 명령
+## 보호 범위와 한계
 
-| 명령 | 하는 일 |
-|---|---|
-| `sb setup [PATH]` | 기존 프로젝트에 siloBrief의 로컬 작업 공간을 만들거나 확인합니다. |
-| `sb ignore PATH --as TEXT [--alias NAME]` | 경로를 제외하고 그 영역을 나타낼 공개용 이름을 저장합니다. |
-| `sb init` | 허용된 Python 파일에서 로컬 검색 목록을 만듭니다. |
-| `sb log PATH --comment TEXT` | 외부 공개를 승인한 프로젝트 메모를 저장합니다. |
-| `sb chat "PROMPT" --out FILE` | 정보를 검토하고 AI 요청 문서와 선택적 코드 첨부 파일을 만듭니다. |
-| `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
-
-`setup` 외 명령은 현재 디렉터리에서 프로젝트 최상위 디렉터리를 찾습니다. `chat`을 사용하려면
-대화형 터미널, 현재 설정과 일치하는 검색 목록, 새로운 `.md` 출력 경로가 필요합니다. 프로젝트 안에
-출력할 때는 `.silobrief/exports/` 아래만 사용할 수 있습니다. 기존 파일은 덮어쓰지 않습니다.
-
-## 보호하는 범위와 보호하지 않는 범위
-
-siloBrief는 다음 원칙을 지킵니다.
+다음 동작은 siloBrief 자체에서 강제합니다.
 
 - 색인을 만들 때 심볼릭 링크를 따라가지 않습니다.
-- 등록된 제외 디렉터리를 열지 않습니다.
-- AI 요청 문서에서는 제외 코드에 대한 참조를 승인된 공개용 이름으로 바꿉니다.
-- 파일을 쓰기 전에 전체 미리보기와 승인을 요구합니다.
-- 네트워크, 언어 모델, 자동 전송 기능을 사용하지 않습니다.
+- 등록된 제외 디렉터리 안의 파일을 열지 않습니다.
+- 제외된 코드에 대한 참조는 승인한 공개용 이름으로 바꿔 AI 요청 문서에 표시합니다.
+- 파일을 쓰기 전에 전체 미리보기와 사용자 승인을 요구합니다.
+- 네트워크 연결, 언어 모델 호출, 자동 파일 전송을 하지 않습니다.
 
-siloBrief는 허용된 파일 안의 비밀정보를 탐지하지 못하고 `sb log`에 입력한 문장을 정리해 주지도
-않습니다. 승인한 소스 코드에는 주석, docstring, 문자열과 내부 식별자가 포함될 수 있습니다.
-siloBrief는 보안 검사기, 조직의 반출 승인 시스템 또는 정보 노출 방지 보장 도구가 아닙니다.
-모든 생성 파일을 공유 전에 직접 확인하십시오.
+하지만 siloBrief가 정보의 공개 가능 여부를 대신 판단해 주지는 않습니다. 허용된 파일 안의
+비밀정보를 탐지하지 못하며, `sb log`에 입력한 문장도 자동으로 정리하거나 검열하지 않습니다.
+선택한 소스 코드에는 주석, docstring, 문자열, 내부 식별자가 그대로 포함될 수 있습니다.
 
-## 현재까지 확인한 결과
+siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아니며, 정보 유출 방지를 보장하지도
+않습니다. 생성된 파일은 조직의 반출 규정에 따라 공유하기 전에 반드시 직접 검토하세요.
 
-현재 공개 버전은 v0.2.0입니다. 같은 패키지가 Windows와 Ubuntu에서 동일한 Markdown 파일을
-생성했고, Claude는 해당 파일로 예제 코드 유지보수 과제 3개를 완료했습니다.
-GPT 검증은 후속 과제입니다. 여러 모델, 실제 비공개 프로젝트 또는 독립 사용자를 대상으로 한
-효과가 검증된 것은 아닙니다.
+## 검증 현황
+
+현재 공개 버전은 v0.2.0입니다. Windows와 Ubuntu에서 같은 패키지와 같은 입력으로 동일한
+Markdown이 생성되는 것을 확인했습니다. Claude에는 예제 코드 유지보수 과제 세 개를 전달했고,
+세 과제 모두 요구한 형식의 답변을 받았습니다.
+
+GPT 검증은 후속 과제입니다. 현재 결과만으로 여러 AI 모델, 실제 비공개 프로젝트, 독립 사용자에게
+동일한 효과가 있다고 말할 수는 없습니다.
 
 - [설치 wheel 검증](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [수동 모델 평가 절차](validation/v0.2/MANUAL_MODEL_GATE.md)
 - [Claude 평가 결과](validation/v0.2/results/CLAUDE_GATE_RESULT.md)
 
-## 기술 문서
-
-- [v0.2 동작 계약](docs/V0_2_CONTRACT.md)
-- [기여 안내](CONTRIBUTING.md)
-- [보안 문제 신고 안내](SECURITY.md)
-
 ## 종료 코드
 
 | 코드 | 의미 |
 |---:|---|
-| `0` | 성공 |
-| `1` | 예상하지 못한 내부 오류 |
-| `2` | 입력, 경로 또는 설정 오류 |
-| `3` | 색인 생성 또는 Python 구문 분석 오류 |
-| `4` | 제외 영역 검증, 승인 또는 출력이 차단됨 |
+| `0` | 정상적으로 완료됨 |
+| `1` | 예상하지 못한 내부 오류가 발생함 |
+| `2` | 입력값, 경로 또는 설정에 문제가 있음 |
+| `3` | 색인 생성이나 Python 구문 분석에 실패함 |
+| `4` | 제외 영역 검증, 사용자 승인 또는 파일 출력 단계에서 차단됨 |
+
+## 문서
+
+- [v0.2 동작 계약](docs/V0_2_CONTRACT.md)
+- [보안 문제 신고 안내](SECURITY.md)
+
+## 기여하기
+
+기여를 환영합니다. Issue나 Pull Request를 만들기 전에 [기여 안내](CONTRIBUTING.md)를 확인해
+주세요. 프로젝트에 참여할 때는 [행동강령](CODE_OF_CONDUCT.md)을 따라야 합니다.
 
 ## 라이선스
 
-Apache License 2.0. 자세한 내용은 [`LICENSE`](LICENSE)를 확인해 주세요.
+siloBrief는 Apache License 2.0으로 배포됩니다. 자세한 내용은 [`LICENSE`](LICENSE)에서 확인할
+수 있습니다.
+
+## 면책 조항
+
+siloBrief는 있는 그대로 제공됩니다. 외부에 전달할 파일을 검토하는 과정을 도와주지만, 해당
+정보를 공유할 권한이 있는지 또는 안전한지는 대신 판단하지 않습니다. 프로젝트나 조직의 정보
+공개 규칙을 따르고 모든 출력물을 직접 확인하세요.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,55 @@
-# siloBrief
+<p align="center">
+  <img src="docs/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
 
-[한국어](README.ko.md)
+---
 
-siloBrief helps Python developers choose what project information and source code to share with
-an external AI assistant. It works locally, shows everything before writing, and creates Markdown
-files that you transfer yourself.
+<p align="center">
+  <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-4f46e5" alt="Release v0.2.0"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
+</p>
 
-Use it when an AI assistant cannot access your repository and some project paths must stay out of
-the material you share.
+<p align="center">
+  <a href="#mission">Mission</a> •
+  <a href="#installation">Installation</a> •
+  <a href="#commands">Commands</a> •
+  <a href="#usage">Usage</a> •
+  <a href="#safety-and-limitations">Safety</a> •
+  <a href="#documentation">Documentation</a> •
+  <a href="README.ko.md">한국어</a>
+</p>
 
+In a closed network or an internal development environment, an external AI assistant cannot access
+the repository directly. Relevant code and project context must be prepared separately, but sending
+the entire repository is often unacceptable.
+
+siloBrief is a local command-line tool that turns a development task and user-approved context from
+a closed Python project into reviewable Markdown. You choose which source code may be included,
+preview the complete result, and transfer the files under your organization's disclosure process.
 siloBrief does not connect to an AI service or send files over the network.
 
-## What it produces
+- Free software: Apache License 2.0
+- Platforms: Windows and Ubuntu
+- Python versions: 3.10 and newer
+- Runtime dependencies: none
 
-You give siloBrief a development task and review the project items it finds. The result can
-contain two files:
+## Mission
 
-```text
-retry-brief.md          task and approved project context
-retry-brief.sources.md  source code you selected and approved
-```
+Our mission is to make context from a project that external AI cannot access useful without treating
+the whole repository as shareable. siloBrief provides:
 
-Send both files to the AI assistant when the `.sources.md` file exists. If you decline every
-source selection, siloBrief creates only the main brief.
-
-See a generated [main brief](validation/v0.2/packets/T01-MODIFY/t01-modify.md) and its
-[code attachment](validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md).
-
-## How it works
-
-1. `setup` creates local siloBrief state in an existing project.
-2. `ignore` registers paths that siloBrief must not read.
-3. `init` scans the remaining Python files and builds a local search list.
-4. `log` optionally records a project fact that the code structure cannot show.
-5. `chat` finds relevant functions and classes, then asks you what may be included.
-6. After a complete preview and exact `WRITE` approval, siloBrief creates the Markdown files.
+- boundary registration before source indexing;
+- local discovery of relevant Python functions and classes;
+- explicit review of every context item and source-code selection;
+- a complete preview before files are written; and
+- deterministic Markdown that can be inspected and moved manually.
 
 The generated files are inputs for another AI assistant. siloBrief does not generate the code
 change itself.
 
-## Install
-
-Requirements:
-
-- Python 3.10 or newer
-- Windows or Ubuntu
-- no runtime dependencies
+## Installation
 
 Install the current checkout and verify the command:
 
@@ -59,51 +63,6 @@ Expected output:
 ```text
 siloBrief 0.2.0
 ```
-
-## Try the complete workflow
-
-Copy the synthetic [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md) to a disposable
-directory. Run the following commands from the copied project root:
-
-```console
-sb setup .
-sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
-sb init
-sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
-sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
-```
-
-During `chat`:
-
-1. Confirm the task and choose the relevant function or class.
-2. Review each proposed project field.
-3. Choose whether to include the displayed source code. The default answer is no.
-4. If the source reveals an excluded boundary identifier, type `EXPOSE` only after reviewing it.
-5. Review the complete main brief and code attachment.
-6. Type `WRITE` to create the files.
-
-Open both generated files before moving them to a different environment.
-
-## Write a useful task
-
-Write `PROMPT` as a concrete task instead of a few keywords. State the required deliverables and
-acceptance criteria so the AI assistant can tell what a complete answer must contain.
-
-Enter only information approved for external disclosure with `sb log`.
-Do not put private source code, secrets, or real names from excluded areas in a project note. Only
-source code you select and approve can be included verbatim in the code attachment; the default
-answer is no.
-
-## Terms used in this project
-
-| Term | Plain meaning |
-|---|---|
-| Main brief | The main `.md` file containing the task and approved project context. It does not contain source code bodies. |
-| Code attachment | The optional `.sources.md` file containing source code selected and approved by the user. The technical contract calls this the source companion. |
-| Excluded path | A file or directory registered with `sb ignore`. siloBrief does not scan files below an excluded directory. |
-| Public name for an excluded area | An alias and description used in place of the excluded path's real name. The technical contract calls this a boundary alias. |
-| Local search list | `.silobrief/index.json`, which records allowed Python files, functions, and classes. The technical contract calls this the index. |
-| Project note | A user-written fact saved with `sb log` that may be offered during review. |
 
 ## Commands
 
@@ -120,7 +79,80 @@ Commands other than `setup` find the project root from the current directory. `c
 interactive terminal, a current index, and a new `.md` output path. Output inside the project must
 be below `.silobrief/exports/`. Existing files are never overwritten.
 
-## What siloBrief does and does not protect
+## Generated files
+
+A review can produce two files:
+
+```text
+retry-brief.md          task and approved project context
+retry-brief.sources.md  source code you selected and approved
+```
+
+Send both files to the AI assistant when the `.sources.md` file exists. If you decline every
+source selection, siloBrief creates only the main brief.
+
+See a generated [main brief](validation/v0.2/packets/T01-MODIFY/t01-modify.md) and its
+[code attachment](validation/v0.2/packets/T01-MODIFY/t01-modify.sources.md).
+
+## Usage
+
+### Basic example
+
+Copy the synthetic [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md) to a disposable
+directory. Run these commands from the copied project root:
+
+```console
+sb setup .
+sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
+sb init
+sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
+```
+
+`setup` prepares local state, `ignore` registers a path that must not be read, and `init` builds a
+local search list from the remaining Python files. `chat` then proposes relevant project context
+for review.
+
+### Complete review
+
+Add an approved project fact when code structure alone does not explain the task:
+
+```console
+sb log src/parcel_sync/service.py --comment "HTTP 503 responses may be retried."
+sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-with-note.md
+```
+
+During `chat`:
+
+1. Confirm the task and choose the relevant function or class.
+2. Review each proposed project field.
+3. Choose whether to include the displayed source code. The default answer is no.
+4. If the source reveals an excluded boundary identifier, type `EXPOSE` only after reviewing it.
+5. Review the complete main brief and code attachment.
+6. Type `WRITE` to create the files.
+
+Open both generated files before moving them to a different environment.
+
+### Write a useful task
+
+Write `PROMPT` as a concrete task instead of a few keywords. State the required deliverables and
+acceptance criteria so the AI assistant can tell what a complete answer must contain.
+
+Enter only information approved for external disclosure with `sb log`. Do not put private source code,
+secrets, or real names from excluded areas in a project note. Only source code you select and approve
+can be included verbatim in the code attachment; the default answer is no.
+
+## Terms
+
+| Term | Plain meaning |
+|---|---|
+| Main brief | The main `.md` file containing the task and approved project context. It does not contain source code bodies. |
+| Code attachment | The optional `.sources.md` file containing source code selected and approved by the user. The technical contract calls this the source companion. |
+| Excluded path | A file or directory registered with `sb ignore`. siloBrief does not scan files below an excluded directory. |
+| Public name for an excluded area | An alias and description used in place of the excluded path's real name. The technical contract calls this a boundary alias. |
+| Local search list | `.silobrief/index.json`, which records allowed Python files, functions, and classes. The technical contract calls this the index. |
+| Project note | A user-written fact saved with `sb log` that may be offered during review. |
+
+## Safety and limitations
 
 siloBrief:
 
@@ -132,10 +164,10 @@ siloBrief:
 
 siloBrief does not detect secrets inside allowed files or clean text entered with `sb log`.
 Approved source code can contain comments, docstrings, strings, and internal identifiers. It is
-not a security scanner, an organizational export-approval system, or a guarantee against
-disclosure. Review every generated file before sharing it.
+not a security scanner, an export-approval system for a closed environment, or a guarantee against
+disclosure. Review every generated file under your organization's disclosure rules before sharing it.
 
-## Current evidence
+## Validation status
 
 The current release is v0.2.0. The same package produced identical Markdown files on Windows and
 Ubuntu. Claude completed three example code-maintenance tasks using those files.
@@ -145,12 +177,6 @@ models, real private projects, or independent users.
 - [Installed wheel verification](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [Manual model gate](validation/v0.2/MANUAL_MODEL_GATE.md)
 - [Claude gate result](validation/v0.2/results/CLAUDE_GATE_RESULT.md)
-
-## Technical reference
-
-- [v0.2 behavior contract](docs/V0_2_CONTRACT.md)
-- [Contributing guide](CONTRIBUTING.md)
-- [Security policy](SECURITY.md)
 
 ## Exit codes
 
@@ -162,6 +188,23 @@ models, real private projects, or independent users.
 | `3` | Indexing or Python parsing error |
 | `4` | Boundary validation, approval, or output was blocked |
 
+## Documentation
+
+- [v0.2 behavior contract](docs/V0_2_CONTRACT.md)
+- [Security policy](SECURITY.md)
+
+## Contributing
+
+Contributions are welcome. Read the [contributing guide](CONTRIBUTING.md) before opening an issue
+or pull request. Everyone participating in the project must follow the
+[code of conduct](CODE_OF_CONDUCT.md).
+
 ## License
 
-Apache License 2.0. See [`LICENSE`](LICENSE).
+siloBrief is distributed under the Apache License 2.0. See [`LICENSE`](LICENSE).
+
+## Disclaimer
+
+siloBrief is provided as-is. It helps you review files for manual disclosure, but it does not
+decide whether information is safe or authorized to share. Use it with your project's disclosure
+rules and review every output yourself.

--- a/docs/assets/silobrief-wordmark.svg
+++ b/docs/assets/silobrief-wordmark.svg
@@ -1,0 +1,68 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1600 480"
+  role="img"
+  aria-labelledby="title description"
+>
+  <title id="title">siloBrief</title>
+  <desc id="description">
+    The siloBrief wordmark beside a document moving through an open project boundary.
+  </desc>
+
+  <style>
+    .silo-fill { fill: #4f46e5; }
+    .silo-stroke { stroke: #4f46e5; }
+    .brief-fill { fill: #0f766e; }
+    .brief-detail { stroke: #ecfdf5; }
+
+    @media (prefers-color-scheme: dark) {
+      .silo-fill { fill: #818cf8; }
+      .silo-stroke { stroke: #818cf8; }
+      .brief-fill { fill: #2dd4bf; }
+      .brief-detail { stroke: #042f2e; }
+    }
+  </style>
+
+  <g transform="translate(92 70)">
+    <path
+      class="silo-stroke"
+      d="M190 30H86C51 30 30 55 30 90V270C30 305 51 330 86 330H190"
+      fill="none"
+      stroke-width="26"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <path
+      class="brief-fill"
+      d="M142 84H250L296 130V310H142Z"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M250 84V130H296"
+      fill="none"
+      stroke="#ffffff"
+      stroke-opacity="0.72"
+      stroke-width="13"
+      stroke-linejoin="round"
+    />
+    <path
+      class="brief-detail"
+      d="M180 175H258M180 216H258M180 257H231"
+      fill="none"
+      stroke-width="14"
+      stroke-linecap="round"
+    />
+  </g>
+
+  <text
+    x="430"
+    y="316"
+    font-family="Inter, 'Segoe UI', Arial, sans-serif"
+    font-size="242"
+    font-weight="750"
+    letter-spacing="-10"
+  >
+    <tspan class="silo-fill">silo</tspan><tspan class="brief-fill">Brief</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## 변경 사항
- NiaPy 스타일의 README 랜딩 구성으로 영문·한국어 문서를 재정리했습니다.
- 폐쇄망과 사내 개발 환경이라는 핵심 사용 맥락을 명확히 설명했습니다.
- light/dark 테마를 지원하는 siloBrief SVG 워드마크를 추가했습니다.
- 소스 배포물에 워드마크가 포함되도록 manifest를 갱신했습니다.

## 확인
- 전체 unittest 128개 통과, 5개 skip
- 문서 계약 테스트 5개 통과
- wheel 및 sdist 빌드 성공
- sdist의 SVG 포함과 git diff 형식 확인

Refs #86