### PR TITLE
feat(language): add independent CLI and brief locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a deterministic synthetic Python practice project with `sb example PATH`, including
   guided modification, addition, and removal tasks.
+- Configure terminal guidance and generated Markdown independently in English or Korean with
+  `sb language`; both settings default to English.
 
 ## [0.5.0] - 2026-08-09
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -77,6 +77,7 @@ siloBrief 0.5.0
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
 | `sb search "PROMPT"` | 관련 코드 후보를 최대 10개까지 찾고 어떤 요청 단어가 일치했는지 보여줍니다. |
+| `sb language [--cli en|ko] [--brief en|ko]` | 터미널 안내와 생성 브리프의 언어를 각각 설정합니다. |
 | `sb chat "PROMPT" --out FILE` | 전달할 내용을 검토하고 자족적인 Markdown 파일 하나를 만듭니다. |
 | `sb --version` | 설치된 siloBrief 버전을 출력합니다. |
 
@@ -84,6 +85,20 @@ siloBrief 0.5.0
 대화형 터미널에서만 실행할 수 있으며, 현재 설정으로 만든 색인과 새로운 `.md` 출력 경로가
 필요합니다. 프로젝트 안에 파일을 만들 때는 `.silobrief/exports/` 아래만 사용할 수 있고 기존
 파일은 덮어쓰지 않습니다.
+
+두 언어의 기본값은 모두 영어입니다. 설정은 프로젝트별로 저장되며 함께 또는 따로 바꿀 수
+있습니다.
+
+```console
+sb language --cli ko
+sb language --brief en
+sb language
+```
+
+CLI 설정은 터미널의 고정 안내 문구를 바꿉니다. 브리프 설정은 siloBrief가 생성하는 제목과
+지시문을 바꿉니다. 사용자가 입력한 작업 요청과 메모, 소스 코드, 경로, 심볼과 식별자는 번역하지
+않고 원문을 유지합니다. 언어 설정은 색인, 후보 순위, ID, 정렬과 소스 digest에 영향을 주지
+않습니다.
 
 ## 생성되는 파일
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,27 @@ siloBrief 0.5.0
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
 | `sb search "PROMPT"` | Lists up to ten code candidates and the request terms that matched each one. |
+| `sb language [--cli en|ko] [--brief en|ko]` | Sets terminal and generated-brief languages independently. |
 | `sb chat "PROMPT" --out FILE` | Reviews context and writes one self-contained brief. |
 | `sb --version` | Prints the installed siloBrief version. |
 
 Commands other than `setup` and `example` find the project root from the current directory. `chat`
 requires an interactive terminal, a current index, and a new `.md` output path. Output inside the
 project must be below `.silobrief/exports/`. Existing files are never overwritten.
+
+Both language settings default to English. They are stored per project and can be changed together
+or separately:
+
+```console
+sb language --cli ko
+sb language --brief en
+sb language
+```
+
+The CLI setting changes fixed terminal guidance. The brief setting changes the headings and
+instructions written by siloBrief. Task text, project notes, source code, paths, symbols, and
+identifiers remain exactly as entered or selected. Language settings do not change indexing,
+candidate ranking, IDs, ordering, or source digests.
 
 ## Generated file
 

--- a/src/silobrief/candidate_search.py
+++ b/src/silobrief/candidate_search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from silobrief.index import IndexData
+from silobrief.language import Language, localized
 from silobrief.ranking import RankEvidence, rank_candidates
 from silobrief.review import CandidateOption, ReviewError, candidate_options
 from silobrief.state import NotesData
