### PR TITLE
feat(boundary): remove registered boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Remove one registered boundary by its exact stored path or alias with `sb unignore`, leaving the
+  current index stale until the user runs `sb init` again.
+
 ## [0.3.0] - 2026-08-06
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -72,6 +72,7 @@ siloBrief 0.3.0
 |---|---|
 | `sb setup [PATH]` | 기존 프로젝트에 siloBrief 작업 공간을 만듭니다. |
 | `sb ignore PATH --as TEXT [--alias NAME]` | 읽지 않을 경로와 그 영역을 대신할 공개용 이름을 등록합니다. |
+| `sb unignore SELECTOR` | 저장된 상대 경로나 별칭으로 등록 경계 하나를 해제합니다. |
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
 | `sb chat "PROMPT" --out FILE` | 전달할 내용을 검토하고 AI 요청 문서와 선택적 코드 첨부 파일을 만듭니다. |
@@ -115,6 +116,20 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 이 과정에서 `setup`은 작업 공간을 만들고, `ignore`는 읽으면 안 되는 경로를 등록합니다. `init`은
 나머지 Python 파일을 분석해 색인을 만들고, `chat`은 작업과 관련 있어 보이는 정보를 찾아
 검토 대상으로 보여줍니다.
+
+### 등록한 제외 경로 해제하기
+
+잘못 등록했거나 더 이상 제외할 필요가 없는 경계는 저장된 상대 경로나 별칭으로 해제한 뒤 색인을
+다시 만듭니다.
+
+```console
+sb unignore delivery-boundary
+sb init
+```
+
+`unignore`는 설정만 바꾸며 해제할 경로의 파일을 열지 않습니다. 기존 색인은 즉시 오래된 상태로
+표시되므로 `sb init`이 끝나기 전까지 `sb chat`을 실행할 수 없습니다. 색인을 다시 만들면 해당
+경로의 파일이 검토 대상이나 코드 첨부 후보로 나타날 수 있습니다.
 
 ### 프로젝트 정보 더하기
 
@@ -164,6 +179,7 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 
 - 색인을 만들 때 심볼릭 링크를 따라가지 않습니다.
 - 등록된 제외 디렉터리 안의 파일을 열지 않습니다.
+- 등록을 해제하는 동안 해당 경로의 파일을 열지 않습니다.
 - 제외된 코드에 대한 참조는 승인한 공개용 이름으로 바꿔 AI 요청 문서에 표시합니다.
 - 파일을 쓰기 전에 전체 미리보기와 사용자 승인을 요구합니다.
 - 네트워크 연결, 언어 모델 호출, 자동 파일 전송을 하지 않습니다.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ siloBrief 0.3.0
 |---|---|
 | `sb setup [PATH]` | Adds or checks local siloBrief state in an existing project. |
 | `sb ignore PATH --as TEXT [--alias NAME]` | Excludes a path and records a public label for that boundary. |
+| `sb unignore SELECTOR` | Removes one registered boundary by its exact stored path or alias. |
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
 | `sb chat "PROMPT" --out FILE` | Reviews context and writes the main brief and optional code attachment. |
@@ -111,6 +112,20 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 `setup` prepares local state, `ignore` registers a path that must not be read, and `init` builds a
 local search list from the remaining Python files. `chat` then proposes relevant project context
 for review.
+
+### Remove a registered boundary
+
+If an ignore entry is no longer correct, remove it by the exact stored path or alias, then rebuild
+the index:
+
+```console
+sb unignore delivery-boundary
+sb init
+```
+
+`unignore` changes only local configuration and does not open the removed path. It marks an existing
+index as stale, so `sb chat` remains blocked until `sb init` finishes. After rebuilding, files below
+that path may be offered for review and source disclosure.
 
 ### Complete review
 
@@ -159,6 +174,7 @@ siloBrief:
 
 - does not follow symbolic links while indexing;
 - does not open registered excluded subtrees;
+- does not open a boundary target while removing its registration;
 - replaces references to excluded code with an approved public label in the main brief;
 - requires a preview before writing output; and
 - uses no network connection, language model, or automatic transfer.

--- a/src/silobrief/boundaries.py
+++ b/src/silobrief/boundaries.py
@@ -71,14 +71,45 @@ def register_boundary(
         default_excludes=list(config["default_excludes"]),
         schema_version=1,
     )
+    _save_config_with_stale_index(root, updated)
+    return RegistrationResult(boundary=boundary, changed=True)
+
+
+def unregister_boundary(selector: str, *, start: Path) -> BoundaryData:
+    if not selector.strip():
+        raise SetupError("boundary selector must not be empty")
+
+    root = find_project_root(start)
+    config = load_config(root)
+    boundaries = config["boundaries"]
+    matches = [
+        boundary
+        for boundary in boundaries
+        if selector == boundary["path"] or selector == boundary["alias"]
+    ]
+    if not matches:
+        raise SetupError("boundary selector is not registered")
+    if len(matches) > 1:
+        raise SetupError("boundary selector matches more than one registered boundary")
+
+    boundary = matches[0]
+    updated = ConfigData(
+        boundaries=[item for item in boundaries if item != boundary],
+        default_excludes=list(config["default_excludes"]),
+        schema_version=1,
+    )
+    _save_config_with_stale_index(root, updated)
+    return boundary
+
+
+def _save_config_with_stale_index(root: Path, config: ConfigData) -> None:
     index_snapshot = _snapshot_index(root)
     try:
         mark_index_stale(root)
