### PR TITLE
fix(review): focus exact-path symbol selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole
+  module.
+
 ## [0.3.0] - 2026-08-06
 
 ### Added

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -177,11 +177,15 @@ def _read_additions(
             options = selector_symbol_options(index, selector)
         except ReviewError as error:
             raise ChatReviewError(str(error)) from error
-        selectors.append(selector)
         if options is None:
+            selectors.append(selector)
             continue
         _show_symbol_options(selector, options, output_stream)
-        for number in _read_symbol_numbers(input_stream, output_stream):
+        numbers = _read_symbol_numbers(input_stream, output_stream)
+        if not numbers:
+            selectors.append(selector)
+            continue
+        for number in numbers:
             if number > len(options):
                 raise ChatReviewError(f"unknown symbol number: {number}")
             selectors.append(options[number - 1].node.id)

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -163,11 +163,18 @@ class ChatReviewTests(unittest.TestCase):
         module = node("module", "src/guided.py", "module", "guided")
         service = node("service", "src/guided.py", "class", "Service")
         method = node("method", "src/guided.py", "function", "run", "Service.run")
+        helper = node("helper", "src/guided.py", "function", "helper")
+        external = node("external", "src/external.py", "function", "external")
         index = IndexData(
             config_digest="a" * 64,
-            edges=(),
+            edges=(
+                IndexEdge("helper", "call", "external", "external"),
+                IndexEdge("module", "contains", "Service", "service"),
+                IndexEdge("module", "contains", "Service.run", "method"),
+                IndexEdge("module", "contains", "helper", "helper"),
+            ),
             index_version=1,
-            nodes=(method, module, service),
+            nodes=(external, helper, method, module, service),
             source_digest="b" * 64,
             stale=False,
         )
@@ -177,7 +184,7 @@ class ChatReviewTests(unittest.TestCase):
             "no matching terms",
             index,
             NotesData(notes=[], notes_version=1),
-            input_stream=TtyBuffer("y\n\nsrc/guided.py\n1 1\n\n\ny\ny\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n\nsrc/guided.py\n1 2\n\n\ny\ny\nn\nn\nn\n"),
             output_stream=output,
         )
         node_id_output = TtyBuffer()
@@ -185,7 +192,7 @@ class ChatReviewTests(unittest.TestCase):
             "no matching terms",
             index,
             NotesData(notes=[], notes_version=1),
-            input_stream=TtyBuffer("y\n\nmodule\nservice\n\n\ny\ny\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n\nservice\nmethod\n\n\ny\ny\nn\nn\nn\n"),
             output_stream=node_id_output,
         )
 
@@ -202,7 +209,39 @@ class ChatReviewTests(unittest.TestCase):
         self.assertNotIn("Symbols in", node_id_output.getvalue())
         self.assertIn("class Service", visible)
         self.assertIn("src/guided.py", rendered.main_markdown)
-        self.assertEqual(rendered.disclosure.symbol_names, 2)
+        self.assertIn("function: Service.run", rendered.main_markdown)
+        self.assertNotIn("function: helper", rendered.main_markdown)
+        self.assertNotIn("src/external.py", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.symbol_names, 3)
+
+    def test_keeps_module_when_file_outline_has_no_symbol_selection(self) -> None:
+        module = node("module", "src/guided.py", "module", "guided")
+        service = node("service", "src/guided.py", "class", "Service")
+        helper = node("helper", "src/guided.py", "function", "helper")
+        index = IndexData(
+            config_digest="a" * 64,
+            edges=(
+                IndexEdge("module", "contains", "Service", "service"),
+                IndexEdge("module", "contains", "helper", "helper"),
+            ),
+            index_version=1,
+            nodes=(helper, module, service),
+            source_digest="b" * 64,
+            stale=False,
+        )
+
+        rendered = review_brief(
+            "no matching terms",
+            index,
+            NotesData(notes=[], notes_version=1),
+            input_stream=TtyBuffer("y\n\nsrc/guided.py\n\n\n\ny\ny\nn\nn\nn\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertIn("module: guided", rendered.main_markdown)
+        self.assertIn("class: Service", rendered.main_markdown)
+        self.assertIn("function: helper", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.symbol_names, 3)
 
     def test_rejects_unknown_file_and_invalid_outline_number(self) -> None:
         module = node("module", "src/guided.py", "module", "guided")


### PR DESCRIPTION
## 변경 사항

- 정확한 파일 경로에서 심볼을 고르면 파일 모듈을 선택 목록에 남기지 않습니다.
- 심볼 선택을 비우면 기존 파일 단위 선택 동작을 유지합니다.
- 선택 심볼과 직접 node ID 선택이 같은 그래프 컨텍스트를 생성하는 회귀 테스트를 추가했습니다.

## 원인

파일 경로를 심볼 선택 전에 항상 selector에 추가해, 선택한 심볼뿐 아니라 모듈도 그래프 확장 시작점이 됐습니다. 이 때문에 같은 파일의 무관한 형제 심볼과 연결 경로가 브리프에 포함됐습니다.

## 사용자 영향

정확한 경로로 목표 심볼을 복구할 때 브리프가 선택한 심볼 중심으로 작아집니다. 심볼을 고르지 않는 파일 단위 검토, 직접 node ID 선택, 랭킹, 인덱스 및 Markdown schema는 바뀌지 않습니다.

## 검증

- `python -m unittest discover -s tests`: 140개 실행, 6개 조건부 skip
- `ruff check .`
- `ruff format --check .`
- `mypy` strict
- wheel 및 sdist 빌드, 새 가상환경 wheel 설치, `sb --version`
- 외부 저장소 6개 installed-wheel E2E 재실행: 6/6 통과
- exact-path 복구 심볼 수: healthchecks 54→4, pretalx 14→2, click 23→5
- source companion SHA-256 동일: 6/6
- 외부 저장소 tracked 파일 변경 없음: 6/6

## 관련 이슈

Refs #103

PR #102가 먼저 병합되면 `CHANGELOG.md` 충돌 여부를 확인하고 develop 기준으로 갱신합니다.