### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-06
+
 ### Added
 
 - Continue an interactive review with an exact indexed Python file path and select its classes or
@@ -19,6 +21,15 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Run `sb init` once after upgrading to rebuild an existing index with scoped text tokens.
 - Explain the Python-only scope when indexing finds no supported source files or a review has no
   indexed symbols.
+
+### Known limitations
+
+- Source indexing supports Python only. A project with no indexed Python symbols is rejected before
+  review instead of producing an empty brief.
+- Exact-path recovery is guided selection, not semantic retrieval; the user must know an indexed
+  relative Python file path.
+- GPT and independent real-project validation remain follow-up work. This release does not
+  establish cross-model effectiveness, security, or demand.
 
 ## [0.2.0] - 2026-08-05
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-4f46e5" alt="릴리스 v0.2.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="릴리스 v0.3.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -63,7 +63,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 0.2.0
+siloBrief 0.3.0
 ```
 
 ## 명령어
@@ -128,7 +128,8 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 
 `chat`을 실행하면 다음 순서로 진행됩니다.
 
-1. 요청한 작업이 맞는지 확인하고 관련 함수나 클래스를 고릅니다.
+1. 요청한 작업이 맞는지 확인하고 관련 함수나 클래스를 고릅니다. 추천 후보에 원하는 코드가
+   없다면 색인에 있는 Python 파일의 정확한 상대 경로를 입력한 뒤 함수나 클래스를 고릅니다.
 2. AI 요청 문서에 넣을 프로젝트 정보를 하나씩 검토합니다.
 3. 화면에 표시된 소스 코드를 첨부할지 선택합니다. 기본값은 `아니요`입니다.
 4. 제외 영역의 실제 식별자가 노출될 때는 내용을 확인한 뒤 `EXPOSE`를 입력해야 합니다.
@@ -176,12 +177,14 @@ siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아
 
 ## 검증 현황
 
-현재 공개 버전은 v0.2.0입니다. Windows와 Ubuntu에서 같은 패키지와 같은 입력으로 동일한
-Markdown이 생성되는 것을 확인했습니다. Claude에는 예제 코드 유지보수 과제 세 개를 전달했고,
-세 과제 모두 요구한 형식의 답변을 받았습니다.
+현재 공개 버전은 v0.3.0입니다. v0.2의 검토·출력 방식을 그대로 유지하면서, 추천 결과에 원하는
+코드가 없을 때 정확한 파일 경로로 함수와 클래스를 찾는 기능을 추가했습니다. 색인에 지원하는
+Python 심볼이 하나도 없으면 빈 문서를 만들지 않고 지원 범위를 분명하게 안내합니다.
 
-GPT 검증은 후속 과제입니다. 현재 결과만으로 여러 AI 모델, 실제 비공개 프로젝트, 독립 사용자에게
-동일한 효과가 있다고 말할 수는 없습니다.
+v0.2 패키지는 Windows와 Ubuntu에서 같은 입력으로 동일한 Markdown을 만들었고, Claude에 전달한
+합성 코드 유지보수 과제 세 개도 모두 요구한 형식의 답변을 받았습니다. GPT 검증은 후속 과제입니다.
+현재 결과만으로 여러 AI 모델, 실제 비공개 프로젝트, 독립 사용자에게 같은 효과가 있다고 말할 수는
+없습니다.
 
 - [설치 wheel 검증](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [수동 모델 평가 절차](validation/v0.2/MANUAL_MODEL_GATE.md)
@@ -199,7 +202,7 @@ GPT 검증은 후속 과제입니다. 현재 결과만으로 여러 AI 모델, �
 
 ## 문서
 
-- [v0.2 동작 계약](docs/V0_2_CONTRACT.md)
+- [출력 및 보호 범위 계약](docs/V0_2_CONTRACT.md)
 - [보안 문제 신고 안내](SECURITY.md)
 
 ## 기여하기

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-4f46e5" alt="Release v0.2.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="Release v0.3.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -61,7 +61,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 0.2.0
+siloBrief 0.3.0
 ```
 
 ## Commands
@@ -123,7 +123,8 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 
 During `chat`:
 
-1. Confirm the task and choose the relevant function or class.
+1. Confirm the task and choose the relevant function or class. If the suggested candidates miss
+   the target, enter an exact indexed Python file path and select its functions or classes.
 2. Review each proposed project field.
 3. Choose whether to include the displayed source code. The default answer is no.
 4. If the source reveals an excluded boundary identifier, type `EXPOSE` only after reviewing it.
@@ -169,10 +170,13 @@ disclosure. Review every generated file under your organization's disclosure rul
 
 ## Validation status
 