@@ -23,29 +24,36 @@ def search_candidates(
         raise CandidateSearchError(str(error)) from error
 
 
-def render_candidate_results(options: tuple[CandidateOption, ...]) -> str:
-    lines = ["Candidates:"]
+def render_candidate_results(
+    options: tuple[CandidateOption, ...], *, language: Language = "en"
+) -> str:
+    lines = [localized(language, "Candidates:", "후보:")]
     if not options:
-        lines.append("- none")
+        lines.append(localized(language, "- none", "- 없음"))
     for option in options:
         node = option.node
         lines.append(
             f"{option.number}. {node.path} | {node.kind} {node.qualified_name} "
             f"| score={option.score}"
         )
-        lines.append(f"   matches: {_render_matches(option.evidence)}")
-        lines.append(f"   connections: {option.evidence.connected_nodes}")
+        lines.append(
+            f"   {localized(language, 'matches', '일치 항목')}: "
+            f"{_render_matches(option.evidence, language=language)}"
+        )
+        lines.append(
+            f"   {localized(language, 'connections', '연결 수')}: {option.evidence.connected_nodes}"
+        )
     return "\n".join(lines) + "\n"
 
 
-def _render_matches(evidence: RankEvidence) -> str:
+def _render_matches(evidence: RankEvidence, *, language: Language) -> str:
     fields = (
-        ("path", evidence.path_matches),
-        ("symbol", evidence.symbol_matches),
+        (localized(language, "path", "경로"), evidence.path_matches),
+        (localized(language, "symbol", "심볼"), evidence.symbol_matches),
         ("import", evidence.import_matches),
         ("docstring", evidence.docstring_matches),
-        ("comment", evidence.comment_matches),
-        ("note", evidence.note_matches),
+        (localized(language, "comment", "주석"), evidence.comment_matches),
+        (localized(language, "note", "메모"), evidence.note_matches),
     )
     matches = [f"{label}={','.join(tokens)}" for label, tokens in fields if tokens]
-    return "; ".join(matches) if matches else "none"
+    return "; ".join(matches) if matches else localized(language, "none", "없음")

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -9,6 +9,7 @@ from silobrief.candidate_search import (
     search_candidates,
 )
 from silobrief.index import IndexData
+from silobrief.language import Language, localized
 from silobrief.renderer import (
     ApprovedBoundary,
     ApprovedSymbol,
@@ -50,26 +51,45 @@ def review_brief(
     input_stream: TextIO,
     output_stream: TextIO,
     snapshot: SourceSnapshot | None = None,
+    brief_language: Language = "en",
+    cli_language: Language = "en",
 ) -> RenderedBrief:
     if not prompt.strip():
-        raise ChatReviewError("request must not be empty")
+        raise ChatReviewError(
+            localized(cli_language, "request must not be empty", "요청은 비어 있을 수 없습니다")
+        )
     if not input_stream.isatty() or not output_stream.isatty():
-        raise ChatReviewError("review requires an interactive terminal")
+        raise ChatReviewError(
+            localized(
+                cli_language,
+                "review requires an interactive terminal",
+                "검토에는 대화형 터미널이 필요합니다",
+            )
+        )
     if not index.nodes:
         raise ChatReviewError(
-            "no indexed Python symbols are available; "
-            "siloBrief currently supports Python projects only"
+            localized(
+                cli_language,
+                "no indexed Python symbols are available; "
+                "siloBrief currently supports Python projects only",
+                "인덱스에 Python 심볼이 없습니다. siloBrief는 현재 Python 프로젝트만 지원합니다",
+            )
         )
-    _confirm_request(input_stream, output_stream)
+    _confirm_request(input_stream, output_stream, cli_language)
 
     try:
         options = search_candidates(prompt, index, notes)
     except CandidateSearchError as error:
         raise ChatReviewError(str(error)) from error
-    _show_candidates(options, output_stream)
-    selected_numbers = _read_numbers(input_stream, output_stream)
-    added = _read_additions(index, input_stream, output_stream)
-    excluded = _read_selectors("Exclude path or node ID", input_stream, output_stream)
+    _show_candidates(options, output_stream, cli_language)
+    selected_numbers = _read_numbers(input_stream, output_stream, cli_language)
+    added = _read_additions(index, input_stream, output_stream, cli_language)
+    excluded = _read_selectors(
+        localized(cli_language, "Exclude path or node ID", "제외할 경로 또는 노드 ID"),
+        input_stream,
+        output_stream,
+        cli_language,
+    )
     try:
         selection = review_selection(
             index,
@@ -81,9 +101,11 @@ def review_brief(
         )
     except ReviewError as error:
         raise ChatReviewError(str(error)) from error
-    _show_selection(selection, output_stream)
+    _show_selection(selection, output_stream, cli_language)
     reviewed = ReviewSelection(
-        selection.selected, selection.expanded, _read_fields(input_stream, output_stream)
+        selection.selected,
+        selection.expanded,
+        _read_fields(input_stream, output_stream, cli_language),
     )
 
     approved_sources: tuple[ApprovedSourceExcerpt, ...] = ()
@@ -95,6 +117,7 @@ def review_brief(
                 reviewed,
                 input_stream=input_stream,
                 output_stream=output_stream,
+                language=cli_language,
             )
         except SourceReviewError as error:
             raise ChatReviewError(str(error)) from error
@@ -106,44 +129,83 @@ def review_brief(
                 notes,
                 reviewed,
                 source_excerpts=approved_sources,
-            )
+            ),
+            language=brief_language,
         )
     except RenderError as error:
         raise ChatReviewError(str(error)) from error
 
 
-def _show_candidates(options: tuple[CandidateOption, ...], output: TextIO) -> None:
-    _write(output, render_candidate_results(options))
+def _show_candidates(
+    options: tuple[CandidateOption, ...], output: TextIO, language: Language
+) -> None:
+    _write(output, render_candidate_results(options, language=language))
 
 
-def _confirm_request(input_stream: TextIO, output_stream: TextIO) -> None:
+def _confirm_request(input_stream: TextIO, output_stream: TextIO, language: Language) -> None:
     _write(
         output_stream,
-        "Request completeness:\n"
-        "- work goal\n"
-        "- required deliverables\n"
-        "- completion or acceptance criteria\n",
+        localized(
+            language,
+            "Request completeness:\n"
+            "- work goal\n"
+            "- required deliverables\n"
+            "- completion or acceptance criteria\n",
+            "요청 내용 확인:\n- 작업 목표\n- 필요한 결과물\n- 완료 또는 승인 기준\n",
+        ),
     )
     if (
-        _read_line("Continue with this complete request? [y/N]: ", input_stream, output_stream)
+        _read_line(
+            localized(
+                language,
+                "Continue with this complete request? [y/N]: ",
+                "이 요청으로 계속할까요? [y/N]: ",
+            ),
+            input_stream,
+            output_stream,
+        )
         != "y"
     ):
-        raise ChatReviewError("request completeness was not confirmed")
+        raise ChatReviewError(
+            localized(
+                language,
+                "request completeness was not confirmed",
+                "요청 내용이 확인되지 않았습니다",
+            )
+        )
 
 
-def _read_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[int, ...]:
-    value = _read_line("Select candidate numbers: ", input_stream, output_stream)
+def _read_numbers(
+    input_stream: TextIO, output_stream: TextIO, language: Language
+) -> tuple[int, ...]:
+    value = _read_line(
+        localized(language, "Select candidate numbers: ", "후보 번호를 선택하세요: "),
+        input_stream,
+        output_stream,
+    )
     if not value:
         return ()
     try:
         return tuple(int(part) for part in value.split())
     except ValueError as error:
-        raise ChatReviewError("candidate numbers must be space-separated integers") from error
+        raise ChatReviewError(
+            localized(
+                language,
+                "candidate numbers must be space-separated integers",
+                "후보 번호는 공백으로 구분한 정수여야 합니다",
+            )
+        ) from error
 
 
-def _read_selectors(label: str, input_stream: TextIO, output_stream: TextIO) -> tuple[str, ...]:
+def _read_selectors(
+    label: str,
+    input_stream: TextIO,
+    output_stream: TextIO,
+    language: Language,
+) -> tuple[str, ...]:
     values: list[str] = []
-    while value := _read_line(f"{label} (blank to finish): ", input_stream, output_stream):
+    suffix = localized(language, " (blank to finish): ", " (끝내려면 Enter): ")
+    while value := _read_line(f"{label}{suffix}", input_stream, output_stream):
         values.append(value)
     return tuple(values)
 
@@ -152,10 +214,17 @@ def _read_additions(
     index: IndexData,
     input_stream: TextIO,
     output_stream: TextIO,
+    language: Language,
 ) -> tuple[str, ...]:
     selectors: list[str] = []
     while selector := _read_line(
-        "Add path or node ID (blank to finish): ", input_stream, output_stream
+        localized(
+            language,
+            "Add path or node ID (blank to finish): ",
+            "추가할 경로 또는 노드 ID (끝내려면 Enter): ",
+        ),
+        input_stream,
+        output_stream,
     ):
         try:
             options = selector_symbol_options(index, selector)
@@ -164,14 +233,20 @@ def _read_additions(
         if options is None:
             selectors.append(selector)
             continue
-        _show_symbol_options(selector, options, output_stream)
-        numbers = _read_symbol_numbers(input_stream, output_stream)
+        _show_symbol_options(selector, options, output_stream, language)
+        numbers = _read_symbol_numbers(input_stream, output_stream, language)
         if not numbers:
             selectors.append(selector)
             continue
         for number in numbers:
             if number > len(options):
-                raise ChatReviewError(f"unknown symbol number: {number}")
+                raise ChatReviewError(
+                    localized(
+                        language,
+                        f"unknown symbol number: {number}",
+                        f"알 수 없는 심볼 번호: {number}",
+                    )
+                )
             selectors.append(options[number - 1].node.id)
     return tuple(selectors)
 
@@ -180,17 +255,27 @@ def _show_symbol_options(
     path: str,
     options: tuple[SymbolOption, ...],
     output: TextIO,
+    language: Language,
 ) -> None:
-    _write(output, f"Symbols in `{path}`:\n")
+    _write(
+        output,
+        localized(language, f"Symbols in `{path}`:\n", f"`{path}`의 심볼:\n"),
+    )
     if not options:
-        _write(output, "- none\n")
+        _write(output, localized(language, "- none\n", "- 없음\n"))
     for option in options:
         _write(output, f"{option.number}. {option.node.kind} {option.node.qualified_name}\n")
 
 
-def _read_symbol_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[int, ...]:
+def _read_symbol_numbers(
+    input_stream: TextIO, output_stream: TextIO, language: Language
+) -> tuple[int, ...]:
     value = _read_line(
-        "Select symbol numbers from this file (blank for module only): ",
+        localized(
+            language,
+            "Select symbol numbers from this file (blank for module only): ",
+            "이 파일에서 심볼 번호를 선택하세요 (모듈만 고르려면 Enter): ",
+        ),
         input_stream,
         output_stream,
     )
@@ -199,40 +284,85 @@ def _read_symbol_numbers(input_stream: TextIO, output_stream: TextIO) -> tuple[i
     try:
         numbers = tuple(int(part) for part in value.split())
     except ValueError as error:
-        raise ChatReviewError("symbol numbers must be space-separated positive integers") from error
+        raise ChatReviewError(
+            localized(
+                language,
+                "symbol numbers must be space-separated positive integers",
+                "심볼 번호는 공백으로 구분한 양의 정수여야 합니다",
+            )
+        ) from error
     if any(number < 1 for number in numbers):
-        raise ChatReviewError("symbol numbers must be space-separated positive integers")
+        raise ChatReviewError(
+            localized(
+                language,
+                "symbol numbers must be space-separated positive integers",
+                "심볼 번호는 공백으로 구분한 양의 정수여야 합니다",
+            )
+        )
     return numbers
 
 
-def _show_selection(selection: ReviewSelection, output: TextIO) -> None:
+def _show_selection(selection: ReviewSelection, output: TextIO, language: Language) -> None:
     for label, nodes in (
-        ("Selected context", selection.selected),
-        ("Expanded context", selection.expanded),
+        (localized(language, "Selected context", "선택한 맥락"), selection.selected),
+        (localized(language, "Expanded context", "확장된 맥락"), selection.expanded),
     ):
         _write(output, f"{label}:\n")
         if not nodes:
-            _write(output, "- none\n")
+            _write(output, localized(language, "- none\n", "- 없음\n"))
         for node in nodes:
             _write(output, f"- {node.path} | {node.kind} {node.qualified_name}\n")
 
 
-def _read_fields(input_stream: TextIO, output_stream: TextIO) -> DisclosureChoices:
+def _read_fields(
+    input_stream: TextIO, output_stream: TextIO, language: Language
+) -> DisclosureChoices:
     return DisclosureChoices(
-        paths=_read_choice("Include relative paths?", input_stream, output_stream),
-        symbols=_read_choice("Include symbols?", input_stream, output_stream),
-        public_libraries=_read_choice("Include public libraries?", input_stream, output_stream),
-        human_notes=_read_choice("Include human notes?", input_stream, output_stream),
+        paths=_read_choice(
+            localized(language, "Include relative paths?", "상대 경로를 포함할까요?"),
+            input_stream,
+            output_stream,
+            language,
+        ),
+        symbols=_read_choice(
+            localized(language, "Include symbols?", "심볼을 포함할까요?"),
+            input_stream,
+            output_stream,
+            language,
+        ),
+        public_libraries=_read_choice(
+            localized(language, "Include public libraries?", "공개 라이브러리를 포함할까요?"),
+            input_stream,
+            output_stream,
+            language,
+        ),
+        human_notes=_read_choice(
+            localized(language, "Include human notes?", "사용자 메모를 포함할까요?"),
+            input_stream,
+            output_stream,
+            language,
+        ),
         boundary_placeholders=_read_choice(
-            "Include boundary placeholders?", input_stream, output_stream
+            localized(language, "Include boundary placeholders?", "경계 정보를 포함할까요?"),
+            input_stream,
+            output_stream,
+            language,
         ),
     )
 
 
-def _read_choice(label: str, input_stream: TextIO, output_stream: TextIO) -> bool:
+def _read_choice(
+    label: str, input_stream: TextIO, output_stream: TextIO, language: Language
+) -> bool:
     value = _read_line(f"{label} [y/n]: ", input_stream, output_stream)
     if value not in {"y", "n"}:
-        raise ChatReviewError("field answer must be exactly y or n")
+        raise ChatReviewError(
+            localized(
+                language,
+                "field answer must be exactly y or n",
+                "항목 응답은 정확히 y 또는 n이어야 합니다",
+            )
+        )
     return value == "y"
 
 

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -16,6 +16,7 @@ from silobrief.chat_review import ChatReviewError, review_brief
 from silobrief.current_index import CurrentIndexError, load_current_index
 from silobrief.example_project import ExampleProjectError, create_example_project
 from silobrief.initialization import IndexingError, SourceChangedError, initialize_index
+from silobrief.language import Language, LanguageSettings, localized, parse_language
 from silobrief.notes import add_note
 from silobrief.output import OutputBlockedError, approve_and_write
 from silobrief.sources import SourceCollectionError
@@ -23,85 +24,202 @@ from silobrief.state import (
     IndexStateError,
     SetupError,
     find_project_root,
+    load_language_settings,
     load_notes,
+    save_language_settings,
     setup_project,
 )
 from silobrief.stored_index import StoredIndexError
 
-_SOURCE_DISCLOSURE_WARNING = (
+_SOURCE_DISCLOSURE_WARNING_EN = (
     "warning: non-ignored Python files are analyzed locally; source excerpts you select and "
     "approve may be exported verbatim with comments, docstrings, strings, and internal "
     "identifiers. siloBrief does not detect secrets or provide security approval; review all "
     "output yourself."
 )
+_SOURCE_DISCLOSURE_WARNING_KO = (
+    "경고: 무시하지 않은 Python 파일은 로컬에서 분석됩니다. 사용자가 선택하고 승인한 "
+    "소스 발췌는 주석, docstring, 문자열과 내부 식별자를 포함한 원문 그대로 내보낼 수 "
+    "있습니다. siloBrief는 비밀정보를 탐지하거나 보안 승인을 제공하지 않습니다. 모든 "
+    "출력을 직접 검토하세요."
+)
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def _build_parser(language: Language = "en") -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="sb",
-        description="Create a reviewed research brief from Python project context.",
+        description=localized(
+            language,
+            "Create a reviewed research brief from Python project context.",
+            "Python 프로젝트 맥락으로 검토된 작업 브리프를 만듭니다.",
+        ),
     )
     parser.add_argument("--version", action="version", version=f"siloBrief {__version__}")
     subcommands = parser.add_subparsers(dest="command", required=True)
-    setup = subcommands.add_parser("setup", help="Initialize local project state.")
+    setup = subcommands.add_parser(
+        "setup",
+        help=localized(
+            language, "Initialize local project state.", "로컬 프로젝트 상태를 만듭니다."
+        ),
+    )
     setup.add_argument("path", nargs="?", type=Path, default=Path.cwd())
-    example = subcommands.add_parser("example", help="Create a guided practice project.")
+    example = subcommands.add_parser(
+        "example",
+        help=localized(
+            language, "Create a guided practice project.", "실습용 예제 프로젝트를 만듭니다."
+        ),
+    )
     example.add_argument("path", type=Path)
-    ignore = subcommands.add_parser("ignore", help="Register a project boundary.")
+    ignore = subcommands.add_parser(
+        "ignore",
+        help=localized(
+            language, "Register a project boundary.", "프로젝트 공개 경계를 등록합니다."
+        ),
+    )
     ignore.add_argument("path")
     ignore.add_argument("--as", dest="description", required=True)
     ignore.add_argument("--alias")
-    unignore = subcommands.add_parser("unignore", help="Remove a registered project boundary.")
+    unignore = subcommands.add_parser(
+        "unignore",
+        help=localized(
+            language, "Remove a registered project boundary.", "등록한 공개 경계를 제거합니다."
+        ),
+    )
     unignore.add_argument("selector")
-    subcommands.add_parser("init", help="Build the local source index.")
-    log = subcommands.add_parser("log", help="Record public project context.")
+    subcommands.add_parser(
+        "init",
+        help=localized(language, "Build the local source index.", "로컬 소스 인덱스를 만듭니다."),
+    )
+    log = subcommands.add_parser(
+        "log",
+        help=localized(
+            language, "Record public project context.", "공개 가능한 프로젝트 메모를 기록합니다."
+        ),
+    )
     log.add_argument("path")
     log.add_argument("--comment", required=True)
-    search = subcommands.add_parser("search", help="Find candidate code for a request.")
+    search = subcommands.add_parser(
+        "search",
+        help=localized(
+            language, "Find candidate code for a request.", "요청과 관련된 코드 후보를 찾습니다."
+        ),
+    )
     search.add_argument("prompt")
-    chat = subcommands.add_parser("chat", help="Create a reviewed research brief.")
+    language_parser = subcommands.add_parser(
+        "language",
+        help=localized(
+            language, "Configure CLI and brief languages.", "CLI와 브리프 언어를 설정합니다."
+        ),
+    )
+    language_parser.add_argument("--cli", dest="cli_language", choices=("en", "ko"))
+    language_parser.add_argument("--brief", dest="brief_language", choices=("en", "ko"))
+    chat = subcommands.add_parser(
+        "chat",
+        help=localized(
+            language, "Create a reviewed research brief.", "검토 후 작업 브리프를 만듭니다."
+        ),
+    )
     chat.add_argument("prompt")
     chat.add_argument("--out", dest="output", required=True)
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
+    cli_language = _detect_cli_language(Path.cwd())
+    parser = _build_parser(cli_language)
     arguments = parser.parse_args(argv)
 
     if arguments.command == "example":
         project = arguments.path
         if not isinstance(project, Path):
-            parser.error("example path must be a filesystem path")
+            parser.error(
+                localized(
+                    cli_language,
+                    "example path must be a filesystem path",
+                    "예제 경로는 파일 시스템 경로여야 합니다",
+                )
+            )
         try:
             file_count = create_example_project(project)
         except ExampleProjectError as error:
             parser.error(str(error))
-        print(f"created example project with {file_count} files at {project}")
-        print("next: enter that directory and run sb setup .")
+        print(
+            localized(
+                cli_language,
+                f"created example project with {file_count} files at {project}",
+                f"{project}에 파일 {file_count}개로 예제 프로젝트를 만들었습니다",
+            )
+        )
+        print(
+            localized(
+                cli_language,
+                "next: enter that directory and run sb setup .",
+                "다음: 해당 디렉터리에서 sb setup . 을 실행하세요",
+            )
+        )
 
     if arguments.command == "setup":
         project = arguments.path
         if not isinstance(project, Path):
-            parser.error("setup path must be a filesystem path")
+            parser.error(
+                localized(
+                    cli_language,
+                    "setup path must be a filesystem path",
+                    "설정 경로는 파일 시스템 경로여야 합니다",
+                )
+            )
         try:
             created = setup_project(project)
         except SetupError as error:
             parser.error(str(error))
+        try:
+            cli_language = load_language_settings(project.resolve(strict=True))["cli_language"]
+        except (OSError, SetupError):
+            pass
         if created:
-            print("created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/")
+            print(
+                localized(
+                    cli_language,
+                    "created .silobrief/config.json, .silobrief/notes.json, "
+                    ".silobrief/language.json, and .silobrief/exports/",
+                    ".silobrief/config.json, .silobrief/notes.json, "
+                    ".silobrief/language.json과 .silobrief/exports/를 만들었습니다",
+                )
+            )
         else:
-            print("validated existing .silobrief state")
-        print(_SOURCE_DISCLOSURE_WARNING)
+            print(
+                localized(
+                    cli_language,
+                    "validated existing .silobrief state",
+                    "기존 .silobrief 상태를 확인했습니다",
+                )
+            )
+        print(
+            localized(
+                cli_language,
+                _SOURCE_DISCLOSURE_WARNING_EN,
+                _SOURCE_DISCLOSURE_WARNING_KO,
+            )
+        )
 
     if arguments.command == "ignore":
         path_text = arguments.path
         description = arguments.description
         alias = arguments.alias
         if not isinstance(path_text, str) or not isinstance(description, str):
-            parser.error("ignore path and description must be text")
+            parser.error(
+                localized(
+                    cli_language,
+                    "ignore path and description must be text",
+                    "무시 경로와 설명은 텍스트여야 합니다",
+                )
+            )
         if alias is not None and not isinstance(alias, str):
-            parser.error("ignore alias must be text")
+            parser.error(
+                localized(
+                    cli_language, "ignore alias must be text", "무시 alias는 텍스트여야 합니다"
+                )
+            )
         try:
             registration = register_boundary(path_text, description, alias, start=Path.cwd())
         except SetupError as error:
@@ -109,23 +227,45 @@ def main(argv: Sequence[str] | None = None) -> int:
         boundary = registration.boundary
         if registration.changed:
             print(
-                f"registered boundary {boundary['alias']} for {boundary['path']}; "
-                "updated .silobrief/config.json"
+                localized(
+                    cli_language,
+                    f"registered boundary {boundary['alias']} for {boundary['path']}; "
+                    "updated .silobrief/config.json",
+                    f"{boundary['path']}에 경계 {boundary['alias']}를 등록하고 "
+                    ".silobrief/config.json을 갱신했습니다",
+                )
             )
         else:
-            print(f"boundary {boundary['alias']} for {boundary['path']} is already registered")
+            print(
+                localized(
+                    cli_language,
+                    f"boundary {boundary['alias']} for {boundary['path']} is already registered",
+                    f"{boundary['path']}의 경계 {boundary['alias']}는 이미 등록되어 있습니다",
+                )
+            )
 
     if arguments.command == "unignore":
         selector = arguments.selector
         if not isinstance(selector, str):
-            parser.error("unignore selector must be text")
+            parser.error(
+                localized(
+                    cli_language,
+                    "unignore selector must be text",
+                    "경계 선택자는 텍스트여야 합니다",
+                )
+            )
         try:
             boundary = unregister_boundary(selector, start=Path.cwd())
         except SetupError as error:
             parser.error(str(error))
         print(
-            f"removed boundary {boundary['alias']} for {boundary['path']}; "
-            "run sb init before sb chat"
+            localized(
+                cli_language,
+                f"removed boundary {boundary['alias']} for {boundary['path']}; "
+                "run sb init before sb chat",
+                f"{boundary['path']}의 경계 {boundary['alias']}를 제거했습니다. "
+                "sb chat 전에 sb init을 실행하세요",
+            )
         )
 
     if arguments.command == "init":
@@ -134,86 +274,170 @@ def main(argv: Sequence[str] | None = None) -> int:
         except SetupError as error:
             parser.error(str(error))
         except IndexingError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 3
         except SourceChangedError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 4
         for warning in warnings:
-            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
-        print("built .silobrief/index.json")
+            print(
+                f"{localized(cli_language, 'warning', '경고')}: {warning.path}: {warning.reason}",
+                file=sys.stderr,
+            )
+        print(
+            localized(
+                cli_language, "built .silobrief/index.json", ".silobrief/index.json을 만들었습니다"
+            )
+        )
 
     if arguments.command == "log":
         path_text = arguments.path
         comment = arguments.comment
         if not isinstance(path_text, str) or not isinstance(comment, str):
-            parser.error("log path and comment must be text")
+            parser.error(
+                localized(
+                    cli_language,
+                    "log path and comment must be text",
+                    "메모 경로와 내용은 텍스트여야 합니다",
+                )
+            )
         if not comment.strip():
-            parser.error("note comment must not be empty")
+            parser.error(
+                localized(
+                    cli_language,
+                    "note comment must not be empty",
+                    "메모 내용은 비어 있을 수 없습니다",
+                )
+            )
         print(
-            "warning: this comment may be included in the final brief",
+            localized(
+                cli_language,
+                "warning: this comment may be included in the final brief",
+                "경고: 이 메모는 최종 브리프에 포함될 수 있습니다",
+            ),
             file=sys.stderr,
         )
         try:
             note = add_note(path_text, comment, start=Path.cwd())
         except SetupError as error:
             parser.error(str(error))
-        print(f"recorded note {note['id']} for {note['path']}; updated .silobrief/notes.json")
+        print(
+            localized(
+                cli_language,
+                f"recorded note {note['id']} for {note['path']}; updated .silobrief/notes.json",
+                f"{note['path']}에 메모 {note['id']}를 기록하고 "
+                ".silobrief/notes.json을 갱신했습니다",
+            )
+        )
+
+    if arguments.command == "language":
+        start = Path.cwd()
+        try:
+            root = find_project_root(start)
+            settings = load_language_settings(root)
+            cli_value = arguments.cli_language
+            brief_value = arguments.brief_language
+            updated = LanguageSettings(
+                brief_language=(
+                    parse_language(brief_value)
+                    if brief_value is not None
+                    else settings["brief_language"]
+                ),
+                cli_language=(
+                    parse_language(cli_value) if cli_value is not None else settings["cli_language"]
+                ),
+                settings_version=1,
+            )
+            if updated != settings:
+                save_language_settings(root, updated)
+        except (SetupError, ValueError) as error:
+            parser.error(str(error))
+        cli_language = updated["cli_language"]
+        print(localized(cli_language, f"CLI language: {cli_language}", f"CLI 언어: {cli_language}"))
+        print(
+            localized(
+                cli_language,
+                f"Brief language: {updated['brief_language']}",
+                f"브리프 언어: {updated['brief_language']}",
+            )
+        )
 
     if arguments.command == "search":
         prompt = arguments.prompt
         if not isinstance(prompt, str) or not prompt.strip():
-            parser.error("request must not be empty")
+            parser.error(
+                localized(cli_language, "request must not be empty", "요청은 비어 있을 수 없습니다")
+            )
 
         start = Path.cwd()
         try:
             root = find_project_root(start)
             index, snapshot = load_current_index(root)
             notes = load_notes(root)
-            search_output = render_candidate_results(search_candidates(prompt, index, notes))
+            settings = load_language_settings(root)
+            cli_language = settings["cli_language"]
+            search_output = render_candidate_results(
+                search_candidates(prompt, index, notes), language=cli_language
+            )
         except IndexStateError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 3
         except SetupError as error:
             parser.error(str(error))
         except StoredIndexError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 3
         except (CurrentIndexError, SourceCollectionError, CandidateSearchError) as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 4
 
         for warning in snapshot.warnings:
-            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
+            print(
+                f"{localized(cli_language, 'warning', '경고')}: {warning.path}: {warning.reason}",
+                file=sys.stderr,
+            )
         print(search_output, end="")
 
     if arguments.command == "chat":
         prompt = arguments.prompt
         output_text = arguments.output
         if not isinstance(prompt, str) or not prompt.strip():
-            parser.error("request must not be empty")
+            parser.error(
+                localized(cli_language, "request must not be empty", "요청은 비어 있을 수 없습니다")
+            )
         if not isinstance(output_text, str) or not output_text.strip():
-            parser.error("output path must not be empty")
+            parser.error(
+                localized(
+                    cli_language,
+                    "output path must not be empty",
+                    "출력 경로는 비어 있을 수 없습니다",
+                )
+            )
 
         start = Path.cwd()
         try:
             root = find_project_root(start)
             index, snapshot = load_current_index(root)
             notes = load_notes(root)
+            settings = load_language_settings(root)
+            cli_language = settings["cli_language"]
         except IndexStateError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 3
         except SetupError as error:
             parser.error(str(error))
         except StoredIndexError as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 3
         except (CurrentIndexError, SourceCollectionError) as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 4
 
         for warning in snapshot.warnings:
-            print(f"warning: {warning.path}: {warning.reason}", file=sys.stderr)
+            print(
+                f"{localized(cli_language, 'warning', '경고')}: {warning.path}: {warning.reason}",
+                file=sys.stderr,
+            )
         try:
             rendered = review_brief(
                 prompt,
@@ -222,6 +446,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 input_stream=sys.stdin,
                 output_stream=sys.stdout,
                 snapshot=snapshot,
+                brief_language=settings["brief_language"],
+                cli_language=cli_language,
             )
             approve_and_write(
                 root,
@@ -231,10 +457,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 input_stream=sys.stdin,
                 output_stream=sys.stdout,
                 source_snapshot=snapshot,
+                language=cli_language,
             )
         except (ChatReviewError, OutputBlockedError) as error:
-            print(f"sb: error: {error}", file=sys.stderr)
+            print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)
             return 4
-        print(f"\nwrote {output_text}")
+        print(
+            localized(cli_language, f"\nwrote {output_text}", f"\n{output_text}을(를) 작성했습니다")
+        )
 
     return 0
+
+
+def _detect_cli_language(start: Path) -> Language:
+    try:
+        root = find_project_root(start)
+        return load_language_settings(root)["cli_language"]
+    except SetupError:
+        return "en"

--- a/src/silobrief/language.py
+++ b/src/silobrief/language.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+Language = Literal["en", "ko"]
+SUPPORTED_LANGUAGES: tuple[Language, ...] = ("en", "ko")
+
+
+class LanguageSettings(TypedDict):
+    brief_language: Language
+    cli_language: Language
+    settings_version: int
+
+
+def default_language_settings() -> LanguageSettings:
+    return LanguageSettings(
+        brief_language="en",
+        cli_language="en",
+        settings_version=1,
+    )
+
+
+def parse_language(value: object) -> Language:
+    if not isinstance(value, str) or value not in SUPPORTED_LANGUAGES:
+        raise ValueError("language must be en or ko")
+    return value
+
+
+def parse_language_settings(value: dict[str, object]) -> LanguageSettings:
+    if set(value) != {"brief_language", "cli_language", "settings_version"}:
+        raise ValueError("language.json has an incompatible schema")
+    if type(value["settings_version"]) is not int or value["settings_version"] != 1:
+        raise ValueError("language.json has an unsupported version")
+    try:
+        brief_language = parse_language(value["brief_language"])
+        cli_language = parse_language(value["cli_language"])
+    except ValueError as error:
+        raise ValueError("language.json languages must be en or ko") from error
+    return LanguageSettings(
+        brief_language=brief_language,
+        cli_language=cli_language,
+        settings_version=1,
+    )
+
+
+def localized(language: Language, english: str, korean: str) -> str:
+    return korean if language == "ko" else english

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -6,11 +6,10 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TextIO
 
+from silobrief.language import Language, localized
 from silobrief.renderer import RenderedBrief
 from silobrief.sources import SourceCollectionError, SourceSnapshot, snapshot_sources
 from silobrief.state import STATE_DIRECTORY, SetupError, load_config
-
-_APPROVAL_PROMPT = "Type exactly WRITE to create the Markdown file: "
 
 
 class OutputBlockedError(Exception):
@@ -37,9 +36,16 @@ def approve_and_write(
     input_stream: TextIO,
     output_stream: TextIO,
     source_snapshot: SourceSnapshot | None = None,
+    language: Language = "en",
 ) -> WrittenBrief:
     if not input_stream.isatty() or not output_stream.isatty():
-        raise OutputBlockedError("approval requires interactive input and output")
+        raise OutputBlockedError(
+            localized(
+                language,
+                "approval requires interactive input and output",
+                "승인에는 대화형 입력과 출력이 필요합니다",
+            )
+        )
     if type(rendered) is not RenderedBrief:
         raise OutputBlockedError("output requires a rendered brief")
 
@@ -48,17 +54,36 @@ def approve_and_write(
 
     try:
         output_stream.write(rendered.markdown)
-        output_stream.write(f"\n{_APPROVAL_PROMPT}")
+        output_stream.write(
+            "\n"
+            + localized(
+                language,
+                "Type exactly WRITE to create the Markdown file: ",
+                "Markdown 파일을 만들려면 WRITE를 정확히 입력하세요: ",
+            )
+        )
         output_stream.flush()
         approval = input_stream.readline()
     except OSError as error:
         raise OutputBlockedError(f"cannot complete interactive approval: {error}") from error
     if _without_line_ending(approval) != "WRITE":
-        raise OutputBlockedError("output was not approved with exact WRITE")
+        raise OutputBlockedError(
+            localized(
+                language,
+                "output was not approved with exact WRITE",
+                "WRITE가 정확히 입력되지 않아 출력을 승인하지 않았습니다",
+            )
+        )
 
     current = _snapshot(root)
     if current.digest != baseline.digest:
-        raise OutputBlockedError("project sources changed during review; run sb init")
+        raise OutputBlockedError(
+            localized(
+                language,
+                "project sources changed during review; run sb init",
+                "검토 중 프로젝트 소스가 변경되었습니다. sb init을 실행하세요",
+            )
+        )
 
     _write_new_file(destination, rendered.markdown)
     return WrittenBrief(destination)

--- a/src/silobrief/renderer.py
+++ b/src/silobrief/renderer.py
@@ -5,13 +5,18 @@ from pathlib import PurePosixPath, PureWindowsPath
 from typing import Literal
 
 from silobrief.index import NodeKind
+from silobrief.language import Language
 from silobrief.source_excerpts import MAX_SOURCE_LINES, MAX_SOURCE_UTF8_BYTES
 from silobrief.source_review import ApprovedSourceExcerpt
 
 _KIND_ORDER = {"module": 0, "class": 1, "function": 2}
-_WARNING = (
+_WARNING_KO = (
     "승인된 source의 민감정보를 자동으로 탐지하거나 반출 안전성을 보장하지 않습니다. "
     "전달 전에 모든 출력 파일을 직접 확인하세요."
+)
+_WARNING_EN = (
+    "siloBrief does not automatically detect sensitive information in approved source or "
+    "guarantee that an export is safe to share. Review every output file before sharing it."
 )
 
 
@@ -68,20 +73,28 @@ class RenderedBrief:
     disclosure: DisclosureManifest
 
 
-def render_brief(source: BriefInput) -> RenderedBrief:
+def render_brief(source: BriefInput, *, language: Language = "en") -> RenderedBrief:
     approved = _prepare(source)
     disclosure = _disclosure(approved)
+    if language == "ko":
+        return _render_korean(approved, disclosure)
+    return _render_english(approved, disclosure)
+
+
+def _render_korean(source: BriefInput, disclosure: DisclosureManifest) -> RenderedBrief:
     sections = [
-        _execution_instruction(bool(approved.source_excerpts)),
-        _section("경고와 공개 범위", _WARNING),
-        _section("작업 요청", _quote(approved.user_prompt)),
-        _section("승인된 프로젝트 맥락", _project_context(approved)),
+        _execution_instruction(bool(source.source_excerpts), language="ko"),
+        _section("경고와 공개 범위", _WARNING_KO),
+        _section("작업 요청", _quote(source.user_prompt)),
+        _section("승인된 프로젝트 맥락", _project_context(source, language="ko")),
     ]
-    if approved.human_notes:
-        sections.append(_section("사용자 작성 메모", _quoted_list(approved.human_notes)))
-    if approved.boundaries:
-        sections.append(_section("등록된 경계", _boundary_list(approved.boundaries)))
-    source_markdown = _source_markdown(approved.source_excerpts)
+    if source.human_notes:
+        sections.append(
+            _section("사용자 작성 메모", _quoted_list(source.human_notes, language="ko"))
+        )
+    if source.boundaries:
+        sections.append(_section("등록된 경계", _boundary_list(source.boundaries, language="ko")))
+    source_markdown = _source_markdown(source.source_excerpts, language="ko")
     if source_markdown is not None:
         sections.append(_section("승인된 소스 코드", source_markdown))
     sections.extend(
@@ -94,6 +107,33 @@ def render_brief(source: BriefInput) -> RenderedBrief:
         markdown="\n\n".join(sections) + "\n",
         disclosure=disclosure,
     )
+
+
+def _render_english(source: BriefInput, disclosure: DisclosureManifest) -> RenderedBrief:
+    sections = [
+        _execution_instruction(bool(source.source_excerpts), language="en"),
+        _section("Warning and disclosure scope", _WARNING_EN),
+        _section("Task request", _quote(source.user_prompt)),
+        _section("Approved project context", _project_context(source, language="en")),
+    ]
+    if source.human_notes:
+        sections.append(
+            _section("User-authored notes", _quoted_list(source.human_notes, language="en"))
+        )
+    if source.boundaries:
+        sections.append(
+            _section("Registered boundaries", _boundary_list(source.boundaries, language="en"))
+        )
+    source_markdown = _source_markdown(source.source_excerpts, language="en")
+    if source_markdown is not None:
+        sections.append(_section("Approved source code", source_markdown))
+    sections.extend(
+        (
+            _section("External AI response contract", _response_contract_english()),
+            _section("Disclosure manifest", _manifest_yaml(disclosure)),
+        )
+    )
+    return RenderedBrief(markdown="\n\n".join(sections) + "\n", disclosure=disclosure)
 
 
 def _prepare(source: BriefInput) -> BriefInput:
@@ -280,7 +320,16 @@ def _section(title: str, body: str) -> str:
     return f"## {title}\n\n{body}"
 
 
-def _execution_instruction(has_source: bool) -> str:
+def _execution_instruction(has_source: bool, *, language: Language) -> str:
+    if language == "en":
+        scope = (
+            "the approved project context and source code in this document"
+            if has_source
+            else "the project context disclosed in this document"
+        )
+        return (
+            f"> Use only {scope} to complete the task below. Provide applicable changes and tests."
+        )
     scope = (
         "이 문서의 승인된 프로젝트 맥락과 소스 코드"
         if has_source
@@ -295,33 +344,49 @@ def _quote(value: str) -> str:
     return "\n".join(">" if not line else f"> {line}" for line in value.split("\n"))
 
 
-def _quoted_list(values: tuple[str, ...]) -> str:
+def _quoted_list(values: tuple[str, ...], *, language: Language) -> str:
     if not values:
-        return "- 없음"
+        return "- 없음" if language == "ko" else "- none"
     lines: list[str] = []
     for value in values:
-        lines.append("- 승인 항목:")
+        lines.append("- 승인 항목:" if language == "ko" else "- approved item:")
         lines.extend(f"  {line}" for line in _quote(value).splitlines())
     return "\n".join(lines)
 
 
-def _project_context(source: BriefInput) -> str:
+def _project_context(source: BriefInput, *, language: Language) -> str:
     symbols = tuple(f"{item.kind}: {item.name}" for item in source.symbols)
+    if language == "en":
+        return "\n\n".join(
+            (
+                f"### Relative paths\n\n{_quoted_list(source.relative_paths, language=language)}",
+                f"### Symbols\n\n{_quoted_list(symbols, language=language)}",
+                f"### Public imports\n\n{_quoted_list(source.public_imports, language=language)}",
+            )
+        )
     return "\n\n".join(
         (
-            f"### 상대 경로\n\n{_quoted_list(source.relative_paths)}",
-            f"### 심볼\n\n{_quoted_list(symbols)}",
-            f"### 공개 import\n\n{_quoted_list(source.public_imports)}",
+            f"### 상대 경로\n\n{_quoted_list(source.relative_paths, language=language)}",
+            f"### 심볼\n\n{_quoted_list(symbols, language=language)}",
+            f"### 공개 import\n\n{_quoted_list(source.public_imports, language=language)}",
         )
     )
 
 
-def _boundary_list(values: tuple[ApprovedBoundary, ...]) -> str:
+def _boundary_list(values: tuple[ApprovedBoundary, ...], *, language: Language) -> str:
     if not values:
-        return "- 없음"
+        return "- 없음" if language == "ko" else "- none"
     lines: list[str] = []
     for value in values:
-        lines.extend(("- 경계 alias:", f"  {_quote(value.alias)}", "  공개 설명:"))
+        labels = (
+            ("- 경계 alias:", "  공개 설명:")
+            if language == "ko"
+            else (
+                "- boundary alias:",
+                "  public description:",
+            )
+        )
+        lines.extend((labels[0], f"  {_quote(value.alias)}", labels[1]))
         lines.extend(f"  {line}" for line in _quote(value.description).splitlines())
     return "\n".join(lines)
 
@@ -347,6 +412,31 @@ def _response_contract() -> str:
             "- `확인 필요`는 최대 2개로 제한하고, 외부 API 주장은 가능한 경우 버전이 "
             "고정된 공식 문서 URL로 뒷받침하세요. 확인할 내용이 없으면 `없음`이라고 적으세요.",
             "- 별도 요구가 없으면 비어 있지 않은 줄 80개 이내로 답하세요.",
+        )
+    )
+
+
+def _response_contract_english() -> str:
+    return "\n".join(
+        (
+            "Use the following four headings in order. Do not add a separate introduction.",
+            "",
+            "```text",
+            "## Change to apply",
+            "## Patch",
+            "## Tests",
+            "## Needs confirmation",
+            "```",
+            "",
+            "- In `Change to apply`, state the target file and purpose first.",
+            "- In `Patch`, include a `diff` code block based only on disclosed code and context.",
+            "- Mark removed lines with `-` and added lines with `+`. File headers, hunk headers, "
+            "and exact line numbers are optional; do not claim the patch can be applied by Git.",
+            "- Do not replace the diff with a full-file code block or infer hidden implementation.",
+            "- Provide focused tests. If you did not run them, do not claim that they passed.",
+            "- Limit `Needs confirmation` to two items. Where possible, support external API "
+            "claims with versioned official documentation. Write `none` if nothing remains.",
+            "- Unless requested otherwise, keep the answer within 80 non-empty lines.",
         )
     )
 
@@ -377,13 +467,19 @@ def _manifest_yaml(value: DisclosureManifest) -> str:
     )
 
 
-def _source_markdown(values: tuple[ApprovedSourceExcerpt, ...]) -> str | None:
+def _source_markdown(
+    values: tuple[ApprovedSourceExcerpt, ...], *, language: Language
+) -> str | None:
     if not values:
         return None
-    parts = [
+    introduction = (
         "이 문서에는 사용자가 외부 공개를 승인한 원문 코드가 포함되어 있습니다. "
-        "주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오.",
-    ]
+        "주석, docstring, 문자열, 경로와 내부 식별자를 직접 확인하십시오."
+        if language == "ko"
+        else "This document includes verbatim source approved for external disclosure. Review "
+        "comments, docstrings, strings, paths, and internal identifiers yourself."
+    )
+    parts = [introduction]
     for value in values:
         aliases = ", ".join(value.boundary_aliases) or "none"
         parts.extend(

--- a/src/silobrief/source_review.py
+++ b/src/silobrief/source_review.py
@@ -6,6 +6,7 @@ from typing import TextIO
 
 from silobrief.boundary_placeholders import BoundaryPlaceholder
 from silobrief.index import IndexData
+from silobrief.language import Language, localized
 from silobrief.python_structure import DefinitionKind
 from silobrief.review import ReviewNode, ReviewSelection
 from silobrief.source_excerpts import (
@@ -49,9 +50,16 @@ def review_source_disclosure(
     *,
     input_stream: TextIO,
     output_stream: TextIO,
+    language: Language = "en",
 ) -> tuple[ApprovedSourceExcerpt, ...]:
     if not input_stream.isatty() or not output_stream.isatty():
-        raise SourceReviewError("source review requires an interactive terminal")
+        raise SourceReviewError(
+            localized(
+                language,
+                "source review requires an interactive terminal",
+                "소스 검토에는 대화형 터미널이 필요합니다",
+            )
+        )
 
     selected_nodes = {
         (node.path, node.kind, node.qualified_name): node
@@ -70,7 +78,11 @@ def review_source_disclosure(
         except SourceExcerptError as error:
             _write(
                 output_stream,
-                f"Source excerpt unavailable: {node.path} {node.qualified_name}: {error}\n",
+                localized(
+                    language,
+                    f"Source excerpt unavailable: {node.path} {node.qualified_name}: {error}\n",
+                    f"소스 발췌를 사용할 수 없음: {node.path} {node.qualified_name}: {error}\n",
+                ),
             )
 
     candidates = list(
@@ -83,9 +95,14 @@ def review_source_disclosure(
     if candidates:
         _write(
             output_stream,
-            "Source disclosure warning: approved excerpts are copied verbatim and may contain "
-            "identifiers, paths, URLs, strings, or secrets that are not classified "
-            "automatically.\n",
+            localized(
+                language,
+                "Source disclosure warning: approved excerpts are copied verbatim and may "
+                "contain identifiers, paths, URLs, strings, or secrets that are not classified "
+                "automatically.\n",
+                "소스 공개 경고: 승인한 발췌는 원문 그대로 복사되며, 자동 분류되지 않은 "
+                "식별자, 경로, URL, 문자열 또는 비밀정보가 포함될 수 있습니다.\n",
+            ),
         )
 
     aliases = {
@@ -97,27 +114,57 @@ def review_source_disclosure(
     }
     approved: tuple[SourceExcerpt, ...] = ()
     for candidate in candidates:
-        _show_candidate(candidate, aliases[_excerpt_key(candidate)], output_stream)
-        answer = _read_line("Include this source excerpt? [y/N]: ", input_stream, output_stream)
+        _show_candidate(candidate, aliases[_excerpt_key(candidate)], output_stream, language)
+        answer = _read_line(
+            localized(
+                language,
+                "Include this source excerpt? [y/N]: ",
+                "이 소스 발췌를 포함할까요? [y/N]: ",
+            ),
+            input_stream,
+            output_stream,
+        )
         if answer not in {"", "n", "y"}:
-            raise SourceReviewError("source answer must be y, n, or blank")
+            raise SourceReviewError(
+                localized(
+                    language,
+                    "source answer must be y, n, or blank",
+                    "소스 응답은 y, n 또는 빈 입력이어야 합니다",
+                )
+            )
         if answer != "y":
             continue
         try:
             approved = prepare_source_excerpts((*approved, candidate))
         except SourceExcerptLimitError as error:
-            _write(output_stream, f"Source excerpt skipped: {error}\n")
+            _write(
+                output_stream,
+                localized(
+                    language,
+                    f"Source excerpt skipped: {error}\n",
+                    f"소스 발췌를 건너뜀: {error}\n",
+                ),
+            )
 
     exposed = tuple(
         sorted({alias for excerpt in approved for alias in aliases[_excerpt_key(excerpt)]})
     )
     if exposed:
         _write(
-            output_stream, f"Boundary aliases exposed in approved source: {', '.join(exposed)}\n"
+            output_stream,
+            localized(
+                language,
+                f"Boundary aliases exposed in approved source: {', '.join(exposed)}\n",
+                f"승인한 소스에 노출되는 경계 alias: {', '.join(exposed)}\n",
+            ),
         )
         if (
             _read_line(
-                "Type exactly EXPOSE to include boundary identifiers: ",
+                localized(
+                    language,
+                    "Type exactly EXPOSE to include boundary identifiers: ",
+                    "경계 식별자를 포함하려면 EXPOSE를 정확히 입력하세요: ",
+                ),
                 input_stream,
                 output_stream,
             )
@@ -169,13 +216,21 @@ def _show_candidate(
     excerpt: SourceExcerpt,
     aliases: tuple[str, ...],
     output: TextIO,
+    language: Language,
 ) -> None:
     _write(
         output,
-        f"Source candidate: {excerpt.path} | {excerpt.kind} {excerpt.qualified_name} | "
-        f"lines {excerpt.start_line}-{excerpt.end_line}\n"
-        f"Boundary aliases: {', '.join(aliases) if aliases else 'none'}\n"
-        "```python\n",
+        localized(
+            language,
+            f"Source candidate: {excerpt.path} | {excerpt.kind} {excerpt.qualified_name} | "
+            f"lines {excerpt.start_line}-{excerpt.end_line}\n"
+            f"Boundary aliases: {', '.join(aliases) if aliases else 'none'}\n"
+            "```python\n",
+            f"소스 후보: {excerpt.path} | {excerpt.kind} {excerpt.qualified_name} | "
+            f"{excerpt.start_line}-{excerpt.end_line}행\n"
+            f"경계 alias: {', '.join(aliases) if aliases else '없음'}\n"
+            "```python\n",
+        ),
     )
     _write(output, excerpt.content)
     if not excerpt.content.endswith("\n"):

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -8,6 +8,12 @@ import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TypedDict
 
+from silobrief.language import (
+    LanguageSettings,
+    default_language_settings,
+    parse_language_settings,
+)
+
 STATE_DIRECTORY = ".silobrief"
 _BOUNDARY_ALIAS_PATTERN = re.compile(r"[a-z0-9-]{1,40}")
 _NOTE_ID_PATTERN = re.compile(r"note-[0-9a-f]{64}")
@@ -80,6 +86,7 @@ def setup_project(project: Path) -> bool:
             ),
         )
         _write_json(state / "notes.json", NotesData(notes=[], notes_version=1))
+        _write_json(state / "language.json", default_language_settings())
     except OSError as error:
         shutil.rmtree(state, ignore_errors=True)
         raise SetupError(f"cannot initialize {STATE_DIRECTORY}: {error}") from error
@@ -130,6 +137,24 @@ def save_notes(root: Path, notes: NotesData) -> None:
     _write_json_atomic(root / STATE_DIRECTORY / "notes.json", notes)
 
 
+def load_language_settings(root: Path) -> LanguageSettings:
+    path = root / STATE_DIRECTORY / "language.json"
+    if not path.exists() and not path.is_symlink():
+        return default_language_settings()
+    try:
+        return parse_language_settings(_read_object(path))
+    except ValueError as error:
+        raise SetupError(str(error)) from error
+
+
+def save_language_settings(root: Path, settings: LanguageSettings) -> None:
+    try:
+        validated = parse_language_settings(dict(settings))
+    except ValueError as error:
+        raise SetupError(str(error)) from error
+    _write_json_atomic(root / STATE_DIRECTORY / "language.json", validated)
+
+
 def save_index(root: Path, content: bytes) -> None:
     _write_bytes_atomic(root / STATE_DIRECTORY / "index.json", content)
 
@@ -149,14 +174,17 @@ def is_valid_boundary_alias(alias: str) -> bool:
     return _BOUNDARY_ALIAS_PATTERN.fullmatch(alias) is not None
 
 
-def _write_json(path: Path, value: ConfigData | NotesData | dict[str, object]) -> None:
+def _write_json(
+    path: Path,
+    value: ConfigData | NotesData | LanguageSettings | dict[str, object],
+) -> None:
     content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     path.write_text(content, encoding="utf-8", newline="\n")
 
 
 def _write_json_atomic(
     path: Path,
-    value: ConfigData | NotesData | dict[str, object],
+    value: ConfigData | NotesData | LanguageSettings | dict[str, object],
 ) -> None:
     content = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode(
         "utf-8"
@@ -194,6 +222,13 @@ def _validate_state(state: Path) -> ConfigData:
     config = _parse_config(_read_object(state / "config.json"))
 
     _parse_notes(_read_object(state / "notes.json"))
+
+    language = state / "language.json"
+    if language.exists() or language.is_symlink():
+        try:
+            parse_language_settings(_read_object(language))
+        except ValueError as error:
+            raise SetupError(str(error)) from error
 
     exports = state / "exports"
     if exports.is_symlink() or not exports.is_dir():

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -155,7 +155,7 @@ class ChatReviewTests(unittest.TestCase):
         )
 
         self.assertEqual(disclosure_counts(rendered), (0, 0, 0, 0, 0))
-        self.assertEqual(rendered.markdown.count("- 없음"), 3)
+        self.assertEqual(rendered.markdown.count("- none"), 3)
         for title in ("사용자 작성 메모", "등록된 경계", "소스 동반 파일"):
             self.assertNotIn(f"## {title}", rendered.markdown)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,9 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(caught.exception.code, 2)
         self.assertIn("usage: sb", stderr.getvalue())
-        self.assertIn("{setup,example,ignore,unignore,init,log,search,chat}", stderr.getvalue())
+        self.assertIn(
+            "{setup,example,ignore,unignore,init,log,search,language,chat}", stderr.getvalue()
+        )
 
     def test_help_lists_commands_and_succeeds(self) -> None:
         stdout = io.StringIO()
@@ -27,7 +29,9 @@ class CommandLineTests(unittest.TestCase):
             main(["--help"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertIn("{setup,example,ignore,unignore,init,log,search,chat}", stdout.getvalue())
+        self.assertIn(
+            "{setup,example,ignore,unignore,init,log,search,language,chat}", stdout.getvalue()
+        )
 
 
 class VersionCommandTests(unittest.TestCase):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -14,6 +14,7 @@ PUBLIC_COMMANDS = (
     "sb init",
     "sb log",
     "sb search",
+    "sb language",
     "sb chat",
     "sb --version",
 )

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from collections.abc import Iterator
+from pathlib import Path
+
+from silobrief.cli import main
+from silobrief.state import SetupError, load_language_settings
+
+
+@contextlib.contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def run_silently(arguments: list[str]) -> int:
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        return main(arguments)
+
+
+class LanguageCommandTests(unittest.TestCase):
+    def test_defaults_to_english_and_updates_each_setting_independently(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+
+            with working_directory(project):
+                self.assertEqual(run_silently(["init"]), 0)
+                index_before = (project / ".silobrief" / "index.json").read_bytes()
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    self.assertEqual(main(["language"]), 0)
+                self.assertEqual(stdout.getvalue(), "CLI language: en\nBrief language: en\n")
+
+                self.assertEqual(run_silently(["language", "--brief", "ko"]), 0)
+                self.assertEqual(
+                    load_language_settings(project),
+                    {
+                        "brief_language": "ko",
+                        "cli_language": "en",
+                        "settings_version": 1,
+                    },
+                )
+                self.assertEqual((project / ".silobrief" / "index.json").read_bytes(), index_before)
+
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    self.assertEqual(main(["language", "--cli", "ko"]), 0)
+                self.assertEqual(stdout.getvalue(), "CLI 언어: ko\n브리프 언어: ko\n")
+                self.assertEqual(
+                    load_language_settings(project),
+                    {
+                        "brief_language": "ko",
+                        "cli_language": "ko",
+                        "settings_version": 1,
+                    },
+                )
+
+    def test_existing_project_without_language_file_uses_english_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            language_path = project / ".silobrief" / "language.json"
+            language_path.unlink()
+
+            with working_directory(project):
+                self.assertEqual(
+                    load_language_settings(project),
+                    {
+                        "brief_language": "en",
+                        "cli_language": "en",
+                        "settings_version": 1,
+                    },
+                )
+                self.assertEqual(run_silently(["init"]), 0)
+
+            self.assertFalse(language_path.exists())
+
+    def test_rejects_an_invalid_persisted_language(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+            language_path = project / ".silobrief" / "language.json"
+            value = json.loads(language_path.read_text(encoding="utf-8"))
+            value["brief_language"] = "ja"
+            language_path.write_text(json.dumps(value), encoding="utf-8")
+
+            with self.assertRaisesRegex(SetupError, "languages must be en or ko"):
+                load_language_settings(project)
+
+    def test_korean_cli_setting_changes_help_and_search_output_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "service.py"
+            source.write_text("def retry_request():\n    return None\n", encoding="utf-8")
+            self.assertEqual(run_silently(["setup", str(project)]), 0)
+
+            with working_directory(project):
+                self.assertEqual(run_silently(["language", "--cli", "ko"]), 0)
+                self.assertEqual(run_silently(["init"]), 0)
+
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    self.assertEqual(main(["search", "retry request"]), 0)
+                self.assertTrue(stdout.getvalue().startswith("후보:\n"))
+
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout), self.assertRaises(SystemExit) as caught:
+                    main(["--help"])
+                self.assertEqual(caught.exception.code, 0)
+                self.assertIn("검토된 작업 브리프", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -154,6 +154,7 @@ def generate_packets(destination_root: Path) -> tuple[GeneratedPacket, ...]:
                         ]
                     ),
                     main(["init"]),
+                    main(["language", "--brief", "ko"]),
                     main(
                         [
                             "log",
@@ -163,7 +164,7 @@ def generate_packets(destination_root: Path) -> tuple[GeneratedPacket, ...]:
                         ]
                     ),
                 )
-        if results != (0, 0, 0):
+        if results != (0, 0, 0, 0):
             raise AssertionError(f"fixture preparation failed: {results}")
 
         before = source_manifest(project)

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -22,7 +22,7 @@ FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-f
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
 INDEX_SHA256 = "e47e1d49d1f3d5ec828e10594922c0586eb5f0eb98bbcf333c7672122e0c901c"
-BRIEF_SHA256 = "c2b7a70c5695bbffdf482b57fa63aa99fb3909b49f41611bb7cdd5e0d154ea79"
+BRIEF_SHA256 = "5ecd0039b62f2346a5cc0752e83b55a3c54bd6302cc662e4a292f038c8f771d4"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",
     "PUBLIC_COMMENT_CANARY",

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -101,7 +101,7 @@ class BriefRendererTests(unittest.TestCase):
             source_excerpts=(first_excerpt, second_excerpt),
         )
 
-        rendered = render_brief(source)
+        rendered = render_brief(source, language="ko")
         reordered = render_brief(
             brief_input(
                 user_prompt=source.user_prompt,
@@ -111,7 +111,8 @@ class BriefRendererTests(unittest.TestCase):
                 human_notes=source.human_notes,
                 boundaries=tuple(reversed(source.boundaries)),
                 source_excerpts=tuple(reversed(source.source_excerpts)),
-            )
+            ),
+            language="ko",
         )
 
         headings: list[str] = []
@@ -170,7 +171,7 @@ class BriefRendererTests(unittest.TestCase):
         )
 
     def test_renders_main_only_when_no_source_is_approved(self) -> None:
-        rendered = render_brief(brief_input(source_excerpts=()))
+        rendered = render_brief(brief_input(source_excerpts=()), language="ko")
 
         self.assertNotIn("## 승인된 소스 코드", rendered.markdown)
         self.assertTrue(rendered.markdown.startswith("> 이 문서에 공개된 프로젝트 맥락만 사용하여"))
@@ -184,7 +185,8 @@ class BriefRendererTests(unittest.TestCase):
                 human_notes=(),
                 boundaries=(),
                 source_excerpts=(),
-            )
+            ),
+            language="ko",
         )
 
         for title in ("사용자 작성 메모", "등록된 경계", "승인된 소스 코드"):
@@ -235,6 +237,37 @@ class BriefRendererTests(unittest.TestCase):
             with self.subTest(message=message):
                 with self.assertRaisesRegex(RenderError, message):
                     render_brief(source)
+
+    def test_defaults_to_english_without_translating_approved_content(self) -> None:
+        source = brief_input()
+
+        english = render_brief(source)
+        korean = render_brief(source, language="ko")
+
+        self.assertIn("## Task request", english.markdown)
+        self.assertIn("## External AI response contract", english.markdown)
+        self.assertIn("## Patch", english.markdown)
+        self.assertNotIn("## 작업 요청", english.markdown)
+        for original in (
+            source.user_prompt,
+            source.human_notes[0],
+            source.boundaries[0].description,
+            source.source_excerpts[0].content,
+        ):
+            self.assertIn(original, english.markdown)
+            self.assertIn(original, korean.markdown)
+        self.assertEqual(english.disclosure, korean.disclosure)
+
+    def test_english_brief_adds_no_korean_text(self) -> None:
+        source = brief_input(
+            user_prompt="Update the retry policy",
+            human_notes=("Python 3.10 is required",),
+            boundaries=(ApprovedBoundary("private-api", "Internal transport"),),
+        )
+
+        rendered = render_brief(source)
+
+        self.assertNotRegex(rendered.markdown, "[가-힣]")
 
 
 if __name__ == "__main__":

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -63,8 +63,8 @@ class SetupCommandTests(unittest.TestCase):
             self.assertEqual(result, 0)
             self.assertEqual(
                 stdout.getvalue(),
-                "created .silobrief/config.json, .silobrief/notes.json, and .silobrief/exports/\n"
-                + SOURCE_DISCLOSURE_WARNING,
+                "created .silobrief/config.json, .silobrief/notes.json, "
+                ".silobrief/language.json, and .silobrief/exports/\n" + SOURCE_DISCLOSURE_WARNING,
             )
             self.assertEqual(
                 json.loads((state / "config.json").read_text(encoding="utf-8")),
@@ -77,6 +77,14 @@ class SetupCommandTests(unittest.TestCase):
             self.assertEqual(
                 json.loads((state / "notes.json").read_text(encoding="utf-8")),
                 {"notes": [], "notes_version": 1},
+            )
+            self.assertEqual(
+                json.loads((state / "language.json").read_text(encoding="utf-8")),
+                {
+                    "brief_language": "en",
+                    "cli_language": "en",
+                    "settings_version": 1,
+                },
             )
             self.assertTrue((state / "exports").is_dir())
             self.assertFalse((state / "index.json").exists())
@@ -111,7 +119,12 @@ class SetupCommandTests(unittest.TestCase):
             project = Path(directory)
             self.assertEqual(main(["setup", str(project)]), 0)
             state = project / ".silobrief"
-            tracked = [state / "config.json", state / "notes.json", state / "exports"]
+            tracked = [
+                state / "config.json",
+                state / "notes.json",
+                state / "language.json",
+                state / "exports",
+            ]
             fixed_time = 1_700_000_000_000_000_000
             for path in tracked:
                 os.utime(path, ns=(fixed_time, fixed_time))


### PR DESCRIPTION
## 변경 내용

- `sb language --cli en|ko`와 `--brief en|ko`를 독립 설정으로 추가했습니다.
- 두 기본값을 영어로 고정하고 기존 프로젝트에서 설정 파일이 없으면 영어 기본값을 사용합니다.
- CLI 안내·검색 결과·대화형 검토 문구와 생성 Markdown을 한국어 또는 영어로 표시합니다.
- 사용자 요청, 메모, 코드, 경로와 식별자는 번역하지 않습니다.
- 과거 한국어 모델 검증 패킷은 명시적 `ko` 설정으로 재현합니다.

## 검증

- Ruff lint/format
- mypy strict (`src`, `tests`)
- unittest 161개 통과, 7개 환경 의존 skip
- wheel 및 sdist 빌드 성공
- 언어 변경 전후 index 바이트 동일성
- 영어 입력으로 만든 기본 브리프에 한국어 고정 문구 없음

Refs #44