### PR TITLE
docs: v1.0.1 검증 자료와 README 표기 정리

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
   <a href="#명령어">명령어</a> •
   <a href="#사용법">사용법</a> •
   <a href="#보호-범위와-한계">보호 범위</a> •
-  <a href="#문서">문서</a> •
+  <a href="#보안">보안</a> •
   <a href="README.md">English</a>
 </p>
 
@@ -242,6 +242,7 @@ Django Ninja, pytest, Jinja 저장소에서 Python 소스를 바꾸거나 네트
 - [v0.7 검색 결과](validation/v0.7/RETRIEVAL_RESULT.md)
 - [v0.8 연관 맥락 결과](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [1인 현장 시험 절차](validation/v0.9/FIELD_TRIAL.md)
+- [v1.0.1 릴리스 검증](validation/v1.0.1/RELEASE_VERIFICATION.md)
 
 ## 종료 코드
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -71,7 +71,7 @@ siloBrief 1.0.1
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
 | `sb search "PROMPT"` | 제한된 수의 관련 코드 후보와 어떤 요청 단어가 일치했는지 보여줍니다. |
-| `sb language [--cli en|ko] [--brief en|ko]` | 터미널 안내와 생성 브리프의 언어를 각각 설정합니다. |
+| `sb language [--cli {en,ko}] [--brief {en,ko}]` | 터미널 안내와 생성 브리프의 언어를 각각 설정합니다. |
 | `sb brief "PROMPT" --out FILE` | 전달할 내용을 검토하고 자족적인 Markdown 파일 하나를 만듭니다. |
 | `sb chat "PROMPT" --out FILE` | `sb brief`의 사용 중단 예정 호환 별칭입니다. |
 | `sb --version` | 설치된 siloBrief 버전을 출력합니다. |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="#commands">Commands</a> •
   <a href="#usage">Usage</a> •
   <a href="#safety-and-limitations">Safety</a> •
-  <a href="#documentation">Documentation</a> •
+  <a href="#security">Security</a> •
   <a href="README.ko.md">한국어</a>
 </p>
 
@@ -236,6 +236,7 @@ export approval, market demand, or effectiveness across external AI models and p
 - [v0.7 retrieval result](validation/v0.7/RETRIEVAL_RESULT.md)
 - [v0.8 related-context result](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [solo field-trial procedure](validation/v0.9/FIELD_TRIAL.md)
+- [v1.0.1 release verification](validation/v1.0.1/RELEASE_VERIFICATION.md)
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ siloBrief 1.0.1
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
 | `sb search "PROMPT"` | Lists a bounded set of code candidates and the request terms that matched each one. |
-| `sb language [--cli en|ko] [--brief en|ko]` | Sets terminal and generated-brief languages independently. |
+| `sb language [--cli {en,ko}] [--brief {en,ko}]` | Sets terminal and generated-brief languages independently. |
 | `sb brief "PROMPT" --out FILE` | Reviews context and writes one self-contained brief. |
 | `sb chat "PROMPT" --out FILE` | Deprecated compatibility alias for `sb brief`. |
 | `sb --version` | Prints the installed siloBrief version. |

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -64,6 +64,15 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
+    def test_readme_navigation_links_target_current_sections(self) -> None:
+        readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn('<a href="#security">Security</a>', readme)
+        self.assertNotIn('href="#documentation"', readme)
+
+        readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
+        self.assertIn('<a href="#보안">보안</a>', readme_ko)
+        self.assertNotIn('href="#문서"', readme_ko)
+
     def test_readmes_cover_the_public_flow_and_limits(self) -> None:
         for relative_path, specific_fragments in README_EXPECTATIONS.items():
             with self.subTest(path=relative_path):

--- a/validation/v1.0.1/RELEASE_VERIFICATION.md
+++ b/validation/v1.0.1/RELEASE_VERIFICATION.md
@@ -1,0 +1,99 @@
+# v1.0.1 release verification
+
+Date: 2026-08-12
+
+Status: PASS for the tagged source, release artifacts, publishing provenance, and frozen retrieval
+benchmark described below.
+
+## Scope
+
+This record verifies the public `v1.0.1` tag and the exact wheel and sdist produced by the successful
+PyPI publishing workflow. Later changes on `main` are outside this record. This is release and
+repository verification, not a user field trial or evidence of market demand.
+
+## Source and publishing provenance
+
+The annotated `v1.0.1` tag resolves to commit
+`74e213c3867fff437c9ac5909a77264b07865fbc`. The successful
+[PyPI publishing run](https://github.com/d3vksy/silobrief/actions/runs/31545145103) reports the same
+`head_sha`, and the tag commit is reachable from `main`.
+
+The publishing workflow checked out `refs/tags/v1.0.1`, compared the tag commit with `HEAD`, checked
+that the commit was reachable from `main`, verified the version in `pyproject.toml`, ran the release
+tests, built exactly one wheel and one sdist, and uploaded those files as artifact `pypi-1.0.1`.
+The publish job downloaded that validated artifact and sent it to PyPI through Trusted Publishing.
+
+The separate [CI run](https://github.com/d3vksy/silobrief/actions/runs/31545007156) for the same commit
+passed the Ubuntu and Windows matrix on Python 3.10 and 3.14. Each matrix job ran Ruff, formatting,
+mypy strict checks, the test suite, distribution builds, wheel installation, and the installed-wheel
+test suite.
+
+The annotated tag is not cryptographically signed. The exact tag, workflow SHA, artifact hashes,
+and release files remain independently comparable.
+
+## Artifact identity
+
+The GitHub Release files and the expiring `pypi-1.0.1` workflow artifact were downloaded separately
+on 2026-08-12 and compared byte for byte by SHA-256.
+
+| Artifact | SHA-256 | Release/workflow match |
+|---|---|---|
+| `silobrief-1.0.1-py3-none-any.whl` | `8e41170563821434b82d3cbf75218e144228b19dbdab86570cd0ebf5873f1784` | yes |
+| `silobrief-1.0.1.tar.gz` | `b7554e16b29a68856a366ded3efcda138237f4246967d673e8e916a44cfd8669` | yes |
+
+All 30 hashed entries in the wheel's `RECORD` file matched their archived bytes and declared sizes.
+
+## Local source-tree checks
+
+The following checks passed on Windows with CPython 3.14.3:
+
+```powershell
+python -m ruff check .
+python -m mypy src tests
+python -m unittest discover -s tests -q
+```
+
+Ruff reported no findings, mypy strict mode reported no issues in 54 source files, and all 179 tests
+passed with 7 environment-dependent skips.
+
+## Frozen retrieval benchmark
+
+The production indexer and ranking implementation were rerun through
+`tests/test_graph_retrieval_baseline.py` at `v1.0.1` behavior. The current result is:
+
+| Metric | Result |
+|---|---:|
+| Fixed maintenance tasks | 12 |
+| Tasks with an expected symbol in returned candidates | 11/12 |
+| Expected symbols returned | 14/17 |
+| Expected symbols reachable within two graph hops | 17/17 |
+| Mean reciprocal rank | 72.2% (`13/18`) |
+| Irrelevant returned candidates | 41 |
+| Maximum expanded nodes for one task | 10 |
+| Registered-boundary canary disclosures | 0 |
+
+Reproduction:
+
+```powershell
+$env:PYTHONPATH='src'
+python -m unittest tests.test_graph_retrieval_baseline -v
+python tests/test_graph_retrieval_baseline.py
+```
+
+The second command prints canonical JSON. For this source tree, including a final newline, its
+SHA-256 is `6109a3a0d8995e81c27cd172bcb7d84faf7c2b2fcb067006e3b0d6e6cc6638f3`.
+
+## Interpretation and limits
+
+The earlier `validation/v0.7/RETRIEVAL_RESULT.md` remains an immutable historical result. Its
+44 irrelevant candidates and pending hosted-CI note describe that revision, while this document
+records the v1.0.1 state.
+
+The benchmark is small and includes repository-local and synthetic tasks. It demonstrates stable
+behavior against declared gates, not superiority to manual selection or other tools. It does not
+establish broad user demand, automatic context completeness, secret detection, export approval, or
+improved answers from external AI models. Candidate search remains lexical and advisory.
+
+The static Python graph also does not promise complete language semantics. Dynamic imports,
+reflection, wildcard-import binding, package re-export chains, and aliases created by assignment may
+remain unresolved. Exact-path selection and human review remain the supported fallback.


### PR DESCRIPTION
## 변경 내용

- `sb language` 명령 표기를 실제 CLI 선택지 문법인 `{en,ko}`로 바로잡았습니다.
- README 상단의 존재하지 않는 `Documentation`·`문서` 앵커를 실제 `Security`·`보안` 절로 연결했습니다.
- 태그, CI, PyPI workflow artifact, GitHub Release 파일, retrieval benchmark를 교차 검증한 `validation/v1.0.1/RELEASE_VERIFICATION.md`를 추가했습니다.
- README 탐색 링크가 이전 앵커로 돌아가지 않도록 문서 회귀 테스트를 추가했습니다.

## 배경

문서 절을 정리한 뒤 상단 탐색 링크가 이전 앵커를 계속 가리켰고, v1.0.1 기준의 릴리스 무결성과 최신 benchmark 수치를 한곳에서 재현할 공개 기록이 없었습니다.

## 영향

런타임 코드, 패키지 버전, GitHub Release 및 PyPI 배포물은 변경하지 않습니다. 기존 v0.7 검증 기록은 역사적 결과로 유지합니다.

## 검증

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy src tests`
- `python -m unittest discover -s tests -q` — 180 tests, 7 skips
- README 로컬 링크 대상 확인
- 별도 v1.0.1 태그 worktree — 179 tests, 7 skips
- GitHub Release와 `pypi-1.0.1` workflow artifact SHA-256 일치
- wheel `RECORD` 30개 해시·크기 검증