### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-07
+
 ### Added
 
 - Remove one registered boundary by its exact stored path or alias with `sb unignore`, leaving the
@@ -16,6 +18,15 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole
   module.
+
+### Known limitations
+
+- Exact-path recovery remains guided selection: the user must know an indexed relative Python
+  file path.
+- The installed-wheel workflow passed on six frozen open-source repositories, but independent
+  lexical retrieval reached the intended symbol in the Top 10 for only one of six tasks.
+- This release does not establish secret detection, export approval, market demand, or general
+  answer quality across external AI models.
 
 ## [0.3.0] - 2026-08-06
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="릴리스 v0.3.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.4.0"><img src="https://img.shields.io/badge/release-v0.4.0-4f46e5" alt="릴리스 v0.4.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -63,7 +63,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 0.3.0
+siloBrief 0.4.0
 ```
 
 ## 명령어
@@ -193,14 +193,15 @@ siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아
 
 ## 검증 현황
 
-현재 공개 버전은 v0.3.0입니다. v0.2의 검토·출력 방식을 그대로 유지하면서, 추천 결과에 원하는
-코드가 없을 때 정확한 파일 경로로 함수와 클래스를 찾는 기능을 추가했습니다. 색인에 지원하는
-Python 심볼이 하나도 없으면 빈 문서를 만들지 않고 지원 범위를 분명하게 안내합니다.
+현재 공개 버전은 v0.4.0입니다. `sb unignore`로 등록된 제외 경계를 경로나 alias로 해제할 수
+있으며, 해제 후에는 다시 `sb init`을 실행해야 검토를 시작할 수 있습니다. 정확한 파일 경로에서
+심볼을 고르면 사용자가 선택한 소스만 공개 검토 대상으로 유지합니다.
 
-v0.2 패키지는 Windows와 Ubuntu에서 같은 입력으로 동일한 Markdown을 만들었고, Claude에 전달한
-합성 코드 유지보수 과제 세 개도 모두 요구한 형식의 답변을 받았습니다. GPT 검증은 후속 과제입니다.
-현재 결과만으로 여러 AI 모델, 실제 비공개 프로젝트, 독립 사용자에게 같은 효과가 있다고 말할 수는
-없습니다.
+설치한 wheel로 동결된 오픈소스 Python 저장소 여섯 개에서 경계 해제, 오래된 색인 차단, 정확한
+경로 검토, Markdown 두 파일 생성을 확인했습니다. 다만 독립 과제 여섯 개 중 자동 lexical 검색이
+목표 심볼을 Top 10에 넣은 경우는 한 개뿐이어서, 아직은 사용자가 경로를 직접 고르는 과정이
+중요합니다. 이 결과가 비밀정보 탐지, 반출 승인, 시장 수요, 여러 외부 AI 모델과 실제 비공개
+프로젝트에서의 효과를 입증하지는 않습니다.
 
 - [설치 wheel 검증](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [수동 모델 평가 절차](validation/v0.2/MANUAL_MODEL_GATE.md)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="Release v0.3.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.4.0"><img src="https://img.shields.io/badge/release-v0.4.0-4f46e5" alt="Release v0.4.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -61,7 +61,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 0.3.0
+siloBrief 0.4.0
 ```
 
 ## Commands
@@ -186,13 +186,15 @@ disclosure. Review every generated file under your organization's disclosure rul
 
 ## Validation status
 
-The current release is v0.3.0. It keeps the reviewed v0.2 output flow and adds exact-path symbol
-selection when lexical suggestions miss the intended code. It also stops before review with a clear
-Python-only message when the index contains no supported symbols.
+The current release is v0.4.0. It can remove one registered boundary by path or alias with
+`sb unignore`, then requires `sb init` before review. Exact-path review now keeps source disclosure
+focused on the symbols the user selected.
 
