### PR TITLE
docs(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-10
+
 ### Added
 
 - Create a deterministic synthetic Python practice project with `sb example PATH`, including

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.5.0"><img src="https://img.shields.io/badge/release-v0.5.0-4f46e5" alt="릴리스 v0.5.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.6.0"><img src="https://img.shields.io/badge/release-v0.6.0-4f46e5" alt="릴리스 v0.6.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -63,7 +63,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 0.5.0
+siloBrief 0.6.0
 ```
 
 ## 명령어
@@ -223,9 +223,10 @@ siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아
 
 ## 검증 현황
 
-현재 공개 버전은 v0.5.0입니다. `sb search`는 요청과 일치한 단어를 근거로 코드 후보를 최대
-10개까지 보여줍니다. `sb chat`은 작업 요청, 승인한 맥락, 승인한 소스 조각을
-하나의 자족적인 Markdown 파일로 묶습니다.
+현재 공개 버전은 v0.6.0입니다. `sb example`은 버려도 되는 실습 프로젝트를 만들고,
+`sb language`는 터미널 안내와 생성 브리프의 언어를 한국어 또는 영어로 각각 설정합니다.
+`sb search`는 요청과 일치한 단어를 근거로 코드 후보를 최대 10개까지 보여주며, `sb chat`은
+작업 요청, 승인한 맥락, 승인한 소스 조각을 하나의 자족적인 Markdown 파일로 묶습니다.
 
 Django Ninja, pytest, Jinja 저장소에서 Python 소스를 바꾸거나 네트워크에 연결하지 않고 같은
 브리프가 반복 생성되는 것을 확인했습니다. 더 넓은 여섯 과제 lexical 회귀 검사에서는 목표

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.5.0"><img src="https://img.shields.io/badge/release-v0.5.0-4f46e5" alt="Release v0.5.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v0.6.0"><img src="https://img.shields.io/badge/release-v0.6.0-4f46e5" alt="Release v0.6.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -61,7 +61,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 0.5.0
+siloBrief 0.6.0
 ```
 
 ## Commands
@@ -216,9 +216,10 @@ disclosure. Review every generated file under your organization's disclosure rul
 
 ## Validation status
 
-The current release is v0.5.0. `sb search` shows up to ten candidates with concrete lexical match
-evidence, and `sb chat` packages the task, approved context, and approved source excerpts into one
-self-contained Markdown file.
+The current release is v0.6.0. `sb example` creates a disposable guided project, and `sb language`
+configures terminal guidance and generated briefs independently in English or Korean. `sb search`
+shows up to ten candidates with concrete lexical match evidence, and `sb chat` packages the task,
+approved context, and approved source excerpts into one self-contained Markdown file.
 
 The deterministic end-to-end flow passed on Django Ninja, pytest, and Jinja checkouts without
 changing Python source files or opening a network connection.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,14 @@
 
 | Version | Supported |
 |---|---|
-| 0.5.x | :white_check_mark: |
+| 0.6.x | :white_check_mark: |
+| 0.5.x | :x: |
 | 0.4.x | :x: |
 | 0.3.x | :x: |
 | 0.2.x | :x: |
 | 0.1.x | :x: |
 
-The latest 0.5.x release is the currently supported line.
+The latest 0.6.x release is the currently supported line.
 
 ## Reporting a vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "0.5.0"
+version = "0.6.0"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,4 +45,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 0.5.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 0.6.0\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -28,6 +28,7 @@ V0_2_RELEASE_DATE = "2026-08-05"
 V0_3_RELEASE_DATE = "2026-08-06"
 V0_4_RELEASE_DATE = "2026-08-09"
 V0_5_RELEASE_DATE = "2026-08-09"
+V0_6_RELEASE_DATE = "2026-08-10"
 BRIEF_GUIDANCE_EXPECTATIONS = {
     "README.md": (
         "concrete task",
@@ -82,9 +83,10 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 for fragment in fragments:
                     self.assertIn(fragment, text)
 
-    def test_v0_5_release_metadata_is_current(self) -> None:
+    def test_v0_6_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn(f"## [0.6.0] - {V0_6_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.5.0] - {V0_5_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.4.0] - {V0_4_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.3.0] - {V0_3_RELEASE_DATE}", changelog)
@@ -100,27 +102,31 @@ class ReleaseDocumentationTests(unittest.TestCase):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("The current release is v0.5.0.", readme)
+        self.assertIn("The current release is v0.6.0.", readme)
+        self.assertIn("`sb example` creates a disposable guided project", readme)
+        self.assertIn("`sb language`", readme)
         self.assertIn("one self-contained Markdown file", readme)
         self.assertIn("Candidate search remains lexical and advisory", readme)
         self.assertIn("exact indexed Python file path", readme)
         self.assertIn("six-task lexical regression", readme)
         self.assertIn("docs/V0_2_CONTRACT.md", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
-        self.assertIn("현재 공개 버전은 v0.5.0입니다.", readme_ko)
+        self.assertIn("현재 공개 버전은 v0.6.0입니다.", readme_ko)
+        self.assertIn("`sb example`은 버려도 되는 실습 프로젝트", readme_ko)
+        self.assertIn("`sb language`", readme_ko)
         self.assertIn("하나의 자족적인 Markdown 파일", readme_ko)
         self.assertIn("색인에 있는 Python 파일의 정확한 상대 경로", readme_ko)
         self.assertIn("여섯 과제 lexical 회귀 검사", readme_ko)
         self.assertIn("docs/V0_2_CONTRACT.md", readme_ko)
 
         security = (REPOSITORY_ROOT / "SECURITY.md").read_text(encoding="utf-8")
-        self.assertIn("| 0.5.x | :white_check_mark: |", security)
-        self.assertIn("| 0.4.x | :x: |", security)
+        self.assertIn("| 0.6.x | :white_check_mark: |", security)
+        self.assertIn("| 0.5.x | :x: |", security)
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "0.5.0"'), 1)
-        self.assertEqual(version("silobrief"), "0.5.0")
+        self.assertEqual(pyproject.count('version = "0.6.0"'), 1)
+        self.assertEqual(version("silobrief"), "0.6.0")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())


### PR DESCRIPTION
## 변경 사항

- 패키지 버전과 공개 문서를 v0.6.0으로 갱신합니다.
- `sb example`과 독립적인 CLI/브리프 언어 설정을 릴리스 노트에 반영합니다.
- 현재 지원 버전과 문서 회귀 검사를 v0.6.0에 맞춥니다.

## 검증

- Ruff lint 및 format check
- mypy strict
- unittest 161개 통과, 7개 skip
- wheel 및 sdist 빌드
- 격리된 Windows 가상환경에서 wheel 설치 후 `sb --version`, `sb example`, `sb setup`, `sb language` 검증

Refs #138