### PR TITLE
docs: README 대표 워드마크 복구

### DIFF
--- a/.github/assets/silobrief-wordmark.svg
+++ b/.github/assets/silobrief-wordmark.svg
@@ -1,0 +1,68 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1600 480"
+  role="img"
+  aria-labelledby="title description"
+>
+  <title id="title">siloBrief</title>
+  <desc id="description">
+    The siloBrief wordmark beside a document moving through an open project boundary.
+  </desc>
+
+  <style>
+    .silo-fill { fill: #4f46e5; }
+    .silo-stroke { stroke: #4f46e5; }
+    .brief-fill { fill: #0f766e; }
+    .brief-detail { stroke: #ecfdf5; }
+
+    @media (prefers-color-scheme: dark) {
+      .silo-fill { fill: #818cf8; }
+      .silo-stroke { stroke: #818cf8; }
+      .brief-fill { fill: #2dd4bf; }
+      .brief-detail { stroke: #042f2e; }
+    }
+  </style>
+
+  <g transform="translate(92 70)">
+    <path
+      class="silo-stroke"
+      d="M190 30H86C51 30 30 55 30 90V270C30 305 51 330 86 330H190"
+      fill="none"
+      stroke-width="26"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <path
+      class="brief-fill"
+      d="M142 84H250L296 130V310H142Z"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M250 84V130H296"
+      fill="none"
+      stroke="#ffffff"
+      stroke-opacity="0.72"
+      stroke-width="13"
+      stroke-linejoin="round"
+    />
+    <path
+      class="brief-detail"
+      d="M180 175H258M180 216H258M180 257H231"
+      fill="none"
+      stroke-width="14"
+      stroke-linecap="round"
+    />
+  </g>
+
+  <text
+    x="430"
+    y="316"
+    font-family="Inter, 'Segoe UI', Arial, sans-serif"
+    font-size="242"
+    font-weight="750"
+    letter-spacing="-10"
+  >
+    <tspan class="silo-fill">silo</tspan><tspan class="brief-fill">Brief</tspan>
+  </text>
+</svg>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,10 @@
 <p align="center">
+  <img src=".github/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
+
+---
+
+<p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
   <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="릴리스 v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <p align="center">
+  <img src=".github/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
+
+---
+
+<p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="Release v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -64,6 +64,14 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
+    def test_readmes_show_the_repository_wordmark(self) -> None:
+        wordmark = ".github/assets/silobrief-wordmark.svg"
+        self.assertTrue((REPOSITORY_ROOT / wordmark).is_file())
+        for readme_name in ("README.md", "README.ko.md"):
+            with self.subTest(path=readme_name):
+                text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")
+                self.assertIn(f'<img src="{wordmark}" alt="siloBrief"', text)
+
     def test_readme_navigation_links_target_current_sections(self) -> None:
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn('<a href="#security">Security</a>', readme)


### PR DESCRIPTION
## 변경 내용

- 과거 README에서 사용하던 siloBrief 워드마크 SVG를 `.github/assets/` 아래에 복구했습니다.
- 영문·한글 README 상단에서 같은 워드마크를 표시하도록 연결했습니다.
- 이미지 파일이나 README 참조가 다시 빠지면 문서 테스트가 실패하도록 회귀 검증을 추가했습니다.

## 원인

공개 저장소 표면을 정리한 커밋에서 `docs/assets/silobrief-wordmark.svg`와 README의 이미지 태그가 함께 삭제됐습니다. 외부 배지 URL은 모두 정상이며 대표 워드마크만 소스에서 사라진 상태였습니다.

## 영향

`docs/` 디렉터리는 복구하지 않습니다. 런타임 코드, 패키지 버전, GitHub Release와 PyPI 배포물에도 변화가 없습니다.

## 검증

- SVG XML 파싱 성공
- 원격 raw 파일 응답: HTTP 200, `image/svg+xml`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy src tests`
- `python -m unittest tests.test_documentation -q`
- `git diff --check`