-The current release is v0.2.0. The same package produced identical Markdown files on Windows and
-Ubuntu. Claude completed three example code-maintenance tasks using those files.
-GPT validation remains follow-up work. These results do not establish effectiveness across
-models, real private projects, or independent users.
+The current release is v0.3.0. It keeps the reviewed v0.2 output flow and adds exact-path symbol
+selection when lexical suggestions miss the intended code. It also stops before review with a clear
+Python-only message when the index contains no supported symbols.
+
+The v0.2 package produced identical Markdown files on Windows and Ubuntu, and Claude completed three
+synthetic code-maintenance tasks using those files. GPT validation remains follow-up work. These
+results do not establish effectiveness across models, real private projects, or independent users.
 
 - [Installed wheel verification](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [Manual model gate](validation/v0.2/MANUAL_MODEL_GATE.md)
@@ -190,7 +194,7 @@ models, real private projects, or independent users.
 
 ## Documentation
 
-- [v0.2 behavior contract](docs/V0_2_CONTRACT.md)
+- [Output and safety contract](docs/V0_2_CONTRACT.md)
 - [Security policy](SECURITY.md)
 
 ## Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,11 @@
 
 | Version | Supported |
 |---|---|
-| 0.2.x | :white_check_mark: |
+| 0.3.x | :white_check_mark: |
+| 0.2.x | :x: |
 | 0.1.x | :x: |
 
-The latest 0.2.x release is the currently supported line.
+The latest 0.3.x release is the currently supported line.
 
 ## Reporting a vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "0.2.0"
+version = "0.3.0"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,4 +41,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 0.2.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 0.3.0\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -21,6 +21,7 @@ README_EXPECTATIONS = {
 CHANGELOG_EXPECTATIONS = (*PUBLIC_COMMANDS[:-1], "WRITE", "parcel-sync-fixture")
 V0_1_RELEASE_DATE = "2026-08-04"
 V0_2_RELEASE_DATE = "2026-08-05"
+V0_3_RELEASE_DATE = "2026-08-06"
 BRIEF_GUIDANCE_EXPECTATIONS = {
     "README.md": (
         "concrete task",
@@ -75,31 +76,34 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 for fragment in fragments:
                     self.assertIn(fragment, text)
 
-    def test_v0_2_release_metadata_is_current(self) -> None:
+    def test_v0_3_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn(f"## [0.3.0] - {V0_3_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.2.0] - {V0_2_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.1.0] - {V0_1_RELEASE_DATE}", changelog)
         for fragment in ("### Added", "### Fixed", "### Known limitations", "source bodies"):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("The current release is v0.2.0.", readme)
+        self.assertIn("The current release is v0.3.0.", readme)
+        self.assertIn("exact indexed Python file path", readme)
         self.assertIn("GPT validation remains follow-up work", readme)
         self.assertIn("docs/V0_2_CONTRACT.md", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
-        self.assertIn("현재 공개 버전은 v0.2.0입니다.", readme_ko)
+        self.assertIn("현재 공개 버전은 v0.3.0입니다.", readme_ko)
+        self.assertIn("색인에 있는 Python 파일의 정확한 상대 경로", readme_ko)
         self.assertIn("GPT 검증은 후속 과제", readme_ko)
         self.assertIn("docs/V0_2_CONTRACT.md", readme_ko)
 
         security = (REPOSITORY_ROOT / "SECURITY.md").read_text(encoding="utf-8")
-        self.assertIn("| 0.2.x | :white_check_mark: |", security)
-        self.assertIn("| 0.1.x | :x: |", security)
+        self.assertIn("| 0.3.x | :white_check_mark: |", security)
+        self.assertIn("| 0.2.x | :x: |", security)
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "0.2.0"'), 1)
-        self.assertEqual(version("silobrief"), "0.2.0")
+        self.assertEqual(pyproject.count('version = "0.3.0"'), 1)
+        self.assertEqual(version("silobrief"), "0.3.0")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())


### PR DESCRIPTION
## 변경 내용

- 패키지와 CLI 표시 버전을 `0.3.0`으로 갱신
- 영문·한국어 README에 정확한 Python 파일 경로 기반 심볼 선택과 Python 전용 한계 반영
- CHANGELOG에 v0.3.0 변경점과 남은 한계 기록
- 지원 버전을 0.3.x로 갱신
- 릴리스 문서·CLI 버전 회귀 테스트 갱신

## 검증

- `python -m unittest discover -s tests`: 139 tests run, OK (6 skipped for Windows symlink privilege)
- `python -m ruff check .`: pass
- `python -m ruff format --check .`: pass
- `python -m mypy`: pass
- wheel·sdist 로컬 빌드: pass
- 새 venv에 wheel을 `--no-index --no-deps`로 설치
- 설치된 wheel의 CLI·공개 fixture 핵심 테스트: 18 tests run, OK (1 skipped)
- 설치된 `sb --version`: `siloBrief 0.3.0`

## 범위

새 기능은 추가하지 않고 이미 병합된 v0.3 범위의 릴리스 정보만 정리합니다.

Refs #99