### PR TITLE
fix(release): make PyPI build environment complete

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -81,7 +81,9 @@ jobs:
           PY
 
       - name: Install build tooling and package
-        run: python -m pip install --disable-pip-version-check "build>=1.2,<2" .
+        run: >-
+          python -m pip install --disable-pip-version-check
+          "build>=1.2,<2" "setuptools>=77" .
 
       - name: Run release tests
         run: python -m unittest discover -s tests -q


### PR DESCRIPTION
## Release hotfix

Promote the verified PyPI workflow fix from `develop` to `main`.

The release runner now installs `setuptools>=77`, matching `pyproject.toml`'s build-system requirement, before running the no-isolation sdist test.

## Validation

- clean environment began with no importable setuptools
- revised install command installed the backend successfully
- 177 tests passed with 7 environment-dependent skips
- wheel and sdist built successfully
- PR #143 passed Ubuntu/Windows on Python 3.10 and 3.14

The prior PyPI run failed before artifact upload, so no package version has been published. After merge, the existing `v1.0.0` tag must be moved to the corrected main commit before the workflow can be rerun.