-The v0.2 package produced identical Markdown files on Windows and Ubuntu, and Claude completed three
-synthetic code-maintenance tasks using those files. GPT validation remains follow-up work. These
-results do not establish effectiveness across models, real private projects, or independent users.
+The installed-wheel workflow passed on six frozen open-source Python repositories, including
+boundary removal, stale-index blocking, exact-path review, and paired Markdown output. Automatic
+lexical retrieval found the intended symbol in the Top 10 for only one of six independent tasks, so
+guided path selection remains important. These results do not establish secret detection, export
+approval, market demand, or effectiveness across external AI models and private projects.
 
 - [Installed wheel verification](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [Manual model gate](validation/v0.2/MANUAL_MODEL_GATE.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@
 
 | Version | Supported |
 |---|---|
-| 0.3.x | :white_check_mark: |
+| 0.4.x | :white_check_mark: |
+| 0.3.x | :x: |
 | 0.2.x | :x: |
 | 0.1.x | :x: |
 
-The latest 0.3.x release is the currently supported line.
+The latest 0.4.x release is the currently supported line.
 
 ## Reporting a vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "0.3.0"
+version = "0.4.0"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,4 +41,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 0.3.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 0.4.0\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -23,6 +23,7 @@ CHANGELOG_EXPECTATIONS = (*PUBLIC_COMMANDS[:-1], "WRITE", "parcel-sync-fixture")
 V0_1_RELEASE_DATE = "2026-08-04"
 V0_2_RELEASE_DATE = "2026-08-05"
 V0_3_RELEASE_DATE = "2026-08-06"
+V0_4_RELEASE_DATE = "2026-08-07"
 BRIEF_GUIDANCE_EXPECTATIONS = {
     "README.md": (
         "concrete task",
@@ -77,9 +78,10 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 for fragment in fragments:
                     self.assertIn(fragment, text)
 
-    def test_v0_3_release_metadata_is_current(self) -> None:
+    def test_v0_4_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn(f"## [0.4.0] - {V0_4_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.3.0] - {V0_3_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.2.0] - {V0_2_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.1.0] - {V0_1_RELEASE_DATE}", changelog)
@@ -87,24 +89,24 @@ class ReleaseDocumentationTests(unittest.TestCase):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("The current release is v0.3.0.", readme)
+        self.assertIn("The current release is v0.4.0.", readme)
         self.assertIn("exact indexed Python file path", readme)
-        self.assertIn("GPT validation remains follow-up work", readme)
+        self.assertIn("six frozen open-source Python repositories", readme)
         self.assertIn("docs/V0_2_CONTRACT.md", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
-        self.assertIn("현재 공개 버전은 v0.3.0입니다.", readme_ko)
+        self.assertIn("현재 공개 버전은 v0.4.0입니다.", readme_ko)
         self.assertIn("색인에 있는 Python 파일의 정확한 상대 경로", readme_ko)
-        self.assertIn("GPT 검증은 후속 과제", readme_ko)
+        self.assertIn("오픈소스 Python 저장소 여섯 개", readme_ko)
         self.assertIn("docs/V0_2_CONTRACT.md", readme_ko)
 
         security = (REPOSITORY_ROOT / "SECURITY.md").read_text(encoding="utf-8")
-        self.assertIn("| 0.3.x | :white_check_mark: |", security)
-        self.assertIn("| 0.2.x | :x: |", security)
+        self.assertIn("| 0.4.x | :white_check_mark: |", security)
+        self.assertIn("| 0.3.x | :x: |", security)
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "0.3.0"'), 1)
-        self.assertEqual(version("silobrief"), "0.3.0")
+        self.assertEqual(pyproject.count('version = "0.4.0"'), 1)
+        self.assertEqual(version("silobrief"), "0.4.0")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())


### PR DESCRIPTION
## 변경 내용

- package metadata와 공개 문서를 v0.4.0으로 갱신합니다.
- CHANGELOG에 exact-path review, boundary 해제, 경계 안전성 수정 내용을 기록합니다.
- 지원 범위와 비보장 사항을 README 및 SECURITY 문서에 맞춥니다.

## 최종 검증

- Ruff lint 및 format check
- mypy --strict src tests
- 전체 unittest 149개 통과, Windows symlink 테스트 6개 제외
- wheel 및 sdist 생성
- 새 가상환경에 wheel 설치 후 siloBrief 0.4.0 확인

Refs #108
