### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-07
+
 ### Added
 
 - Remove one registered boundary by its exact stored path or alias with `sb unignore`, leaving the
@@ -16,6 +18,15 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole
   module.
+
+### Known limitations
+
+- Exact-path recovery remains guided selection: the user must know an indexed relative Python
+  file path.
+- The installed-wheel workflow passed on six frozen open-source repositories, but independent
+  lexical retrieval reached the intended symbol in the Top 10 for only one of six tasks.
+- This release does not establish secret detection, export approval, market demand, or general
+  answer quality across external AI models.
 
 ## [0.3.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Remove one registered boundary by its exact stored path or alias with `sb unignore`, leaving the
+  current index stale until the user runs `sb init` again.
+
 ### Fixed
 
 - Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole
+  module.
+
 ## [0.3.0] - 2026-08-06
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="릴리스 v0.3.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.4.0"><img src="https://img.shields.io/badge/release-v0.4.0-4f46e5" alt="릴리스 v0.4.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -63,7 +63,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 0.3.0
+siloBrief 0.4.0
 ```
 
 ## 명령어
@@ -193,14 +193,15 @@ siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아
 
 ## 검증 현황
 
-현재 공개 버전은 v0.3.0입니다. v0.2의 검토·출력 방식을 그대로 유지하면서, 추천 결과에 원하는
-코드가 없을 때 정확한 파일 경로로 함수와 클래스를 찾는 기능을 추가했습니다. 색인에 지원하는
-Python 심볼이 하나도 없으면 빈 문서를 만들지 않고 지원 범위를 분명하게 안내합니다.
+현재 공개 버전은 v0.4.0입니다. `sb unignore`로 등록된 제외 경계를 경로나 alias로 해제할 수
+있으며, 해제 후에는 다시 `sb init`을 실행해야 검토를 시작할 수 있습니다. 정확한 파일 경로에서
+심볼을 고르면 사용자가 선택한 소스만 공개 검토 대상으로 유지합니다.
 
-v0.2 패키지는 Windows와 Ubuntu에서 같은 입력으로 동일한 Markdown을 만들었고, Claude에 전달한
-합성 코드 유지보수 과제 세 개도 모두 요구한 형식의 답변을 받았습니다. GPT 검증은 후속 과제입니다.
-현재 결과만으로 여러 AI 모델, 실제 비공개 프로젝트, 독립 사용자에게 같은 효과가 있다고 말할 수는
-없습니다.
+설치한 wheel로 동결된 오픈소스 Python 저장소 여섯 개에서 경계 해제, 오래된 색인 차단, 정확한
+경로 검토, Markdown 두 파일 생성을 확인했습니다. 다만 독립 과제 여섯 개 중 자동 lexical 검색이
+목표 심볼을 Top 10에 넣은 경우는 한 개뿐이어서, 아직은 사용자가 경로를 직접 고르는 과정이
+중요합니다. 이 결과가 비밀정보 탐지, 반출 승인, 시장 수요, 여러 외부 AI 모델과 실제 비공개
+프로젝트에서의 효과를 입증하지는 않습니다.
 
 - [설치 wheel 검증](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [수동 모델 평가 절차](validation/v0.2/MANUAL_MODEL_GATE.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -72,6 +72,7 @@ siloBrief 0.3.0
 |---|---|
 | `sb setup [PATH]` | 기존 프로젝트에 siloBrief 작업 공간을 만듭니다. |
 | `sb ignore PATH --as TEXT [--alias NAME]` | 읽지 않을 경로와 그 영역을 대신할 공개용 이름을 등록합니다. |
+| `sb unignore SELECTOR` | 저장된 상대 경로나 별칭으로 등록 경계 하나를 해제합니다. |
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
 | `sb chat "PROMPT" --out FILE` | 전달할 내용을 검토하고 AI 요청 문서와 선택적 코드 첨부 파일을 만듭니다. |
@@ -115,6 +116,20 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 이 과정에서 `setup`은 작업 공간을 만들고, `ignore`는 읽으면 안 되는 경로를 등록합니다. `init`은
 나머지 Python 파일을 분석해 색인을 만들고, `chat`은 작업과 관련 있어 보이는 정보를 찾아
 검토 대상으로 보여줍니다.
+
+### 등록한 제외 경로 해제하기
+
+잘못 등록했거나 더 이상 제외할 필요가 없는 경계는 저장된 상대 경로나 별칭으로 해제한 뒤 색인을
+다시 만듭니다.
+
+```console
+sb unignore delivery-boundary
+sb init
+```
+
+`unignore`는 설정만 바꾸며 해제할 경로의 파일을 열지 않습니다. 기존 색인은 즉시 오래된 상태로
+표시되므로 `sb init`이 끝나기 전까지 `sb chat`을 실행할 수 없습니다. 색인을 다시 만들면 해당
+경로의 파일이 검토 대상이나 코드 첨부 후보로 나타날 수 있습니다.
 
 ### 프로젝트 정보 더하기
 
@@ -164,6 +179,7 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 
 - 색인을 만들 때 심볼릭 링크를 따라가지 않습니다.
 - 등록된 제외 디렉터리 안의 파일을 열지 않습니다.
+- 등록을 해제하는 동안 해당 경로의 파일을 열지 않습니다.
 - 제외된 코드에 대한 참조는 승인한 공개용 이름으로 바꿔 AI 요청 문서에 표시합니다.
 - 파일을 쓰기 전에 전체 미리보기와 사용자 승인을 요구합니다.
 - 네트워크 연결, 언어 모델 호출, 자동 파일 전송을 하지 않습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.3.0"><img src="https://img.shields.io/badge/release-v0.3.0-4f46e5" alt="Release v0.3.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.4.0"><img src="https://img.shields.io/badge/release-v0.4.0-4f46e5" alt="Release v0.4.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -61,7 +61,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 0.3.0
+siloBrief 0.4.0
 ```
 
 ## Commands
