### PR TITLE
feat(review): guide exact symbol selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Continue an interactive review with an exact indexed Python file path and select its classes or
+  functions, including when lexical search finds no candidates.
+
 ### Changed
 
 - Search comments and docstrings only within their owning module, class, or function instead of
   copying module-wide text into every index node.
 - Run `sb init` once after upgrading to rebuild an existing index with scoped text tokens.
+- Explain the Python-only scope when indexing finds no supported source files or a review has no
+  indexed symbols.
 
 ## [0.2.0] - 2026-08-05
 

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -18,8 +18,10 @@ from silobrief.review import (
     DisclosureChoices,
     ReviewError,
     ReviewSelection,
+    SymbolOption,
     candidate_options,
     review_selection,
+    selector_symbol_options,
 )
 from silobrief.source_review import (
     ApprovedSourceExcerpt,
@@ -51,18 +53,20 @@ def review_brief(
         raise ChatReviewError("request must not be empty")
     if not input_stream.isatty() or not output_stream.isatty():
         raise ChatReviewError("review requires an interactive terminal")
+    if not index.nodes:
+        raise ChatReviewError(
+            "no indexed Python symbols are available; "
+            "siloBrief currently supports Python projects only"
+        )
     _confirm_request(input_stream, output_stream)
 
     try:
         options = candidate_options(rank_candidates(prompt, index, notes))
     except ReviewError as error:
         raise ChatReviewError(str(error)) from error
-    if not options:
-        raise ChatReviewError("no candidate matches the request")
-
     _show_candidates(options, output_stream)
     selected_numbers = _read_numbers(input_stream, output_stream)
-    added = _read_selectors("Add path or node ID", input_stream, output_stream)
+    added = _read_additions(index, input_stream, output_stream)
     excluded = _read_selectors("Exclude path or node ID", input_stream, output_stream)
     try:
         selection = review_selection(
@@ -112,6 +116,8 @@ def review_brief(
 
 def _show_candidates(options: tuple[CandidateOption, ...], output: TextIO) -> None:
     _write(output, "Candidates:\n")
+    if not options:
+        _write(output, "- none\n")
     for option in options:
         evidence = option.evidence
         note = "yes" if evidence.note_match else "no"
@@ -156,6 +162,59 @@ def _read_selectors(label: str, input_stream: TextIO, output_stream: TextIO) -> 
     while value := _read_line(f"{label} (blank to finish): ", input_stream, output_stream):
         values.append(value)
     return tuple(values)
+
+
+def _read_additions(
+    index: IndexData,
+    input_stream: TextIO,
+    output_stream: TextIO,
+) -> tuple[str, ...]:
+    selectors: list[str] = []
+    while selector := _read_line(
+        "Add path or node ID (blank to finish): ", input_stream, output_stream
+    ):
+        try:
+            options = selector_symbol_options(index, selector)
+        except ReviewError as error:
+            raise ChatReviewError(str(error)) from error
+        selectors.append(selector)
+        if options is None:
+            continue
+        _show_symbol_options(selector, options, output_stream)
+        for number in _read_symbol_numbers(input_stream, output_stream):
+            if number > len(options):
+                raise ChatReviewError(f"unknown symbol number: {number}")
+            selectors.append(options[number - 1].node.id)
+    return tuple(selectors)
+
+
+def _show_symbol_options(
+    path: str,
+    options: tuple[SymbolOption, ...],
+    output: TextIO,
+) -> None:
+    _write(output, f"Symbols in `{path}`:\n")
+    if not options:
+        _write(output, "- none\n")
+    for option in options:
+        _write(output, f"{option.number}. {option.node.kind} {option.node.qualified_name}\n")
+
+
+def _read_symbol_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[int, ...]:
+    value = _read_line(
+        "Select symbol numbers from this file (blank for module only): ",
+        input_stream,
+        output_stream,
+    )
+    if not value:
+        return ()
+    try:
+        numbers = tuple(int(part) for part in value.split())
+    except ValueError as error:
+        raise ChatReviewError("symbol numbers must be space-separated positive integers") from error
+    if any(number < 1 for number in numbers):
+        raise ChatReviewError("symbol numbers must be space-separated positive integers")
+    return numbers
 
 
 def _show_selection(selection: ReviewSelection, output: TextIO) -> None:

--- a/src/silobrief/initialization.py
+++ b/src/silobrief/initialization.py
@@ -36,7 +36,18 @@ def initialize_index(start: Path) -> tuple[SourceWarning, ...]:
         save_index(root, render_index_json(index))
     except SetupError as error:
         raise IndexingError(str(error)) from error
-    return before.warnings
+    if before.files:
+        return before.warnings
+    return (
+        *before.warnings,
+        SourceWarning(
+            path=".",
+            reason=(
+                "no supported Python files were found; "
+                "siloBrief currently supports Python projects only"
+            ),
+        ),
+    )
 
 
 def _source_change_message(changes: SourceChanges) -> str:

--- a/src/silobrief/review.py
+++ b/src/silobrief/review.py
@@ -32,6 +32,12 @@ class CandidateOption:
 
 
 @dataclass(frozen=True, slots=True)
+class SymbolOption:
+    number: int
+    node: ReviewNode
+
+
+@dataclass(frozen=True, slots=True)
 class DisclosureChoices:
     paths: bool
     symbols: bool
@@ -66,6 +72,27 @@ def candidate_options(candidates: tuple[RankedCandidate, ...]) -> tuple[Candidat
     return tuple(options[:_MAX_OPTIONS])
 
 
+def selector_symbol_options(
+    index: IndexData,
+    selector: str,
+) -> tuple[SymbolOption, ...] | None:
+    nodes = _node_map(index)
+    if selector in nodes:
+        return None
+    modules = _module_path_map(nodes.values())
+    if selector not in modules:
+        raise ReviewError("file path or node ID is not present in the current index")
+    symbols = sorted(
+        (
+            _review_node(node)
+            for node in nodes.values()
+            if node.path == selector and node.kind != "module"
+        ),
+        key=_symbol_outline_key,
+    )
+    return tuple(SymbolOption(number, node) for number, node in enumerate(symbols, start=1))
+
+
 def review_selection(
     index: IndexData,
     options: tuple[CandidateOption, ...],
@@ -75,9 +102,6 @@ def review_selection(
     excluded: tuple[str, ...],
     fields: DisclosureChoices,
 ) -> ReviewSelection:
-    if not options:
-        raise ReviewError("no ranked candidates are available")
-
     nodes = _node_map(index)
     modules = _module_path_map(nodes.values())
     option_by_number = _option_map(options, nodes)
@@ -199,3 +223,7 @@ def _index_node_key(node: IndexNode) -> tuple[str, int, str, str, str]:
 
 def _review_node_key(node: ReviewNode) -> tuple[str, int, str, str, str]:
     return node.path, _KIND_ORDER[node.kind], node.name, node.qualified_name, node.id
+
+
+def _symbol_outline_key(node: ReviewNode) -> tuple[str, int, str]:
+    return node.qualified_name, _KIND_ORDER[node.kind], node.id

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -109,6 +109,7 @@ def prepare_project(project: Path) -> Path:
 
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\n"
 NO_SOURCE_REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\nn\n"
+GUIDED_REVIEW_INPUT = "y\n\npackage/service.py\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\n"
 
 
 def run_chat(
@@ -193,6 +194,75 @@ class ChatCommandTests(unittest.TestCase):
             self.assertTrue(destination.is_file())
             self.assertFalse(destination.with_name("context-only.sources.md").exists())
             self.assertIn('source_companion: "none"', destination.read_text(encoding="utf-8"))
+
+    def test_selects_an_approved_source_from_a_file_outline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            output = ".silobrief/exports/guided.md"
+
+            result, _, stdout, stderr = run_chat(
+                project,
+                output,
+                GUIDED_REVIEW_INPUT + "WRITE\n",
+            )
+
+            destination = project / output
+            source_destination = destination.with_name("guided.sources.md")
+            self.assertEqual(result, 0)
+            self.assertEqual(stderr, "")
+            self.assertIn("Symbols in `package/service.py`:", stdout)
+            self.assertIn("1. function run", stdout)
+            generated = source_destination.read_text(encoding="utf-8")
+            self.assertIn("def run():", generated)
+            self.assertNotIn("private-boundary-canary", generated)
+
+    def test_rejects_an_invalid_guided_symbol_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            output = ".silobrief/exports/invalid-guided.md"
+
+            result, _, _, stderr = run_chat(
+                project,
+                output,
+                "y\n\npackage/service.py\n2\n",
+            )
+
+            self.assertEqual(result, 4)
+            self.assertIn("unknown symbol number", stderr)
+            self.assertFalse((project / output).exists())
+            self.assertFalse((project / ".silobrief/exports/invalid-guided.sources.md").exists())
+
+    def test_explains_python_only_scope_when_index_has_no_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "src" / "App.tsx"
+            source.parent.mkdir()
+            source.write_text(
+                "export function App() { return <button>Start</button>; }\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            before = source.read_bytes()
+            self.assertEqual(main(["setup", str(project)]), 0)
+            init_stderr = io.StringIO()
+            with (
+                working_directory(project),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(init_stderr),
+            ):
+                self.assertEqual(main(["init"]), 0)
+
+            output = ".silobrief/exports/frontend.md"
+            result, _, _, chat_stderr = run_chat(project, output, "y\n\n\n")
+
+            self.assertIn("no supported Python files were found", init_stderr.getvalue())
+            self.assertEqual(result, 4)
+            self.assertIn("siloBrief currently supports Python projects only", chat_stderr)
+            self.assertFalse((project / output).exists())
+            self.assertFalse((project / ".silobrief/exports/frontend.sources.md").exists())
+            self.assertEqual(source.read_bytes(), before)
 
     def test_maps_invalid_input_and_index_state_to_contract_codes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -89,7 +89,7 @@ def source_notes() -> NotesData:
     )
 
 
-APPROVED_INPUT = "y\n1\nsrc/direct.py\n\nsrc/direct.py\n\ny\ny\ny\ny\ny\n"
+APPROVED_INPUT = "y\n1\nsrc/direct.py\n\n\nsrc/direct.py\n\ny\ny\ny\ny\ny\n"
 
 
 def disclosure_counts(rendered: RenderedBrief) -> tuple[int, int, int, int, int]:
@@ -138,11 +138,12 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("path=1", visible)
         self.assertIn("connected=1", visible)
         hidden_values = (
-            "source-body-canary|internal-real-name|.models.SyncResult|src/direct.py|src/second.py|"
+            "source-body-canary|internal-real-name|.models.SyncResult|src/second.py|"
             "second-hop-canary|unselected-note-canary|root-id"
         )
         for hidden in hidden_values.split("|"):
             self.assertNotIn(hidden, visible + rendered.main_markdown)
+        self.assertNotIn("src/direct.py", rendered.main_markdown)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
         rendered = review_brief(
@@ -158,10 +159,84 @@ class ChatReviewTests(unittest.TestCase):
         for title in ("사용자 작성 메모", "등록된 경계", "소스 동반 파일"):
             self.assertNotIn(f"## {title}", rendered.main_markdown)
 
+    def test_recovers_from_empty_candidates_with_a_file_outline(self) -> None:
+        module = node("module", "src/guided.py", "module", "guided")
+        service = node("service", "src/guided.py", "class", "Service")
+        method = node("method", "src/guided.py", "function", "run", "Service.run")
+        index = IndexData(
+            config_digest="a" * 64,
+            edges=(),
+            index_version=1,
+            nodes=(method, module, service),
+            source_digest="b" * 64,
+            stale=False,
+        )
+        output = TtyBuffer()
+
+        rendered = review_brief(
+            "no matching terms",
+            index,
+            NotesData(notes=[], notes_version=1),
+            input_stream=TtyBuffer("y\n\nsrc/guided.py\n1 1\n\n\ny\ny\nn\nn\nn\n"),
+            output_stream=output,
+        )
+        node_id_output = TtyBuffer()
+        selected_by_id = review_brief(
+            "no matching terms",
+            index,
+            NotesData(notes=[], notes_version=1),
+            input_stream=TtyBuffer("y\n\nmodule\nservice\n\n\ny\ny\nn\nn\nn\n"),
+            output_stream=node_id_output,
+        )
+
+        visible = output.getvalue()
+        self.assertEqual(rendered, selected_by_id)
+        self.assertIn("Candidates:\n- none", visible)
+        self.assertIn("Symbols in `src/guided.py`:", visible)
+        self.assertIn("1. class Service", visible)
+        self.assertIn("2. function Service.run", visible)
+        outline = visible.split("Symbols in `src/guided.py`:\n", 1)[1].split(
+            "Select symbol numbers", 1
+        )[0]
+        self.assertNotIn("module guided", outline)
+        self.assertNotIn("Symbols in", node_id_output.getvalue())
+        self.assertIn("class Service", visible)
+        self.assertIn("src/guided.py", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.symbol_names, 2)
+
+    def test_rejects_unknown_file_and_invalid_outline_number(self) -> None:
+        module = node("module", "src/guided.py", "module", "guided")
+        function = node("function", "src/guided.py", "function", "run")
+        index = IndexData(
+            config_digest="a" * 64,
+            edges=(),
+            index_version=1,
+            nodes=(module, function),
+            source_digest="b" * 64,
+            stale=False,
+        )
+        cases = (
+            ("y\n\n../secret.py\n", "not present in the current index"),
+            ("y\n\nsrc/guided.py\n-1\n", "positive integers"),
+            ("y\n\nsrc/guided.py\n0\n", "symbol number"),
+            ("y\n\nsrc/guided.py\none\n", "positive integers"),
+            ("y\n\nsrc/guided.py\n2\n", "symbol number"),
+        )
+        for input_text, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ChatReviewError, message):
+                    review_brief(
+                        "no matching terms",
+                        index,
+                        NotesData(notes=[], notes_version=1),
+                        input_stream=TtyBuffer(input_text),
+                        output_stream=TtyBuffer(),
+                    )
+
     def test_rejects_invalid_or_empty_review_input(self) -> None:
         cases = (
             (" ", "", "request"),
-            ("absent", "y\n", "candidate"),
+            ("absent", "y\n", "start selection"),
             ("retry", "y\n2\n\n\n", "candidate number"),
             ("retry", "y\n1\n\n\nY\n", "y or n"),
         )

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from unittest import mock
 
 from silobrief.cli import main
+from silobrief.current_index import load_current_index
+from silobrief.review import ReviewError, selector_symbol_options
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPOSITORY_ROOT / "examples" / "model-validation-fixture"
@@ -201,6 +203,79 @@ def generate_packets(destination_root: Path) -> tuple[GeneratedPacket, ...]:
 
 
 class ModelValidationTests(unittest.TestCase):
+    def test_guided_outline_cannot_select_a_symlinked_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            project.mkdir()
+            outside = root / "outside.py"
+            outside.write_text(
+                "SYMLINK_GUIDED_CANARY = True\n\ndef outside_function():\n    return None\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            linked = project / "linked.py"
+            try:
+                linked.symlink_to(outside)
+            except OSError as error:
+                self.skipTest(f"symbolic links unavailable: {error}")
+
+            terminal = TtyBuffer()
+            with contextlib.redirect_stdout(terminal), contextlib.redirect_stderr(terminal):
+                self.assertEqual(main(["setup", str(project)]), 0)
+                with working_directory(project):
+                    self.assertEqual(main(["init"]), 0)
+            index, _ = load_current_index(project)
+
+        self.assertNotIn("SYMLINK_GUIDED_CANARY", repr(index))
+        with self.assertRaisesRegex(ReviewError, "not present in the current index"):
+            selector_symbol_options(index, "linked.py")
+
+    def test_guided_outline_covers_the_three_frozen_task_files(self) -> None:
+        expected = {
+            "src/parcel_lab/retry.py": (("function", "retry_request"),),
+            "src/parcel_lab/labels.py": (
+                ("class", "LabelOptions"),
+                ("function", "format_label"),
+            ),
+            "src/parcel_lab/cleanup.py": (("function", "choose_reference"),),
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "fixture"
+            shutil.copytree(FIXTURE_ROOT, project)
+            terminal = TtyBuffer()
+            with contextlib.redirect_stdout(terminal), contextlib.redirect_stderr(terminal):
+                self.assertEqual(main(["setup", str(project)]), 0)
+                with working_directory(project):
+                    self.assertEqual(
+                        main(
+                            [
+                                "ignore",
+                                "private_adapter",
+                                "--as",
+                                "External delivery adapter",
+                                "--alias",
+                                "delivery-boundary",
+                            ]
+                        ),
+                        0,
+                    )
+                    self.assertEqual(main(["init"]), 0)
+            index, _ = load_current_index(project)
+
+        for path, symbols in expected.items():
+            with self.subTest(path=path):
+                options = selector_symbol_options(index, path)
+                self.assertIsNotNone(options)
+                self.assertEqual(
+                    tuple(
+                        (option.node.kind, option.node.qualified_name) for option in options or ()
+                    ),
+                    symbols,
+                )
+        with self.assertRaisesRegex(ReviewError, "not present in the current index"):
+            selector_symbol_options(index, "private_adapter/client.py")
+
     def test_frozen_packets_match_current_cli_and_preserve_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as first_directory:
             first = generate_packets(Path(first_directory))

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import asdict, replace
+from unittest import mock
 
 from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
 from silobrief.ranking import RankedCandidate, RankEvidence
@@ -12,15 +13,22 @@ from silobrief.review import (
     ReviewNode,
     candidate_options,
     review_selection,
+    selector_symbol_options,
 )
 
 
-def node(node_id: str, path: str, kind: NodeKind, name: str) -> IndexNode:
+def node(
+    node_id: str,
+    path: str,
+    kind: NodeKind,
+    name: str,
+    qualified_name: str | None = None,
+) -> IndexNode:
     return IndexNode(
         id=node_id,
         kind=kind,
         name=name,
-        qualified_name=name,
+        qualified_name=qualified_name or name,
         path=path,
         tokens=NodeTokens(
             path=("raw-canary",),
@@ -84,6 +92,56 @@ class CandidateOptionTests(unittest.TestCase):
         self.assertEqual(options[0].evidence, source[1].evidence)
         self.assertFalse(hasattr(options[0].node, "tokens"))
         self.assertNotIn("raw-canary", repr(tuple(asdict(option) for option in options)))
+
+
+class SelectorSymbolOptionTests(unittest.TestCase):
+    def test_lists_indexed_symbols_in_a_deterministic_safe_order(self) -> None:
+        module = node("module", "src/service.py", "module", "service")
+        service = node("service", "src/service.py", "class", "Service")
+        method = node("method", "src/service.py", "function", "run", "Service.run")
+        helper = node("helper", "src/service.py", "function", "helper")
+        other = node("other", "src/other.py", "function", "other")
+        source = index(other, helper, method, module, service)
+
+        blocked = AssertionError("outline must use the current index only")
+        with (
+            mock.patch("builtins.open", side_effect=blocked),
+            mock.patch("pathlib.Path.open", side_effect=blocked),
+            mock.patch("pathlib.Path.iterdir", side_effect=blocked),
+            mock.patch("os.scandir", side_effect=blocked),
+            mock.patch("ast.parse", side_effect=blocked),
+        ):
+            options = selector_symbol_options(source, "src/service.py")
+        reordered = selector_symbol_options(
+            replace(source, nodes=tuple(reversed(source.nodes))), "src/service.py"
+        )
+
+        self.assertEqual(options, reordered)
+        self.assertEqual([option.number for option in options or ()], [1, 2, 3])
+        self.assertEqual(
+            [option.node.id for option in options or ()],
+            ["service", "method", "helper"],
+        )
+        self.assertNotIn("raw-canary", repr(options))
+        self.assertIsNone(selector_symbol_options(source, "service"))
+
+    def test_returns_an_empty_outline_and_rejects_unknown_selectors(self) -> None:
+        module = node("module", "src/empty.py", "module", "empty")
+        source = index(module)
+
+        self.assertEqual(selector_symbol_options(source, "src/empty.py"), ())
+        for selector in (
+            "src/missing.py",
+            "../secret.py",
+            "/src/empty.py",
+            "C:/project/src/empty.py",
+            "src\\empty.py",
+            "src\\nested/empty.py",
+            "src",
+        ):
+            with self.subTest(selector=selector):
+                with self.assertRaisesRegex(ReviewError, "not present in the current index"):
+                    selector_symbol_options(source, selector)
 
 
 class ReviewSelectionTests(unittest.TestCase):
@@ -157,13 +215,39 @@ class ReviewSelectionTests(unittest.TestCase):
 
         self.assertEqual([item.id for item in result.selected], ["direct"])
 
+    def test_allows_direct_selection_when_ranked_candidates_are_empty(self) -> None:
+        module = node("module", "src/work.py", "module", "work")
+        function = node("function", "src/work.py", "function", "run")
+
+        result = review_selection(
+            index(function, module),
+            (),
+            selected_numbers=(),
+            added=("src/work.py", "function"),
+            excluded=(),
+            fields=FIELDS,
+        )
+
+        self.assertEqual([item.id for item in result.selected], ["module", "function"])
+
+        by_node_id = review_selection(
+            index(function, module),
+            (),
+            selected_numbers=(),
+            added=("module", "function"),
+            excluded=(),
+            fields=FIELDS,
+        )
+        self.assertEqual(result, by_node_id)
+
     def test_rejects_missing_candidates_selections_and_unknown_references(self) -> None:
         root = node("root", "root.py", "module", "root")
         options = candidate_options((ranked(root, 4),))
         source_index = index(root)
 
         cases = (
-            ((), (), (), (), "ranked candidates"),
+            ((), (), (), (), "start selection"),
+            ((), (1,), (), (), "candidate number"),
             (options, (2,), (), (), "candidate number"),
             (options, (), ("missing.py",), (), "selector"),
             (options, (1,), (), ("missing",), "selector"),


### PR DESCRIPTION
## 변경 사항

- lexical 후보가 없어도 정확한 indexed Python 파일 경로를 입력해 class/function 목록을 확인할 수 있게 했습니다.
- 파일 목록에서 고른 심볼을 기존 선택·그래프 확장·source preview 흐름에 연결했습니다.
- 지원되는 Python 파일이 하나도 없으면 `sb init`에서 경고하고, `sb chat`에서 Python 전용 범위를 명확히 설명하며 출력을 차단합니다.
- 경로·번호 오류, 빈 후보 복구, symlink 경계, 실제 프론트엔드 형태의 빈 인덱스 회귀 테스트를 추가했습니다.

## 이유

기존 lexical 검색이 정확한 심볼을 놓치면 사용자가 파일 경로를 알고 있어도 긴 node ID 없이는 source를 선택하기 어려웠습니다. 또한 순수 프론트엔드 프로젝트에서는 빈 인덱스를 만든 뒤 `start selection is empty`라는 내부적인 오류만 표시해 지원 범위를 이해하기 어려웠습니다.

## 사용자 영향

Python 프로젝트 사용자는 검색 결과가 비어도 알고 있는 파일 경로에서 필요한 심볼을 직접 선택할 수 있습니다. 지원 범위 밖의 프로젝트는 소스나 Markdown을 생성하지 않고 Python 전용이라는 설명을 받습니다. CLI 명령과 persisted schema는 변경하지 않습니다.

## 검증

- `python -m unittest discover -s tests -v`: 139 tests OK, 6 skipped (Windows symlink privilege)
- `ruff check .`: passed
- `ruff format --check .`: passed
- `mypy`: passed under strict configuration
- 순수 React/Next/Nuxt 계열 공개 저장소 5개: 명확한 경고·종료 코드 4·출력 0건·원본 변경 0건

Refs #97