### PR TITLE
feat(search): add explainable candidate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Inspect up to ten deterministic code candidates with `sb search`, including the exact request
+  terms matched by each indexed field.
+
+### Changed
+
+- Show concrete matching terms instead of only match counts during `sb chat` candidate review.
+
+### Known limitations
+
+- Candidate search remains lexical and advisory. It does not automatically identify or approve
+  every source excerpt required for a change.
+
 ## [0.4.0] - 2026-08-09
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -75,6 +75,7 @@ siloBrief 0.4.0
 | `sb unignore SELECTOR` | 저장된 상대 경로나 별칭으로 등록 경계 하나를 해제합니다. |
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
+| `sb search "PROMPT"` | 관련 코드 후보를 최대 10개까지 찾고 어떤 요청 단어가 일치했는지 보여줍니다. |
 | `sb chat "PROMPT" --out FILE` | 전달할 내용을 검토하고 AI 요청 문서와 선택적 코드 첨부 파일을 만듭니다. |
 | `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
 
@@ -110,12 +111,14 @@ retry-brief.sources.md  사용자가 선택하고 승인한 소스 코드
 sb setup .
 sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
+sb search "Update retry_request to retry HTTP 503 but not 500."
 sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
 ```
 
 이 과정에서 `setup`은 작업 공간을 만들고, `ignore`는 읽으면 안 되는 경로를 등록합니다. `init`은
-나머지 Python 파일을 분석해 색인을 만들고, `chat`은 작업과 관련 있어 보이는 정보를 찾아
-검토 대상으로 보여줍니다.
+나머지 Python 파일을 분석해 색인을 만듭니다. `search`는 공개 검토를 시작하지 않고 관련 코드
+후보와 선정 근거를 확인할 때 사용합니다. `chat`은 같은 후보를 보여 준 뒤 실제로 포함할 내용을
+직접 선택하게 합니다.
 
 ### 등록한 제외 경로 해제하기
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ siloBrief 0.4.0
 | `sb unignore SELECTOR` | Removes one registered boundary by its exact stored path or alias. |
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
+| `sb search "PROMPT"` | Lists up to ten code candidates and the request terms that matched each one. |
 | `sb chat "PROMPT" --out FILE` | Reviews context and writes the main brief and optional code attachment. |
 | `sb --version` | Prints the installed siloBrief version. |
 
@@ -106,12 +107,14 @@ directory. Run these commands from the copied project root:
 sb setup .
 sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