@@ -186,13 +186,15 @@ disclosure. Review every generated file under your organization's disclosure rul
 
 ## Validation status
 
-The current release is v0.3.0. It keeps the reviewed v0.2 output flow and adds exact-path symbol
-selection when lexical suggestions miss the intended code. It also stops before review with a clear
-Python-only message when the index contains no supported symbols.
+The current release is v0.4.0. It can remove one registered boundary by path or alias with
+`sb unignore`, then requires `sb init` before review. Exact-path review now keeps source disclosure
+focused on the symbols the user selected.
 
-The v0.2 package produced identical Markdown files on Windows and Ubuntu, and Claude completed three
-synthetic code-maintenance tasks using those files. GPT validation remains follow-up work. These
-results do not establish effectiveness across models, real private projects, or independent users.
+The installed-wheel workflow passed on six frozen open-source Python repositories, including
+boundary removal, stale-index blocking, exact-path review, and paired Markdown output. Automatic
+lexical retrieval found the intended symbol in the Top 10 for only one of six independent tasks, so
+guided path selection remains important. These results do not establish secret detection, export
+approval, market demand, or effectiveness across external AI models and private projects.
 
 - [Installed wheel verification](validation/v0.2/INSTALLED_WHEEL_VERIFICATION.md)
 - [Manual model gate](validation/v0.2/MANUAL_MODEL_GATE.md)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ siloBrief 0.3.0
 |---|---|
 | `sb setup [PATH]` | Adds or checks local siloBrief state in an existing project. |
 | `sb ignore PATH --as TEXT [--alias NAME]` | Excludes a path and records a public label for that boundary. |
+| `sb unignore SELECTOR` | Removes one registered boundary by its exact stored path or alias. |
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
 | `sb chat "PROMPT" --out FILE` | Reviews context and writes the main brief and optional code attachment. |