-        save_config(root, updated)
+        save_config(root, config)
     except SetupError:
         _restore_snapshot(index_snapshot)
         raise
-    return RegistrationResult(boundary=boundary, changed=True)
 
 
 def _boundary_path(root: Path, start: Path, path_text: str) -> str:

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from silobrief import __version__
-from silobrief.boundaries import register_boundary
+from silobrief.boundaries import register_boundary, unregister_boundary
 from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
@@ -43,6 +43,8 @@ def _build_parser() -> argparse.ArgumentParser:
     ignore.add_argument("path")
     ignore.add_argument("--as", dest="description", required=True)
     ignore.add_argument("--alias")
+    unignore = subcommands.add_parser("unignore", help="Remove a registered project boundary.")
+    unignore.add_argument("selector")
     subcommands.add_parser("init", help="Build the local source index.")
     log = subcommands.add_parser("log", help="Record public project context.")
     log.add_argument("path")
@@ -91,6 +93,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print(f"boundary {boundary['alias']} for {boundary['path']} is already registered")
+
+    if arguments.command == "unignore":
+        selector = arguments.selector
+        if not isinstance(selector, str):
+            parser.error("unignore selector must be text")
+        try:
+            boundary = unregister_boundary(selector, start=Path.cwd())
+        except SetupError as error:
+            parser.error(str(error))
+        print(
+            f"removed boundary {boundary['alias']} for {boundary['path']}; "
+            "run sb init before sb chat"
+        )
 
     if arguments.command == "init":
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.code, 2)
         self.assertIn("usage: sb", stderr.getvalue())
-        self.assertIn("{setup,ignore,init,log,chat}", stderr.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,chat}", stderr.getvalue())
 
     def test_help_lists_commands_and_succeeds(self) -> None:
         stdout = io.StringIO()
