### PR TITLE
Sync v1.0.1 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-12
+
+### Fixed
+
+- Normalize modules below a conventional `src/` source root and resolve absolute, relative, and
+  aliased imports when connecting cross-file import and call graph edges. Existing projects should
+  run `sb init` after upgrading to rebuild the derived index with the corrected graph (#145).
+
 ## [1.0.0] - 2026-08-11
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.0"><img src="https://img.shields.io/badge/release-v1.0.0-4f46e5" alt="릴리스 v1.0.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="릴리스 v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -57,7 +57,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.0
+siloBrief 1.0.1
 ```
 
 ## 명령어
@@ -224,7 +224,7 @@ siloBrief는 보안 검사기나 폐쇄 환경의 반출 승인 시스템이 아
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.0이며, 지원되는 1.x 호환성 계약을 정의합니다.
+최신 공개 버전은 v1.0.1이며, 지원되는 1.x 호환성 계약을 따릅니다.
 `sb search`는 고정된 12개 과제 중 11개에서 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다.
 `sb brief`는 관계가 표시된 맥락 후보를 기본 미선택 상태로 보여주며, 명시적으로 승인한 맥락과
 소스만 하나의 자족적인 Markdown 파일로 묶습니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.0"><img src="https://img.shields.io/badge/release-v1.0.0-4f46e5" alt="Release v1.0.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="Release v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -55,7 +55,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.0
+siloBrief 1.0.1
 ```
 
 ## Commands
@@ -218,7 +218,7 @@ disclosure. Review every generated file under your organization's disclosure rul
 
 ## Validation status
 
-The latest public release is v1.0.0 and defines the supported 1.x compatibility contract.
+The latest public release is v1.0.1 and follows the supported 1.x compatibility contract.
 `sb search` now reaches an expected symbol for 11 of 12 frozen tasks, with mean reciprocal rank
 72.2%. `sb brief` shows relation-labeled context proposals, defaults every proposal to unselected,
 and packages only explicitly approved context and source into one self-contained Markdown file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.0"
+version = "1.0.1"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -62,12 +62,20 @@ class IndexData:
 
 
 @dataclass(frozen=True, slots=True)
+class _ImportBinding:
+    context: str | None
+    visible: str
+    target: str
+
+
+@dataclass(frozen=True, slots=True)
 class _ModuleContext:
     module_id: str
     module_name: str
     structure: ModuleStructure
     definition_nodes: tuple[IndexNode, ...]
     context_ids: dict[str, str]
+    import_bindings: tuple[_ImportBinding, ...]
     path_tokens: tuple[str, ...]
     import_tokens: tuple[str, ...]
     comment_tokens: tuple[str, ...]
@@ -187,6 +195,7 @@ def _build_module_context(
         structure=structure,
         definition_nodes=tuple(definition_nodes),
         context_ids=context_ids,
+        import_bindings=_import_bindings(module_name, source.path, structure.imports),
         path_tokens=path_tokens,
         import_tokens=import_tokens,
         comment_tokens=text_tokens.module.comments,
@@ -235,8 +244,13 @@ def _add_import_edges(
             target: str | BoundaryPlaceholder = placeholder
             target_id = None
         else:
-            target = import_target(imported)
-            target_id = global_targets.get(target)
+            resolved_target = _resolved_import_target(
+                context.module_name, context.structure.path, imported
+            )
+            if resolved_target is None:
+                resolved_target = import_target(imported)
+            target = resolved_target
+            target_id = global_targets.get(resolved_target)
         edges.add(IndexEdge(source_id, "import", target, target_id))
 
 
@@ -281,6 +295,9 @@ def _resolve_target(
                 return context.context_ids[candidate]
     if target in context.context_ids:
         return context.context_ids[target]
+    imported_target = _resolve_import_binding(context, source_context, target)
+    if imported_target is not None:
+        return global_targets.get(imported_target)
     return global_targets.get(target)
 
 
@@ -296,12 +313,93 @@ def _context_id(context: _ModuleContext, qualified_name: str | None) -> str:
 def _module_name(path: str) -> str:
     _validate_relative_path(path)
     parts = list(PurePosixPath(path).parts)
+    if len(parts) > 1 and parts[0] == "src" and parts[1] != "__init__.py":
+        parts.pop(0)
     filename = parts[-1]
     if filename == "__init__.py" and len(parts) > 1:
         parts.pop()
     else:
         parts[-1] = filename.removesuffix(".py")
     return ".".join(parts)
+
+
+def _import_bindings(
+    module_name: str,
+    source_path: str,
+    imports: tuple[ImportEntry, ...],
+) -> tuple[_ImportBinding, ...]:
+    bindings: dict[str | None, dict[str, str]] = {}
+    for imported in imports:
+        target = _resolved_import_target(module_name, source_path, imported)
+        visible = _visible_import_binding(imported)
+        if target is None or visible is None:
+            continue
+        bindings.setdefault(imported.context, {})[visible] = target
+
+    result: list[_ImportBinding] = []
+    for context in sorted(bindings, key=lambda value: value or ""):
+        for visible, target in sorted(
+            bindings[context].items(),
+            key=lambda item: (-len(item[0].split(".")), item[0], item[1]),
+        ):
+            result.append(_ImportBinding(context, visible, target))
+    return tuple(result)
+
+
+def _resolved_import_target(
+    module_name: str,
+    source_path: str,
+    imported: ImportEntry,
+) -> str | None:
+    if imported.level == 0:
+        return import_target(imported)
+
+    package = module_name.split(".")
+    if PurePosixPath(source_path).name != "__init__.py":
+        package.pop()
+    upward = imported.level - 1
+    if upward > len(package):
+        return None
+    if upward:
+        package = package[:-upward]
+
+    parts = [*package]
+    if imported.module:
+        parts.extend(imported.module.split("."))
+    if imported.name and imported.name != "*":
+        parts.append(imported.name)
+    return ".".join(parts) or None
+
+
+def _visible_import_binding(imported: ImportEntry) -> str | None:
+    if imported.alias is not None:
+        return imported.alias
+    if imported.name is not None:
+        return None if imported.name == "*" else imported.name
+    if imported.module is None:
+        return None
+    return imported.module
+
+
+def _resolve_import_binding(
+    context: _ModuleContext,
+    source_context: str | None,
+    target: str,
+) -> str | None:
+    current = source_context
+    while True:
+        for binding in context.import_bindings:
+            if binding.context != current:
+                continue
+            if target == binding.visible:
+                return binding.target
+            if target.startswith(f"{binding.visible}."):
+                return f"{binding.target}{target[len(binding.visible) :]}"
+        if current is None:
+            return None
+        current, separator, _ = current.rpartition(".")
+        if not separator:
+            current = None
 
 
 def _import_search_values(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.1\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -88,6 +88,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.1] - 2026-08-12", changelog)
         self.assertIn("## [1.0.0] - 2026-08-11", changelog)
         self.assertIn(f"## [0.6.0] - {V0_6_RELEASE_DATE}", changelog)
         self.assertIn(f"## [0.5.0] - {V0_5_RELEASE_DATE}", changelog)
@@ -105,7 +106,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
             self.assertIn(fragment, changelog)
 
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("latest public release is v1.0.0", readme)
+        self.assertIn("latest public release is v1.0.1", readme)
         self.assertIn("supported 1.x compatibility contract", readme)
         self.assertIn("Create a disposable project", readme)
         self.assertIn("`sb language [", readme)
@@ -114,7 +115,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertIn("exact indexed Python file path", readme)
         self.assertIn("11 of 12 frozen tasks", readme)
         readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
-        self.assertIn("최신 공개 버전은 v1.0.0", readme_ko)
+        self.assertIn("최신 공개 버전은 v1.0.1", readme_ko)
         self.assertIn("지원되는 1.x 호환성 계약", readme_ko)
         self.assertIn("버려도 되는 합성 프로젝트", readme_ko)
         self.assertIn("`sb language [", readme_ko)
@@ -129,8 +130,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.0"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.0")
+        self.assertEqual(pyproject.count('version = "1.0.1"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.1")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_graph_retrieval_baseline.py
+++ b/tests/test_graph_retrieval_baseline.py
@@ -73,7 +73,7 @@ TASKS: tuple[BenchmarkTask, ...] = (
         "Update the retry policy so status-code retries apply to HTTP 503 and not HTTP 500. "
         "Keep total=2 and preserve the delivery boundary call order.",
         targets("src/parcel_lab/retry.py", "retry_request"),
-        targets("src/parcel_lab/retry.py", "src.parcel_lab.retry"),
+        targets("src/parcel_lab/retry.py", "parcel_lab.retry"),
         "validation:v0.2/T01-MODIFY",
     ),
     BenchmarkTask(
@@ -84,7 +84,7 @@ TASKS: tuple[BenchmarkTask, ...] = (
         "keep current output. Insert it between prefix and reference and preserve uppercase "
         "behavior.",
         targets("src/parcel_lab/labels.py", "LabelOptions", "format_label"),
-        targets("src/parcel_lab/labels.py", "src.parcel_lab.labels"),
+        targets("src/parcel_lab/labels.py", "parcel_lab.labels"),
         "validation:v0.2/T02-ADD",
     ),
     BenchmarkTask(
@@ -94,7 +94,7 @@ TASKS: tuple[BenchmarkTask, ...] = (
         "Remove the legacy fallback from choose_reference. Accept only primary, return the "
         "stripped value, and raise ValueError when it is blank.",
         targets("src/parcel_lab/cleanup.py", "choose_reference"),
-        targets("src/parcel_lab/cleanup.py", "src.parcel_lab.cleanup"),
+        targets("src/parcel_lab/cleanup.py", "parcel_lab.cleanup"),
         "validation:v0.2/T03-REMOVE",
     ),
     BenchmarkTask(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -147,6 +147,73 @@ class DeterministicIndexTests(unittest.TestCase):
                 self.assertNotIn("documentation", nodes[name].tokens.docstrings)
                 self.assertNotIn("comment", nodes[name].tokens.comments)
 
+    def test_resolves_absolute_imports_and_calls_across_src_layout_modules(self) -> None:
+        caller = source_file(
+            "src/pkg/a.py",
+            b"from pkg.b import helper\n\ndef run():\n    return helper()\n",
+        )
+        dependency = source_file("src/pkg/b.py", b"def helper():\n    return 42\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.kind, node.qualified_name): node for node in index.nodes}
+        caller_module = nodes[("src/pkg/a.py", "module", "pkg.a")]
+        dependency_function = nodes[("src/pkg/b.py", "function", "helper")]
+        run = nodes[("src/pkg/a.py", "function", "run")]
+
+        self.assertIn(
+            IndexEdge(caller_module.id, "import", "pkg.b.helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "helper", dependency_function.id),
+            index.edges,
+        )
+
+    def test_resolves_relative_and_aliased_import_calls(self) -> None:
+        caller = source_file(
+            "src/pkg/feature.py",
+            (
+                b"from .b import helper as local_helper\n"
+                b"import pkg.b as module_alias\n"
+                b"import pkg.b\n\n"
+                b"def run():\n"
+                b"    local_helper()\n"
+                b"    module_alias.helper()\n"
+                b"    pkg.b.helper()\n"
+            ),
+        )
+        dependency = source_file("src/pkg/b.py", b"def helper():\n    return 42\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.kind, node.qualified_name): node for node in index.nodes}
+        caller_module = nodes[("src/pkg/feature.py", "module", "pkg.feature")]
+        dependency_module = nodes[("src/pkg/b.py", "module", "pkg.b")]
+        dependency_function = nodes[("src/pkg/b.py", "function", "helper")]
+        run = nodes[("src/pkg/feature.py", "function", "run")]
+
+        self.assertIn(
+            IndexEdge(caller_module.id, "import", "pkg.b.helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(caller_module.id, "import", "pkg.b", dependency_module.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "local_helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "module_alias.helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "pkg.b.helper", dependency_function.id),
+            index.edges,
+        )
+
     def test_json_is_identical_for_equivalent_input_order(self) -> None:
         first_source = source_file(
             "a.py",

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -21,7 +21,7 @@ from silobrief.cli import main
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
-INDEX_SHA256 = "e47e1d49d1f3d5ec828e10594922c0586eb5f0eb98bbcf333c7672122e0c901c"
+INDEX_SHA256 = "8809c96fed66de0d08d600c8797943269c12ae3b2bb3216325f533fff11b34ad"
 BRIEF_SHA256 = "065e297861d5839a20a06607bf282a5bb19224c6ced007b75893fe47d7a32533"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",


### PR DESCRIPTION
## Summary

Merge the released `v1.0.1` hotfix from `main` back into `develop` so future development retains the corrected src-layout import graph resolution and the current package metadata.

## Included release

- [v1.0.1](https://github.com/d3vksy/silobrief/releases/tag/v1.0.1)
- Fixes #145 through #146
- Published to PyPI through Trusted Publishing

No additional product changes are introduced by this synchronization PR.