### PR TITLE
docs(release): correct v0.4.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-08-07
+## [0.4.0] - 2026-08-09
 
 ### Added
 
@@ -18,6 +18,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep exact-path symbol selection focused on the chosen symbols instead of expanding the whole
   module.
+- Replace excluded src-layout module and symbol names with their registered boundary placeholder
+  in the index and generated brief.
 
 ### Known limitations
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -23,7 +23,7 @@ CHANGELOG_EXPECTATIONS = (*PUBLIC_COMMANDS[:-1], "WRITE", "parcel-sync-fixture")
 V0_1_RELEASE_DATE = "2026-08-04"
 V0_2_RELEASE_DATE = "2026-08-05"
 V0_3_RELEASE_DATE = "2026-08-06"
-V0_4_RELEASE_DATE = "2026-08-07"
+V0_4_RELEASE_DATE = "2026-08-09"
 BRIEF_GUIDANCE_EXPECTATIONS = {
     "README.md": (
         "concrete task",
@@ -85,7 +85,13 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertIn(f"## [0.3.0] - {V0_3_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.2.0] - {V0_2_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.1.0] - {V0_1_RELEASE_DATE}", changelog)
-        for fragment in ("### Added", "### Fixed", "### Known limitations", "source bodies"):
+        for fragment in (
+            "### Added",
+            "### Fixed",
+            "### Known limitations",
+            "source bodies",
+            "excluded src-layout module and symbol names",
+        ):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
실제 발행일을 2026-08-09로 바로잡고 src-layout 경계 치환 수정 내용을 릴리스 노트에 추가합니다.

Refs #108