@@ -27,7 +27,7 @@ class CommandLineTests(unittest.TestCase):
             main(["--help"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertIn("{setup,ignore,init,log,chat}", stdout.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,chat}", stdout.getvalue())
 
 
 class VersionCommandTests(unittest.TestCase):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -9,6 +9,7 @@ FIXTURE_README = "examples/parcel-sync-fixture/README.md"
 PUBLIC_COMMANDS = (
     "sb setup",
     "sb ignore",
+    "sb unignore",
     "sb init",
     "sb log",
     "sb chat",

--- a/tests/test_unignore.py
+++ b/tests/test_unignore.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import stat
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from typing import cast
+from unittest import mock
+
+from silobrief.cli import main
+from silobrief.state import BoundaryData, SetupError
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def boundaries(project: Path) -> list[BoundaryData]:
+    value: object = json.loads((project / ".silobrief" / "config.json").read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("config must be an object")
+    raw = value.get("boundaries")
+    if not isinstance(raw, list):
+        raise AssertionError("boundaries must be an array")
+    return cast(list[BoundaryData], raw)
+
+
+def state_snapshot(project: Path) -> dict[str, tuple[bytes, int, int]]:
+    state = project / ".silobrief"
+    result: dict[str, tuple[bytes, int, int]] = {}
+    for name in ("config.json", "index.json"):
+        path = state / name
+        if path.is_file():
+            metadata = path.stat()
+            result[name] = (
+                path.read_bytes(),
+                metadata.st_mtime_ns,
+                stat.S_IMODE(metadata.st_mode),
+            )
+    return result
+
+
+def run_silently(arguments: list[str]) -> int:
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        return main(arguments)
+
+
+class UnignoreCommandTests(unittest.TestCase):
+    def assert_unignore_error(self, selector: str) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main(["unignore", selector])
+        self.assertEqual(caught.exception.code, 2)
+        message = stderr.getvalue()
+        self.assertNotIn("invalid choice", message)
+        return message
+
+    def test_removes_boundary_by_path_without_requiring_the_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            private = project / "private"
+            private.mkdir()
+            (private / "secret.py").write_text("SECRET = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private",
+                            "--as",
+                            "Private adapter",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+
+            (private / "secret.py").unlink()
+            private.rmdir()
+            stdout = io.StringIO()
+            with working_directory(project), contextlib.redirect_stdout(stdout):
+                self.assertEqual(main(["unignore", "private"]), 0)
+
+            self.assertEqual(boundaries(project), [])
+            index: object = json.loads(
+                (project / ".silobrief" / "index.json").read_text(encoding="utf-8")
+            )
+            self.assertIsInstance(index, dict)
+            self.assertIs(cast(dict[str, object], index).get("stale"), True)
+            self.assertIn("private-boundary", stdout.getvalue())
+            self.assertIn("private", stdout.getvalue())
+            self.assertIn("sb init", stdout.getvalue())
+
+    def test_removes_only_the_boundary_selected_by_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            for name in ("first.py", "second.py"):
+                (project / name).write_text("VALUE = 1\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        ["ignore", "first.py", "--as", "First", "--alias", "first-boundary"]
+                    ),
+                    0,
+                )
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "second.py",
+                            "--as",
+                            "Second",
+                            "--alias",
+                            "second-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                self.assertEqual(run_silently(["unignore", "first-boundary"]), 0)
+
+            self.assertEqual(
+                boundaries(project),
+                [
+                    {
+                        "alias": "second-boundary",
+                        "description": "Second",
+                        "path": "second.py",
+                    }
+                ],
+            )
+
+    def test_rejects_unknown_default_empty_and_ambiguous_selectors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "shared").mkdir()
+            (project / "other").mkdir()
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(["ignore", "shared", "--as", "Shared path", "--alias", "first"]),
+                    0,
+                )
+                self.assertEqual(
+                    run_silently(["ignore", "other", "--as", "Other path", "--alias", "shared"]),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                before = state_snapshot(project)
+                for selector in ("missing", ".git/", "", "shared"):
+                    with self.subTest(selector=selector):
+                        self.assert_unignore_error(selector)
+                        self.assertEqual(state_snapshot(project), before)
+
+    def test_stale_index_blocks_chat_until_reinitialized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "public.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+            (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private.py",
+                            "--as",
+                            "Private module",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                self.assertEqual(run_silently(["unignore", "private-boundary"]), 0)
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    result = main(
+                        [
+                            "chat",
+                            "Review run",
+                            "--out",
+                            ".silobrief/exports/brief.md",
+                        ]
+                    )
+                self.assertEqual(result, 4)
+                self.assertIn("index is stale; run sb init", stderr.getvalue())
+                self.assertFalse((project / ".silobrief" / "exports" / "brief.md").exists())
+                self.assertEqual(run_silently(["init"]), 0)
+
+    def test_preserves_state_when_index_or_config_update_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private.py",
+                            "--as",
+                            "Private module",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                before = state_snapshot(project)
+                for function in ("mark_index_stale", "save_config"):
+                    with (
+                        self.subTest(function=function),
+                        mock.patch(
+                            f"silobrief.boundaries.{function}",
+                            side_effect=SetupError("write failed"),
+                        ),
+                    ):
+                        self.assert_unignore_error("private-boundary")
+                        self.assertEqual(state_snapshot(project), before)
+
+    def test_same_state_produces_identical_config_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            results: list[bytes] = []
+            for name in ("first", "second"):
+                project = root / name
+                project.mkdir()
+                (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+                self.assertEqual(run_silently(["setup", str(project)]), 0)
+                with working_directory(project):
+                    self.assertEqual(
+                        run_silently(
+                            [
+                                "ignore",
+                                "private.py",
+                                "--as",
+                                "Private module",
+                                "--alias",
+                                "private-boundary",
+                            ]
+                        ),
+                        0,
+                    )
+                    self.assertEqual(run_silently(["unignore", "private-boundary"]), 0)
+                results.append((project / ".silobrief" / "config.json").read_bytes())
+
+            self.assertEqual(results[0], results[1])
+
+    def test_requires_initialized_project(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            with working_directory(project):
+                message = self.assert_unignore_error("private-boundary")
+            self.assertIn("run sb setup first", message)


### PR DESCRIPTION
## 변경 내용

- 저장된 상대 경로나 별칭으로 경계 하나를 해제하는 `sb unignore SELECTOR`를 추가했습니다.
- 해제 시 대상 경로를 열거나 존재 여부를 확인하지 않습니다.
- 기존 색인을 stale 상태로 표시해 `sb init` 전까지 `sb chat`을 차단합니다.
- 설정 또는 색인 갱신이 실패하면 기존 바이트·mtime·권한을 복구합니다.
- 영문·한국어 README와 CHANGELOG, CLI 문서 검증을 갱신했습니다.

## 사용자 영향

잘못 등록했거나 더 이상 필요하지 않은 ignore 경계를 설정 파일을 직접 편집하지 않고 안전하게 해제할 수 있습니다. 해제 후에는 새로 공개될 수 있는 소스 범위를 사용자가 명시적으로 `sb init`으로 다시 확인해야 합니다.

## 범위

- 상태 스키마 변경 없음
- 런타임 의존성 추가 없음
- 자동 재색인 및 확인 프롬프트 없음
- Issue #42, #44, #58 기능은 포함하지 않음

## 검증

- 전체 unittest: 147 passed, 6 skipped
- Ruff lint 및 format check
- mypy strict
- source distribution 및 wheel build
- 설치된 wheel에서 `sb unignore` 노출 확인
- 설치 wheel 전체 unittest: 147 passed, 6 skipped
- `git diff --check`

Refs #43