@@ -111,6 +112,20 @@ sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified di
 `setup` prepares local state, `ignore` registers a path that must not be read, and `init` builds a
 local search list from the remaining Python files. `chat` then proposes relevant project context
 for review.
+
+### Remove a registered boundary
+
+If an ignore entry is no longer correct, remove it by the exact stored path or alias, then rebuild
+the index:
+
+```console
+sb unignore delivery-boundary
+sb init
+```
+
+`unignore` changes only local configuration and does not open the removed path. It marks an existing
+index as stale, so `sb chat` remains blocked until `sb init` finishes. After rebuilding, files below
+that path may be offered for review and source disclosure.
 
 ### Complete review
 
@@ -159,6 +174,7 @@ siloBrief:
 
 - does not follow symbolic links while indexing;
 - does not open registered excluded subtrees;
+- does not open a boundary target while removing its registration;
 - replaces references to excluded code with an approved public label in the main brief;
 - requires a preview before writing output; and
 - uses no network connection, language model, or automatic transfer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@
 
 | Version | Supported |
 |---|---|
-| 0.3.x | :white_check_mark: |
+| 0.4.x | :white_check_mark: |
+| 0.3.x | :x: |
 | 0.2.x | :x: |
 | 0.1.x | :x: |
 
-The latest 0.3.x release is the currently supported line.
+The latest 0.4.x release is the currently supported line.
 
 ## Reporting a vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "0.3.0"
+version = "0.4.0"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/silobrief/boundaries.py
+++ b/src/silobrief/boundaries.py
@@ -71,14 +71,45 @@ def register_boundary(
         default_excludes=list(config["default_excludes"]),
         schema_version=1,
     )
+    _save_config_with_stale_index(root, updated)
+    return RegistrationResult(boundary=boundary, changed=True)
+
+
+def unregister_boundary(selector: str, *, start: Path) -> BoundaryData:
+    if not selector.strip():
+        raise SetupError("boundary selector must not be empty")
+
+    root = find_project_root(start)
+    config = load_config(root)
+    boundaries = config["boundaries"]
+    matches = [
+        boundary
+        for boundary in boundaries
+        if selector == boundary["path"] or selector == boundary["alias"]
+    ]
+    if not matches:
+        raise SetupError("boundary selector is not registered")
+    if len(matches) > 1:
+        raise SetupError("boundary selector matches more than one registered boundary")
+
+    boundary = matches[0]
+    updated = ConfigData(
+        boundaries=[item for item in boundaries if item != boundary],
+        default_excludes=list(config["default_excludes"]),
+        schema_version=1,
+    )
+    _save_config_with_stale_index(root, updated)
+    return boundary
+
+
+def _save_config_with_stale_index(root: Path, config: ConfigData) -> None:
     index_snapshot = _snapshot_index(root)
     try:
         mark_index_stale(root)
-        save_config(root, updated)
+        save_config(root, config)
     except SetupError:
         _restore_snapshot(index_snapshot)
         raise
-    return RegistrationResult(boundary=boundary, changed=True)
 
 
 def _boundary_path(root: Path, start: Path, path_text: str) -> str:

--- a/src/silobrief/boundary_placeholders.py
+++ b/src/silobrief/boundary_placeholders.py
@@ -15,7 +15,7 @@ class BoundaryPlaceholder:
 
 @dataclass(frozen=True, slots=True)
 class _BoundaryRule:
-    module: str
+    modules: tuple[str, ...]
     placeholder: BoundaryPlaceholder
 
 
