### PR TITLE
fix(boundary): redact src-layout imports

### DIFF
--- a/src/silobrief/boundary_placeholders.py
+++ b/src/silobrief/boundary_placeholders.py
@@ -15,7 +15,7 @@ class BoundaryPlaceholder:
 
 @dataclass(frozen=True, slots=True)
 class _BoundaryRule:
-    module: str
+    modules: tuple[str, ...]
     placeholder: BoundaryPlaceholder
 
 
@@ -31,8 +31,8 @@ class BoundaryMatcher:
             sorted(
                 (_boundary_rule(boundary) for boundary in boundaries),
                 key=lambda rule: (
-                    -(rule.module.count(".") + 1 if rule.module else 0),
-                    rule.module,
+                    -(rule.modules[0].count(".") + 1 if rule.modules[0] else 0),
+                    rule.modules,
                     rule.placeholder.alias,
                     rule.placeholder.description,
                 ),
@@ -94,8 +94,9 @@ class BoundaryMatcher:
         if module is None:
             return None
         for rule in self._rules:
-            if not rule.module or module == rule.module or module.startswith(f"{rule.module}."):
-                return rule.placeholder
+            for candidate in rule.modules:
+                if not candidate or module == candidate or module.startswith(f"{candidate}."):
+                    return rule.placeholder
         return None
 
 
@@ -121,12 +122,20 @@ def _boundary_rule(boundary: BoundaryData) -> _BoundaryRule:
     else:
         module = ".".join(parts)
     return _BoundaryRule(
-        module=module,
+        modules=_module_candidates(module),
         placeholder=BoundaryPlaceholder(
             alias=boundary["alias"],
             description=boundary["description"],
         ),
     )
+
+
+def _module_candidates(module: str) -> tuple[str, ...]:
+    if not module:
+        return ("",)
+    # Stored paths are project-relative, while absolute imports start at a package root.
+    parts = module.split(".")
+    return tuple(".".join(parts[index:]) for index in range(len(parts)))
 
 
 def _resolved_import_target(source_path: str, imported: ImportEntry) -> str | None:

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -27,6 +27,31 @@ def config(*boundaries: BoundaryData) -> ConfigData:
 
 
 class BoundaryPlaceholderTests(unittest.TestCase):
+    def test_replaces_absolute_import_for_src_layout_boundary(self) -> None:
+        snapshot = source_snapshot(
+            "src/pkg/app.py",
+            (
+                b"from pkg.secretmod import hidden_internal_name\n"
+                b"def run():\n"
+                b"    return hidden_internal_name()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="secret-boundary",
+            description="Approved internal module",
+            path="src/pkg/secretmod.py",
+        )
+
+        rendered = render_index_json(
+            build_index(snapshot, extract_structures(snapshot), config(boundary))
+        )
+
+        self.assertIn(b'"alias": "secret-boundary"', rendered)
+        self.assertIn(b'"description": "Approved internal module"', rendered)
+        for forbidden in (b"pkg.secretmod", b"secretmod", b"hidden_internal_name"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
     def test_replaces_directory_boundary_imports_calls_and_references(self) -> None:
         snapshot = source_snapshot(
             "app.py",

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -195,6 +195,55 @@ class ChatCommandTests(unittest.TestCase):
             self.assertFalse(destination.with_name("context-only.sources.md").exists())
             self.assertIn('source_companion: "none"', destination.read_text(encoding="utf-8"))
 
+    def test_src_layout_boundary_is_redacted_in_exact_path_brief(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            package = project / "src" / "pkg"
+            package.mkdir(parents=True)
+            (package / "app.py").write_text(
+                "from pkg.secretmod import hidden_internal_name\n\n"
+                "def run():\n"
+                "    return hidden_internal_name()\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            (package / "secretmod.py").write_text(
+                "def hidden_internal_name():\n    return 'PRIVATE_CANARY'\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+
+            self.assertEqual(main(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    main(
+                        [
+                            "ignore",
+                            "src/pkg/secretmod.py",
+                            "--as",
+                            "Approved internal module",
+                            "--alias",
+                            "secret-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(main(["init"]), 0)
+
+            output = ".silobrief/exports/src-layout.md"
+            review = "y\n\nsrc/pkg/app.py\n1\n\n\ny\ny\ny\nn\ny\nn\nWRITE\n"
+            result, _, _, stderr = run_chat(project, output, review)
+
+            destination = project / output
+            self.assertEqual(result, 0)
+            self.assertEqual(stderr, "")
+            generated = destination.read_text(encoding="utf-8")
+            self.assertIn("secret-boundary", generated)
+            self.assertIn("Approved internal module", generated)
+            for forbidden in ("pkg.secretmod", "hidden_internal_name", "PRIVATE_CANARY"):
+                with self.subTest(forbidden=forbidden):
+                    self.assertNotIn(forbidden, generated)
+
     def test_selects_an_approved_source_from_a_file_outline(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             project = Path(directory)


### PR DESCRIPTION
## 변경 내용

- 프로젝트 상대 경계 경로와 패키지 루트 기준 절대 import를 함께 비교합니다.
- src-layout 제외 모듈의 실제 이름을 인덱스와 메인 브리프에서 placeholder로 치환합니다.
- 인덱스 단위 및 exact-path 전체 흐름 회귀 테스트를 추가합니다.

## 검증

- Ruff lint 및 format check
- mypy --strict src tests
- 전체 unittest 149개 통과, Windows symlink 테스트 6개 제외

Refs #109
Refs #108