+sb search "Update retry_request to retry HTTP 503 but not 500."
 sb chat "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
 ```
 
 `setup` prepares local state, `ignore` registers a path that must not be read, and `init` builds a
-local search list from the remaining Python files. `chat` then proposes relevant project context
-for review.
+local search list from the remaining Python files. `search` lets you inspect ranked candidates
+without starting disclosure review. `chat` uses the same candidates and then asks you to choose
+what may be included.
 
 ### Remove a registered boundary
 

--- a/src/silobrief/candidate_search.py
+++ b/src/silobrief/candidate_search.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from silobrief.index import IndexData
+from silobrief.ranking import RankEvidence, rank_candidates
+from silobrief.review import CandidateOption, ReviewError, candidate_options
+from silobrief.state import NotesData
+
+
+class CandidateSearchError(ValueError):
+    pass
+
+
+def search_candidates(
+    prompt: str,
+    index: IndexData,
+    notes: NotesData,
+) -> tuple[CandidateOption, ...]:
+    if not prompt.strip():
+        raise CandidateSearchError("request must not be empty")
+    try:
+        return candidate_options(rank_candidates(prompt, index, notes))
+    except ReviewError as error:
+        raise CandidateSearchError(str(error)) from error
+
+
+def render_candidate_results(options: tuple[CandidateOption, ...]) -> str:
+    lines = ["Candidates:"]
+    if not options:
+        lines.append("- none")
+    for option in options:
+        node = option.node
+        lines.append(
+            f"{option.number}. {node.path} | {node.kind} {node.qualified_name} "
+            f"| score={option.score}"
+        )
+        lines.append(f"   matches: {_render_matches(option.evidence)}")
+        lines.append(f"   connections: {option.evidence.connected_nodes}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_matches(evidence: RankEvidence) -> str:
+    fields = (
+        ("path", evidence.path_matches),
+        ("symbol", evidence.symbol_matches),
+        ("import", evidence.import_matches),
+        ("docstring", evidence.docstring_matches),
+        ("comment", evidence.comment_matches),
+        ("note", evidence.note_matches),
+    )
+    matches = [f"{label}={','.join(tokens)}" for label, tokens in fields if tokens]
+    return "; ".join(matches) if matches else "none"

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from typing import TextIO
 
 from silobrief.boundary_placeholders import BoundaryPlaceholder
+from silobrief.candidate_search import (
+    CandidateSearchError,
+    render_candidate_results,
+    search_candidates,
+)
 from silobrief.index import IndexData
-from silobrief.ranking import rank_candidates
 from silobrief.renderer import (
     ApprovedBoundary,
     ApprovedSymbol,
@@ -19,7 +23,6 @@ from silobrief.review import (
     ReviewError,
     ReviewSelection,
     SymbolOption,
-    candidate_options,
     review_selection,
     selector_symbol_options,
 )
@@ -61,8 +64,8 @@ def review_brief(
     _confirm_request(input_stream, output_stream)
 
     try:
-        options = candidate_options(rank_candidates(prompt, index, notes))
-    except ReviewError as error:
+        options = search_candidates(prompt, index, notes)
+    except CandidateSearchError as error:
         raise ChatReviewError(str(error)) from error
     _show_candidates(options, output_stream)
     selected_numbers = _read_numbers(input_stream, output_stream)
@@ -115,21 +118,7 @@ def review_brief(
 
 
 def _show_candidates(options: tuple[CandidateOption, ...], output: TextIO) -> None:
-    _write(output, "Candidates:\n")
-    if not options:
-        _write(output, "- none\n")
-    for option in options:
-        evidence = option.evidence
-        note = "yes" if evidence.note_match else "no"
-        _write(
-            output,
-            f"{option.number}. {option.node.path} | {option.node.kind} "
-            f"{option.node.qualified_name} | score={option.score} | "
-            f"path={evidence.path_matches} symbol={evidence.symbol_matches} "
-            f"import={evidence.import_matches} docstring={evidence.docstring_matches} "
-            f"comment={evidence.comment_matches} note={note} "
-            f"connected={evidence.connected_nodes}\n",
-        )
+    _write(output, render_candidate_results(options))
 
 
 def _confirm_request(input_stream: TextIO, output_stream: TextIO) -> None:

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 from silobrief import __version__
 from silobrief.boundaries import register_boundary, unregister_boundary
+from silobrief.candidate_search import (
+    CandidateSearchError,
+    render_candidate_results,
+    search_candidates,
+)
 from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
@@ -49,6 +54,8 @@ def _build_parser() -> argparse.ArgumentParser:
     log = subcommands.add_parser("log", help="Record public project context.")
     log.add_argument("path")
     log.add_argument("--comment", required=True)
+    search = subcommands.add_parser("search", help="Find candidate code for a request.")
+    search.add_argument("prompt")
     chat = subcommands.add_parser("chat", help="Create a reviewed research brief.")
     chat.add_argument("prompt")
     chat.add_argument("--out", dest="output", required=True)
@@ -138,6 +145,33 @@ def main(argv: Sequence[str] | None = None) -> int:
         except SetupError as error:
             parser.error(str(error))
         print(f"recorded note {note['id']} for {note['path']}; updated .silobrief/notes.json")
+
+    if arguments.command == "search":
+        prompt = arguments.prompt
+        if not isinstance(prompt, str) or not prompt.strip():
+            parser.error("request must not be empty")
+
+        start = Path.cwd()
+        try:
+            root = find_project_root(start)
+            index, snapshot = load_current_index(root)
+            notes = load_notes(root)
+            search_output = render_candidate_results(search_candidates(prompt, index, notes))
+        except IndexStateError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 3
+        except SetupError as error:
+            parser.error(str(error))
+        except StoredIndexError as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 3
+        except (CurrentIndexError, SourceCollectionError, CandidateSearchError) as error:
+            print(f"sb: error: {error}", file=sys.stderr)
+            return 4
+
+        for warning in snapshot.warnings:
+            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
+        print(search_output, end="")
 
     if arguments.command == "chat":
         prompt = arguments.prompt

--- a/src/silobrief/ranking.py
+++ b/src/silobrief/ranking.py
@@ -18,13 +18,17 @@ _MAX_CANDIDATES = 10
 
 @dataclass(frozen=True, slots=True)
 class RankEvidence:
-    path_matches: int
-    symbol_matches: int
-    import_matches: int
-    docstring_matches: int
-    comment_matches: int
-    note_match: bool
+    path_matches: tuple[str, ...]
+    symbol_matches: tuple[str, ...]
+    import_matches: tuple[str, ...]
+    docstring_matches: tuple[str, ...]
+    comment_matches: tuple[str, ...]
+    note_matches: tuple[str, ...]
     connected_nodes: int
+
+    @property
+    def note_match(self) -> bool:
+        return bool(self.note_matches)
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,14 +74,20 @@ def _evidence(
     note_tokens: tuple[tuple[HumanNoteData, frozenset[str]], ...],
 ) -> RankEvidence:
     return RankEvidence(
-        path_matches=_match_count(query, node.tokens.path),
-        symbol_matches=_match_count(query, node.tokens.symbol),
-        import_matches=_match_count(query, node.tokens.imports),
-        docstring_matches=_match_count(query, node.tokens.docstrings),
-        comment_matches=_match_count(query, node.tokens.comments),
-        note_match=any(
-            _note_applies(note["path"], node.path) and not query.isdisjoint(tokens)
-            for note, tokens in note_tokens
+        path_matches=_matches(query, node.tokens.path),
+        symbol_matches=_matches(query, node.tokens.symbol),
+        import_matches=_matches(query, node.tokens.imports),
+        docstring_matches=_matches(query, node.tokens.docstrings),
+        comment_matches=_matches(query, node.tokens.comments),
+        note_matches=tuple(
+            sorted(
+                {
+                    token
+                    for note, tokens in note_tokens
+                    if _note_applies(note["path"], node.path)
+                    for token in query.intersection(tokens)
+                }
+            )
         ),
         connected_nodes=len(adjacency.get(node.id, ())),
     )
@@ -103,8 +113,8 @@ def _note_applies(note_path: str, node_path: str) -> bool:
     return note_path == "." or node_path == note_path or node_path.startswith(f"{note_path}/")
 
 
-def _match_count(query: frozenset[str], tokens: tuple[str, ...]) -> int:
-    return len(query.intersection(tokens))
+def _matches(query: frozenset[str], tokens: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted(query.intersection(tokens)))
 
 
 def _has_text_match(evidence: RankEvidence) -> bool:
@@ -120,11 +130,11 @@ def _has_text_match(evidence: RankEvidence) -> bool:
 
 def _score(evidence: RankEvidence) -> int:
     return (
-        evidence.symbol_matches * _SYMBOL_WEIGHT
-        + evidence.path_matches * _PATH_WEIGHT
-        + evidence.import_matches * _IMPORT_WEIGHT
-        + evidence.docstring_matches * _DOCSTRING_WEIGHT
-        + evidence.comment_matches * _COMMENT_WEIGHT
+        len(evidence.symbol_matches) * _SYMBOL_WEIGHT
+        + len(evidence.path_matches) * _PATH_WEIGHT
+        + len(evidence.import_matches) * _IMPORT_WEIGHT
+        + len(evidence.docstring_matches) * _DOCSTRING_WEIGHT
+        + len(evidence.comment_matches) * _COMMENT_WEIGHT
         + (_NOTE_WEIGHT if evidence.note_match else 0)
         + min(evidence.connected_nodes, _MAX_CONNECTIVITY_SCORE)
     )

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -135,8 +135,8 @@ class ChatReviewTests(unittest.TestCase):
         visible = output.getvalue()
         self.assertIn("src/service.py", visible)
         self.assertIn("src/helper.py", visible)
-        self.assertIn("path=1", visible)
-        self.assertIn("connected=1", visible)
+        self.assertIn("path=retry", visible)
+        self.assertIn("connections: 1", visible)
         hidden_values = (
             "source-body-canary|internal-real-name|.models.SyncResult|src/second.py|"
             "second-hop-canary|unselected-note-canary|root-id"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.code, 2)
         self.assertIn("usage: sb", stderr.getvalue())
-        self.assertIn("{setup,ignore,unignore,init,log,chat}", stderr.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,search,chat}", stderr.getvalue())
 
     def test_help_lists_commands_and_succeeds(self) -> None:
         stdout = io.StringIO()
@@ -27,7 +27,7 @@ class CommandLineTests(unittest.TestCase):
             main(["--help"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertIn("{setup,ignore,unignore,init,log,chat}", stdout.getvalue())
+        self.assertIn("{setup,ignore,unignore,init,log,search,chat}", stdout.getvalue())
 
 
 class VersionCommandTests(unittest.TestCase):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -12,6 +12,7 @@ PUBLIC_COMMANDS = (
     "sb unignore",
     "sb init",
     "sb log",
+    "sb search",
     "sb chat",
     "sb --version",
 )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -111,12 +111,12 @@ class LexicalRankingTests(unittest.TestCase):
                     node=candidate,
                     score=27,
                     evidence=RankEvidence(
-                        path_matches=1,
-                        symbol_matches=2,
-                        import_matches=1,
-                        docstring_matches=1,
-                        comment_matches=1,
-                        note_match=True,
+                        path_matches=("retry",),
+                        symbol_matches=("client", "retry"),
+                        import_matches=("http",),
+                        docstring_matches=("docs",),
+                        comment_matches=("comment",),
+                        note_matches=("note",),
                         connected_nodes=4,
                     ),
                 ),
@@ -151,7 +151,7 @@ class LexicalRankingTests(unittest.TestCase):
         self.assertEqual(ranked, reordered)
         self.assertEqual([item.node.id for item in ranked], ["worker", "service"])
         self.assertTrue(all(item.score == 4 for item in ranked))
-        self.assertTrue(all(item.evidence.note_match for item in ranked))
+        self.assertTrue(all(item.evidence.note_matches == ("retry",) for item in ranked))
 
     def test_limits_results_and_uses_deterministic_tie_breakers(self) -> None:
         same_path = (

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -56,12 +56,12 @@ def ranked(candidate: IndexNode, score: int) -> RankedCandidate:
         node=candidate,
         score=score,
         evidence=RankEvidence(
-            path_matches=1,
-            symbol_matches=0,
-            import_matches=0,
-            docstring_matches=0,
-            comment_matches=0,
-            note_match=False,
+            path_matches=("match",),
+            symbol_matches=(),
+            import_matches=(),
+            docstring_matches=(),
+            comment_matches=(),
+            note_matches=(),
             connected_nodes=0,
         ),
     )

--- a/tests/test_search_command.py
+++ b/tests/test_search_command.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from silobrief.cli import main
+from tests.test_chat_command import prepare_project, working_directory
+
+
+def project_digest(project: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(item for item in project.rglob("*") if item.is_file()):
+        digest.update(path.relative_to(project).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+class SearchCommandTests(unittest.TestCase):
+    def test_prints_explainable_candidates_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            before = project_digest(project)
+
+            first_stdout = io.StringIO()
+            first_stderr = io.StringIO()
+            with (
+                working_directory(project),
+                contextlib.redirect_stdout(first_stdout),
+                contextlib.redirect_stderr(first_stderr),
+            ):
+                first_result = main(["search", "run delivery with urllib3"])
+
+            second_stdout = io.StringIO()
+            second_stderr = io.StringIO()
+            with (
+                working_directory(project),
+                contextlib.redirect_stdout(second_stdout),
+                contextlib.redirect_stderr(second_stderr),
+            ):
+                second_result = main(["search", "run delivery with urllib3"])
+
+            self.assertEqual((first_result, second_result), (0, 0))
+            self.assertEqual(first_stderr.getvalue(), "")
+            self.assertEqual(second_stderr.getvalue(), "")
+            self.assertEqual(first_stdout.getvalue(), second_stdout.getvalue())
+            self.assertEqual(project_digest(project), before)
+
+            output = first_stdout.getvalue()
+            self.assertIn("Candidates:\n", output)
+            self.assertIn("package/service.py | function run", output)
+            self.assertIn("symbol=run", output)
+            self.assertIn("import=delivery,urllib3", output)
+            self.assertNotIn("private-boundary-canary", output)
+
+    def test_rejects_empty_prompt(self) -> None:
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            main(["search", "   "])
+
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("request must not be empty", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 Issue

Refs #116

## 변경 이유

검색 후보는 `sb chat` 안에서만 볼 수 있었고, 후보 근거가 필드별 일치 개수로만 표시되어 수정 지점을 고르기 어려웠습니다. 공개 검토 전에 검색만 반복할 수 있는 읽기 전용 단계가 필요합니다.

## 변경 내용

- `sb search PROMPT` 비대화형 명령 추가
- 최대 10개 후보의 경로, 심볼, 점수와 실제 일치 요청 토큰 표시
- `sb search`와 `sb chat`이 같은 후보 생성·표시 코드를 사용
- 검색 전후 프로젝트와 siloBrief 상태가 동일한 acceptance test 추가
- 영문·한국어 README와 Unreleased changelog 갱신

검색 점수 공식과 Top 10 제한은 바꾸지 않았습니다. 이번 변경은 자동 선택 정확도 향상을 주장하지 않고 사람이 후보를 검토하는 단계를 독립시킵니다.

## 검증

- [x] 관련 acceptance 또는 regression test를 추가했습니다.
- [x] 로컬 테스트를 실행했습니다.
- [x] 타입 검사와 lint를 통과했습니다.
- [x] 실제 조직·저장소·자격 증명·제한 정보를 포함하지 않았습니다.

실행한 명령과 결과:

```text
python -m unittest discover
151 tests OK, 6 skipped
python -m ruff check src tests
All checks passed
python -m ruff format --check src tests
49 files already formatted
python -m mypy src tests
Success: no issues found in 49 source files
```

## 제외 범위와 남은 제한

- 검색 결과 자동 선택·자동 반출 없음
- lexical 순위 공식 변경 없음
- 임베딩·벡터 DB·그래프 DB 없음
- 검색 정확도 개선을 주장하지 않음