@@ -31,8 +31,8 @@ class BoundaryMatcher:
             sorted(
                 (_boundary_rule(boundary) for boundary in boundaries),
                 key=lambda rule: (
-                    -(rule.module.count(".") + 1 if rule.module else 0),
-                    rule.module,
+                    -(rule.modules[0].count(".") + 1 if rule.modules[0] else 0),
+                    rule.modules,
                     rule.placeholder.alias,
                     rule.placeholder.description,
                 ),
@@ -94,8 +94,9 @@ class BoundaryMatcher:
         if module is None:
             return None
         for rule in self._rules:
-            if not rule.module or module == rule.module or module.startswith(f"{rule.module}."):
-                return rule.placeholder
+            for candidate in rule.modules:
+                if not candidate or module == candidate or module.startswith(f"{candidate}."):
+                    return rule.placeholder
         return None
 
 
@@ -121,12 +122,20 @@ def _boundary_rule(boundary: BoundaryData) -> _BoundaryRule:
     else:
         module = ".".join(parts)
     return _BoundaryRule(
-        module=module,
+        modules=_module_candidates(module),
         placeholder=BoundaryPlaceholder(
             alias=boundary["alias"],
             description=boundary["description"],
         ),
     )
+
+
+def _module_candidates(module: str) -> tuple[str, ...]:
+    if not module:
+        return ("",)
+    # Stored paths are project-relative, while absolute imports start at a package root.
+    parts = module.split(".")
+    return tuple(".".join(parts[index:]) for index in range(len(parts)))
 
 
 def _resolved_import_target(source_path: str, imported: ImportEntry) -> str | None:

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -177,11 +177,15 @@ def _read_additions(
             options = selector_symbol_options(index, selector)
         except ReviewError as error:
             raise ChatReviewError(str(error)) from error
-        selectors.append(selector)
         if options is None:
+            selectors.append(selector)
             continue
         _show_symbol_options(selector, options, output_stream)
-        for number in _read_symbol_numbers(input_stream, output_stream):
+        numbers = _read_symbol_numbers(input_stream, output_stream)
+        if not numbers:
+            selectors.append(selector)
+            continue
+        for number in numbers:
             if number > len(options):
                 raise ChatReviewError(f"unknown symbol number: {number}")
             selectors.append(options[number - 1].node.id)

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from silobrief import __version__
-from silobrief.boundaries import register_boundary
+from silobrief.boundaries import register_boundary, unregister_boundary
 from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
@@ -43,6 +43,8 @@ def _build_parser() -> argparse.ArgumentParser:
     ignore.add_argument("path")
     ignore.add_argument("--as", dest="description", required=True)
     ignore.add_argument("--alias")
+    unignore = subcommands.add_parser("unignore", help="Remove a registered project boundary.")
+    unignore.add_argument("selector")
     subcommands.add_parser("init", help="Build the local source index.")
     log = subcommands.add_parser("log", help="Record public project context.")
     log.add_argument("path")
@@ -91,6 +93,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print(f"boundary {boundary['alias']} for {boundary['path']} is already registered")
+
+    if arguments.command == "unignore":
+        selector = arguments.selector
+        if not isinstance(selector, str):
+            parser.error("unignore selector must be text")
+        try:
+            boundary = unregister_boundary(selector, start=Path.cwd())
+        except SetupError as error:
+            parser.error(str(error))
+        print(
+            f"removed boundary {boundary['alias']} for {boundary['path']}; "
+            "run sb init before sb chat"
+        )
 
     if arguments.command == "init":
         try:

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -27,6 +27,31 @@ def config(*boundaries: BoundaryData) -> ConfigData:
 
 
 class BoundaryPlaceholderTests(unittest.TestCase):
+    def test_replaces_absolute_import_for_src_layout_boundary(self) -> None:
+        snapshot = source_snapshot(
+            "src/pkg/app.py",
+            (
+                b"from pkg.secretmod import hidden_internal_name\n"
+                b"def run():\n"
+                b"    return hidden_internal_name()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="secret-boundary",
+            description="Approved internal module",
+            path="src/pkg/secretmod.py",
+        )
+
+        rendered = render_index_json(
+            build_index(snapshot, extract_structures(snapshot), config(boundary))
+        )
+
+        self.assertIn(b'"alias": "secret-boundary"', rendered)
+        self.assertIn(b'"description": "Approved internal module"', rendered)
+        for forbidden in (b"pkg.secretmod", b"secretmod", b"hidden_internal_name"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
     def test_replaces_directory_boundary_imports_calls_and_references(self) -> None:
         snapshot = source_snapshot(
             "app.py",

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -195,6 +195,55 @@ class ChatCommandTests(unittest.TestCase):
             self.assertFalse(destination.with_name("context-only.sources.md").exists())
             self.assertIn('source_companion: "none"', destination.read_text(encoding="utf-8"))
 
+    def test_src_layout_boundary_is_redacted_in_exact_path_brief(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            package = project / "src" / "pkg"
+            package.mkdir(parents=True)
+            (package / "app.py").write_text(
+                "from pkg.secretmod import hidden_internal_name\n\n"
+                "def run():\n"
+                "    return hidden_internal_name()\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            (package / "secretmod.py").write_text(
+                "def hidden_internal_name():\n    return 'PRIVATE_CANARY'\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+
+            self.assertEqual(main(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    main(
+                        [
+                            "ignore",
+                            "src/pkg/secretmod.py",
+                            "--as",
+                            "Approved internal module",
+                            "--alias",
+                            "secret-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(main(["init"]), 0)
+
+            output = ".silobrief/exports/src-layout.md"
+            review = "y\n\nsrc/pkg/app.py\n1\n\n\ny\ny\ny\nn\ny\nn\nWRITE\n"
+            result, _, _, stderr = run_chat(project, output, review)
+
+            destination = project / output
+            self.assertEqual(result, 0)
+            self.assertEqual(stderr, "")
+            generated = destination.read_text(encoding="utf-8")
+            self.assertIn("secret-boundary", generated)
+            self.assertIn("Approved internal module", generated)
+            for forbidden in ("pkg.secretmod", "hidden_internal_name", "PRIVATE_CANARY"):
+                with self.subTest(forbidden=forbidden):
+                    self.assertNotIn(forbidden, generated)
+
     def test_selects_an_approved_source_from_a_file_outline(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             project = Path(directory)

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -163,11 +163,18 @@ class ChatReviewTests(unittest.TestCase):
         module = node("module", "src/guided.py", "module", "guided")
         service = node("service", "src/guided.py", "class", "Service")
         method = node("method", "src/guided.py", "function", "run", "Service.run")
+        helper = node("helper", "src/guided.py", "function", "helper")
+        external = node("external", "src/external.py", "function", "external")
         index = IndexData(
             config_digest="a" * 64,
-            edges=(),
+            edges=(
+                IndexEdge("helper", "call", "external", "external"),
+                IndexEdge("module", "contains", "Service", "service"),
+                IndexEdge("module", "contains", "Service.run", "method"),
+                IndexEdge("module", "contains", "helper", "helper"),
+            ),
             index_version=1,
-            nodes=(method, module, service),
+            nodes=(external, helper, method, module, service),
             source_digest="b" * 64,
             stale=False,
         )
@@ -177,7 +184,7 @@ class ChatReviewTests(unittest.TestCase):
             "no matching terms",
             index,
             NotesData(notes=[], notes_version=1),
-            input_stream=TtyBuffer("y\n\nsrc/guided.py\n1 1\n\n\ny\ny\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n\nsrc/guided.py\n1 2\n\n\ny\ny\nn\nn\nn\n"),
             output_stream=output,
         )
         node_id_output = TtyBuffer()
@@ -185,7 +192,7 @@ class ChatReviewTests(unittest.TestCase):
             "no matching terms",
             index,
             NotesData(notes=[], notes_version=1),
-            input_stream=TtyBuffer("y\n\nmodule\nservice\n\n\ny\ny\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n\nservice\nmethod\n\n\ny\ny\nn\nn\nn\n"),
             output_stream=node_id_output,
         )
 
@@ -202,7 +209,39 @@ class ChatReviewTests(unittest.TestCase):
         self.assertNotIn("Symbols in", node_id_output.getvalue())
         self.assertIn("class Service", visible)
         self.assertIn("src/guided.py", rendered.main_markdown)
-        self.assertEqual(rendered.disclosure.symbol_names, 2)
+        self.assertIn("function: Service.run", rendered.main_markdown)
+        self.assertNotIn("function: helper", rendered.main_markdown)
+        self.assertNotIn("src/external.py", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.symbol_names, 3)
+
+    def test_keeps_module_when_file_outline_has_no_symbol_selection(self) -> None:
+        module = node("module", "src/guided.py", "module", "guided")
+        service = node("service", "src/guided.py", "class", "Service")
+        helper = node("helper", "src/guided.py", "function", "helper")
+        index = IndexData(
+            config_digest="a" * 64,
+            edges=(
+                IndexEdge("module", "contains", "Service", "service"),
+                IndexEdge("module", "contains", "helper", "helper"),
+            ),
+            index_version=1,
+            nodes=(helper, module, service),
+            source_digest="b" * 64,
+            stale=False,
+        )
+
+        rendered = review_brief(
+            "no matching terms",
+            index,
+            NotesData(notes=[], notes_version=1),
+            input_stream=TtyBuffer("y\n\nsrc/guided.py\n\n\n\ny\ny\nn\nn\nn\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertIn("module: guided", rendered.main_markdown)
+        self.assertIn("class: Service", rendered.main_markdown)
+        self.assertIn("function: helper", rendered.main_markdown)
+        self.assertEqual(rendered.disclosure.symbol_names, 3)
 
     def test_rejects_unknown_file_and_invalid_outline_number(self) -> None:
         module = node("module", "src/guided.py", "module", "guided")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.code, 2)
         self.assertIn("usage: sb", stderr.getvalue())
-        self.assertIn("{setup,ignore,init,log,chat}", stderr.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,chat}", stderr.getvalue())
 
     def test_help_lists_commands_and_succeeds(self) -> None:
         stdout = io.StringIO()
@@ -27,7 +27,7 @@ class CommandLineTests(unittest.TestCase):
             main(["--help"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertIn("{setup,ignore,init,log,chat}", stdout.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,chat}", stdout.getvalue())
 
 
 class VersionCommandTests(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,4 +41,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 0.3.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 0.4.0\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -9,6 +9,7 @@ FIXTURE_README = "examples/parcel-sync-fixture/README.md"
 PUBLIC_COMMANDS = (
     "sb setup",
     "sb ignore",
+    "sb unignore",
     "sb init",
     "sb log",
     "sb chat",

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -23,6 +23,7 @@ CHANGELOG_EXPECTATIONS = (*PUBLIC_COMMANDS[:-1], "WRITE", "parcel-sync-fixture")
 V0_1_RELEASE_DATE = "2026-08-04"
 V0_2_RELEASE_DATE = "2026-08-05"
 V0_3_RELEASE_DATE = "2026-08-06"
+V0_4_RELEASE_DATE = "2026-08-07"
 BRIEF_GUIDANCE_EXPECTATIONS = {
     "README.md": (
         "concrete task",
@@ -77,9 +78,10 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 for fragment in fragments:
                     self.assertIn(fragment, text)
 
-    def test_v0_3_release_metadata_is_current(self) -> None:
+    def test_v0_4_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn(f"## [0.4.0] - {V0_4_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.3.0] - {V0_3_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.2.0] - {V0_2_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.1.0] - {V0_1_RELEASE_DATE}", changelog)
@@ -87,24 +89,24 @@ class ReleaseDocumentationTests(unittest.TestCase):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("The current release is v0.3.0.", readme)
+        self.assertIn("The current release is v0.4.0.", readme)
         self.assertIn("exact indexed Python file path", readme)
-        self.assertIn("GPT validation remains follow-up work", readme)
+        self.assertIn("six frozen open-source Python repositories", readme)
         self.assertIn("docs/V0_2_CONTRACT.md", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
-        self.assertIn("현재 공개 버전은 v0.3.0입니다.", readme_ko)
+        self.assertIn("현재 공개 버전은 v0.4.0입니다.", readme_ko)
         self.assertIn("색인에 있는 Python 파일의 정확한 상대 경로", readme_ko)
-        self.assertIn("GPT 검증은 후속 과제", readme_ko)
+        self.assertIn("오픈소스 Python 저장소 여섯 개", readme_ko)
         self.assertIn("docs/V0_2_CONTRACT.md", readme_ko)
 
         security = (REPOSITORY_ROOT / "SECURITY.md").read_text(encoding="utf-8")
-        self.assertIn("| 0.3.x | :white_check_mark: |", security)
-        self.assertIn("| 0.2.x | :x: |", security)
+        self.assertIn("| 0.4.x | :white_check_mark: |", security)
+        self.assertIn("| 0.3.x | :x: |", security)
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "0.3.0"'), 1)
-        self.assertEqual(version("silobrief"), "0.3.0")
+        self.assertEqual(pyproject.count('version = "0.4.0"'), 1)
+        self.assertEqual(version("silobrief"), "0.4.0")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_unignore.py
+++ b/tests/test_unignore.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import stat
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+from typing import cast
+from unittest import mock
+
+from silobrief.cli import main
+from silobrief.state import BoundaryData, SetupError
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def boundaries(project: Path) -> list[BoundaryData]:
+    value: object = json.loads((project / ".silobrief" / "config.json").read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AssertionError("config must be an object")
+    raw = value.get("boundaries")
+    if not isinstance(raw, list):
+        raise AssertionError("boundaries must be an array")
+    return cast(list[BoundaryData], raw)
+
+
+def state_snapshot(project: Path) -> dict[str, tuple[bytes, int, int]]:
+    state = project / ".silobrief"
+    result: dict[str, tuple[bytes, int, int]] = {}
+    for name in ("config.json", "index.json"):
+        path = state / name
+        if path.is_file():
+            metadata = path.stat()
+            result[name] = (
+                path.read_bytes(),
+                metadata.st_mtime_ns,
+                stat.S_IMODE(metadata.st_mode),
+            )
+    return result
+
+
+def run_silently(arguments: list[str]) -> int:
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        return main(arguments)
+
+
+class UnignoreCommandTests(unittest.TestCase):
+    def assert_unignore_error(self, selector: str) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main(["unignore", selector])
+        self.assertEqual(caught.exception.code, 2)
+        message = stderr.getvalue()
+        self.assertNotIn("invalid choice", message)
+        return message
+
+    def test_removes_boundary_by_path_without_requiring_the_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            private = project / "private"
+            private.mkdir()
+            (private / "secret.py").write_text("SECRET = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private",
+                            "--as",
+                            "Private adapter",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+
+            (private / "secret.py").unlink()
+            private.rmdir()
+            stdout = io.StringIO()
+            with working_directory(project), contextlib.redirect_stdout(stdout):
+                self.assertEqual(main(["unignore", "private"]), 0)
+
+            self.assertEqual(boundaries(project), [])
+            index: object = json.loads(
+                (project / ".silobrief" / "index.json").read_text(encoding="utf-8")
+            )
+            self.assertIsInstance(index, dict)
+            self.assertIs(cast(dict[str, object], index).get("stale"), True)
+            self.assertIn("private-boundary", stdout.getvalue())
+            self.assertIn("private", stdout.getvalue())
+            self.assertIn("sb init", stdout.getvalue())
+
+    def test_removes_only_the_boundary_selected_by_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            for name in ("first.py", "second.py"):
+                (project / name).write_text("VALUE = 1\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        ["ignore", "first.py", "--as", "First", "--alias", "first-boundary"]
+                    ),
+                    0,
+                )
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "second.py",
+                            "--as",
+                            "Second",
+                            "--alias",
+                            "second-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                self.assertEqual(run_silently(["unignore", "first-boundary"]), 0)
+
+            self.assertEqual(
+                boundaries(project),
+                [
+                    {
+                        "alias": "second-boundary",
+                        "description": "Second",
+                        "path": "second.py",
+                    }
+                ],
+            )
+
+    def test_rejects_unknown_default_empty_and_ambiguous_selectors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "shared").mkdir()
+            (project / "other").mkdir()
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(["ignore", "shared", "--as", "Shared path", "--alias", "first"]),
+                    0,
+                )
+                self.assertEqual(
+                    run_silently(["ignore", "other", "--as", "Other path", "--alias", "shared"]),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                before = state_snapshot(project)
+                for selector in ("missing", ".git/", "", "shared"):
+                    with self.subTest(selector=selector):
+                        self.assert_unignore_error(selector)
+                        self.assertEqual(state_snapshot(project), before)
+
+    def test_stale_index_blocks_chat_until_reinitialized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "public.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+            (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private.py",
+                            "--as",
+                            "Private module",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                self.assertEqual(run_silently(["unignore", "private-boundary"]), 0)
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    result = main(
+                        [
+                            "chat",
+                            "Review run",
+                            "--out",
+                            ".silobrief/exports/brief.md",
+                        ]
+                    )
+                self.assertEqual(result, 4)
+                self.assertIn("index is stale; run sb init", stderr.getvalue())
+                self.assertFalse((project / ".silobrief" / "exports" / "brief.md").exists())
+                self.assertEqual(run_silently(["init"]), 0)
+
+    def test_preserves_state_when_index_or_config_update_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            with working_directory(project):
+                self.assertEqual(
+                    run_silently(
+                        [
+                            "ignore",
+                            "private.py",
+                            "--as",
+                            "Private module",
+                            "--alias",
+                            "private-boundary",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+                before = state_snapshot(project)
+                for function in ("mark_index_stale", "save_config"):
+                    with (
+                        self.subTest(function=function),
+                        mock.patch(
+                            f"silobrief.boundaries.{function}",
+                            side_effect=SetupError("write failed"),
+                        ),
+                    ):
+                        self.assert_unignore_error("private-boundary")
+                        self.assertEqual(state_snapshot(project), before)
+
+    def test_same_state_produces_identical_config_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            results: list[bytes] = []
+            for name in ("first", "second"):
+                project = root / name
+                project.mkdir()
+                (project / "private.py").write_text("PRIVATE = True\n", encoding="utf-8")
+                self.assertEqual(run_silently(["setup", str(project)]), 0)
+                with working_directory(project):
+                    self.assertEqual(
+                        run_silently(
+                            [
+                                "ignore",
+                                "private.py",
+                                "--as",
+                                "Private module",
+                                "--alias",
+                                "private-boundary",
+                            ]
+                        ),
+                        0,
+                    )
+                    self.assertEqual(run_silently(["unignore", "private-boundary"]), 0)
+                results.append((project / ".silobrief" / "config.json").read_bytes())
+
+            self.assertEqual(results[0], results[1])
+
+    def test_requires_initialized_project(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            with working_directory(project):
+                message = self.assert_unignore_error("private-boundary")
+            self.assertIn("run sb setup first", message)


### PR DESCRIPTION
## v0.4.0

이번 릴리스는 사용자가 파일과 심볼을 직접 지정할 수 있는 exact-path review를 추가하고, 등록한 제외 경계를 해제할 수 있게 합니다. 또한 src-layout에서 제외 영역의 실제 이름이 브리프에 남을 수 있던 릴리스 차단 결함을 수정했습니다.

## 검증

- Ubuntu/Windows × Python 3.10/3.14 CI 통과
- 전체 unittest 149개 통과, Windows symlink 테스트 6개 제외
- wheel 및 sdist 생성
- 새 환경 wheel 설치 후 siloBrief 0.4.0 확인

Refs #108
