### PR TITLE
docs: README 워드마크 시각 중심 정렬

### DIFF
--- a/.github/assets/silobrief-wordmark.svg
+++ b/.github/assets/silobrief-wordmark.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 1600 480"
+  viewBox="-100 0 1600 480"
   role="img"
   aria-labelledby="title description"
 >

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -67,6 +67,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_readmes_show_the_repository_wordmark(self) -> None:
         wordmark = ".github/assets/silobrief-wordmark.svg"
         self.assertTrue((REPOSITORY_ROOT / wordmark).is_file())
+        wordmark_text = (REPOSITORY_ROOT / wordmark).read_text(encoding="utf-8")
+        self.assertIn('viewBox="-100 0 1600 480"', wordmark_text)
         for readme_name in ("README.md", "README.ko.md"):
             with self.subTest(path=readme_name):
                 text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")


### PR DESCRIPTION
## 변경 내용

- 워드마크 SVG의 좌표계를 조정해 좌우 투명 여백을 대칭으로 맞췄습니다.
- 가운데 정렬용 viewBox가 유지되는지 문서 테스트에 추가했습니다.

## 원인

README의 `<p align="center">`는 정상 동작해 이미지 박스 자체는 가운데였습니다. 하지만 SVG 원본의 오른쪽 투명 여백이 왼쪽보다 약 200 좌표 단위 더 커서 실제 로고 도형이 왼쪽으로 치우쳐 보였습니다.

## 검증

- GitHub 브랜치 README 실제 렌더링 화면에서 시각 중심 확인
- SVG XML 파싱 성공
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy src tests`
- `python -m unittest tests.test_documentation -q`
- `git diff --check`

런타임 코드, 버전, GitHub Release와 PyPI 배포물은 변경하지 않습니다.