### PR TITLE
docs: sync post-release documentation to develop

### DIFF
--- a/.github/assets/silobrief-wordmark.svg
+++ b/.github/assets/silobrief-wordmark.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 1600 480"
+  viewBox="-100 0 1600 480"
   role="img"
   aria-labelledby="title description"
 >

--- a/.github/assets/silobrief-wordmark.svg
+++ b/.github/assets/silobrief-wordmark.svg
@@ -1,0 +1,68 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1600 480"
+  role="img"
+  aria-labelledby="title description"
+>
+  <title id="title">siloBrief</title>
+  <desc id="description">
+    The siloBrief wordmark beside a document moving through an open project boundary.
+  </desc>
+
+  <style>
+    .silo-fill { fill: #4f46e5; }
+    .silo-stroke { stroke: #4f46e5; }
+    .brief-fill { fill: #0f766e; }
+    .brief-detail { stroke: #ecfdf5; }
+
+    @media (prefers-color-scheme: dark) {
+      .silo-fill { fill: #818cf8; }
+      .silo-stroke { stroke: #818cf8; }
+      .brief-fill { fill: #2dd4bf; }
+      .brief-detail { stroke: #042f2e; }
+    }
+  </style>
+
+  <g transform="translate(92 70)">
+    <path
+      class="silo-stroke"
+      d="M190 30H86C51 30 30 55 30 90V270C30 305 51 330 86 330H190"
+      fill="none"
+      stroke-width="26"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+
+    <path
+      class="brief-fill"
+      d="M142 84H250L296 130V310H142Z"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M250 84V130H296"
+      fill="none"
+      stroke="#ffffff"
+      stroke-opacity="0.72"
+      stroke-width="13"
+      stroke-linejoin="round"
+    />
+    <path
+      class="brief-detail"
+      d="M180 175H258M180 216H258M180 257H231"
+      fill="none"
+      stroke-width="14"
+      stroke-linecap="round"
+    />
+  </g>
+
+  <text
+    x="430"
+    y="316"
+    font-family="Inter, 'Segoe UI', Arial, sans-serif"
+    font-size="242"
+    font-weight="750"
+    letter-spacing="-10"
+  >
+    <tspan class="silo-fill">silo</tspan><tspan class="brief-fill">Brief</tspan>
+  </text>
+</svg>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,10 @@
 <p align="center">
+  <img src=".github/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
+
+---
+
+<p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
   <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="릴리스 v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
   <a href="#명령어">명령어</a> •
   <a href="#사용법">사용법</a> •
   <a href="#보호-범위와-한계">보호 범위</a> •
-  <a href="#문서">문서</a> •
+  <a href="#보안">보안</a> •
   <a href="README.md">English</a>
 </p>
 
@@ -242,6 +242,7 @@ Django Ninja, pytest, Jinja 저장소에서 Python 소스를 바꾸거나 네트
 - [v0.7 검색 결과](validation/v0.7/RETRIEVAL_RESULT.md)
 - [v0.8 연관 맥락 결과](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [1인 현장 시험 절차](validation/v0.9/FIELD_TRIAL.md)
+- [v1.0.1 릴리스 검증](validation/v1.0.1/RELEASE_VERIFICATION.md)
 
 ## 종료 코드
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -71,7 +71,7 @@ siloBrief 1.0.1
 | `sb init` | 제외하지 않은 Python 파일을 분석해 로컬 색인을 만듭니다. |
 | `sb log PATH --comment TEXT` | 코드만 보고는 알 수 없는 프로젝트 정보를 기록합니다. |
 | `sb search "PROMPT"` | 제한된 수의 관련 코드 후보와 어떤 요청 단어가 일치했는지 보여줍니다. |
-| `sb language [--cli en|ko] [--brief en|ko]` | 터미널 안내와 생성 브리프의 언어를 각각 설정합니다. |
+| `sb language [--cli {en,ko}] [--brief {en,ko}]` | 터미널 안내와 생성 브리프의 언어를 각각 설정합니다. |
 | `sb brief "PROMPT" --out FILE` | 전달할 내용을 검토하고 자족적인 Markdown 파일 하나를 만듭니다. |
 | `sb chat "PROMPT" --out FILE` | `sb brief`의 사용 중단 예정 호환 별칭입니다. |
 | `sb --version` | 설치된 siloBrief 버전을 출력합니다. |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <p align="center">
+  <img src=".github/assets/silobrief-wordmark.svg" alt="siloBrief" width="840">
+</p>
+
+---
+
+<p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="Release v1.0.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="#commands">Commands</a> •
   <a href="#usage">Usage</a> •
   <a href="#safety-and-limitations">Safety</a> •
-  <a href="#documentation">Documentation</a> •
+  <a href="#security">Security</a> •
   <a href="README.ko.md">한국어</a>
 </p>
 
@@ -236,6 +236,7 @@ export approval, market demand, or effectiveness across external AI models and p
 - [v0.7 retrieval result](validation/v0.7/RETRIEVAL_RESULT.md)
 - [v0.8 related-context result](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [solo field-trial procedure](validation/v0.9/FIELD_TRIAL.md)
+- [v1.0.1 release verification](validation/v1.0.1/RELEASE_VERIFICATION.md)
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ siloBrief 1.0.1
 | `sb init` | Builds the local search list from allowed Python files. |
 | `sb log PATH --comment TEXT` | Saves an approved project note. |
 | `sb search "PROMPT"` | Lists a bounded set of code candidates and the request terms that matched each one. |
-| `sb language [--cli en|ko] [--brief en|ko]` | Sets terminal and generated-brief languages independently. |
+| `sb language [--cli {en,ko}] [--brief {en,ko}]` | Sets terminal and generated-brief languages independently. |
 | `sb brief "PROMPT" --out FILE` | Reviews context and writes one self-contained brief. |
 | `sb chat "PROMPT" --out FILE` | Deprecated compatibility alias for `sb brief`. |
 | `sb --version` | Prints the installed siloBrief version. |

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -64,6 +64,15 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
+    def test_readme_navigation_links_target_current_sections(self) -> None:
+        readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn('<a href="#security">Security</a>', readme)
+        self.assertNotIn('href="#documentation"', readme)
+
+        readme_ko = (REPOSITORY_ROOT / "README.ko.md").read_text(encoding="utf-8")
+        self.assertIn('<a href="#보안">보안</a>', readme_ko)
+        self.assertNotIn('href="#문서"', readme_ko)
+
     def test_readmes_cover_the_public_flow_and_limits(self) -> None:
         for relative_path, specific_fragments in README_EXPECTATIONS.items():
             with self.subTest(path=relative_path):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -67,6 +67,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_readmes_show_the_repository_wordmark(self) -> None:
         wordmark = ".github/assets/silobrief-wordmark.svg"
         self.assertTrue((REPOSITORY_ROOT / wordmark).is_file())
+        wordmark_text = (REPOSITORY_ROOT / wordmark).read_text(encoding="utf-8")
+        self.assertIn('viewBox="-100 0 1600 480"', wordmark_text)
         for readme_name in ("README.md", "README.ko.md"):
             with self.subTest(path=readme_name):
                 text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -64,6 +64,14 @@ BRIEF_GUIDANCE_EXPECTATIONS = {
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
+    def test_readmes_show_the_repository_wordmark(self) -> None:
+        wordmark = ".github/assets/silobrief-wordmark.svg"
+        self.assertTrue((REPOSITORY_ROOT / wordmark).is_file())
+        for readme_name in ("README.md", "README.ko.md"):
+            with self.subTest(path=readme_name):
+                text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")
+                self.assertIn(f'<img src="{wordmark}" alt="siloBrief"', text)
+
     def test_readme_navigation_links_target_current_sections(self) -> None:
         readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn('<a href="#security">Security</a>', readme)

--- a/validation/v1.0.1/RELEASE_VERIFICATION.md
+++ b/validation/v1.0.1/RELEASE_VERIFICATION.md
@@ -1,0 +1,99 @@
+# v1.0.1 release verification
+
+Date: 2026-08-12
+
+Status: PASS for the tagged source, release artifacts, publishing provenance, and frozen retrieval
+benchmark described below.
+
+## Scope
+
+This record verifies the public `v1.0.1` tag and the exact wheel and sdist produced by the successful
+PyPI publishing workflow. Later changes on `main` are outside this record. This is release and
+repository verification, not a user field trial or evidence of market demand.
+
+## Source and publishing provenance
+
+The annotated `v1.0.1` tag resolves to commit
+`74e213c3867fff437c9ac5909a77264b07865fbc`. The successful
+[PyPI publishing run](https://github.com/d3vksy/silobrief/actions/runs/31545145103) reports the same
+`head_sha`, and the tag commit is reachable from `main`.
+
+The publishing workflow checked out `refs/tags/v1.0.1`, compared the tag commit with `HEAD`, checked
+that the commit was reachable from `main`, verified the version in `pyproject.toml`, ran the release
+tests, built exactly one wheel and one sdist, and uploaded those files as artifact `pypi-1.0.1`.
+The publish job downloaded that validated artifact and sent it to PyPI through Trusted Publishing.
+
+The separate [CI run](https://github.com/d3vksy/silobrief/actions/runs/31545007156) for the same commit
+passed the Ubuntu and Windows matrix on Python 3.10 and 3.14. Each matrix job ran Ruff, formatting,
+mypy strict checks, the test suite, distribution builds, wheel installation, and the installed-wheel
+test suite.
+
+The annotated tag is not cryptographically signed. The exact tag, workflow SHA, artifact hashes,
+and release files remain independently comparable.
+
+## Artifact identity
+
+The GitHub Release files and the expiring `pypi-1.0.1` workflow artifact were downloaded separately
+on 2026-08-12 and compared byte for byte by SHA-256.
+
+| Artifact | SHA-256 | Release/workflow match |
+|---|---|---|
+| `silobrief-1.0.1-py3-none-any.whl` | `8e41170563821434b82d3cbf75218e144228b19dbdab86570cd0ebf5873f1784` | yes |
+| `silobrief-1.0.1.tar.gz` | `b7554e16b29a68856a366ded3efcda138237f4246967d673e8e916a44cfd8669` | yes |
+
+All 30 hashed entries in the wheel's `RECORD` file matched their archived bytes and declared sizes.
+
+## Local source-tree checks
+
+The following checks passed on Windows with CPython 3.14.3:
+
+```powershell
+python -m ruff check .
+python -m mypy src tests
+python -m unittest discover -s tests -q
+```
+
+Ruff reported no findings, mypy strict mode reported no issues in 54 source files, and all 179 tests
+passed with 7 environment-dependent skips.
+
+## Frozen retrieval benchmark
+
+The production indexer and ranking implementation were rerun through
+`tests/test_graph_retrieval_baseline.py` at `v1.0.1` behavior. The current result is:
+
+| Metric | Result |
+|---|---:|
+| Fixed maintenance tasks | 12 |
+| Tasks with an expected symbol in returned candidates | 11/12 |
+| Expected symbols returned | 14/17 |
+| Expected symbols reachable within two graph hops | 17/17 |
+| Mean reciprocal rank | 72.2% (`13/18`) |
+| Irrelevant returned candidates | 41 |
+| Maximum expanded nodes for one task | 10 |
+| Registered-boundary canary disclosures | 0 |
+
+Reproduction:
+
+```powershell
+$env:PYTHONPATH='src'
+python -m unittest tests.test_graph_retrieval_baseline -v
+python tests/test_graph_retrieval_baseline.py
+```
+
+The second command prints canonical JSON. For this source tree, including a final newline, its
+SHA-256 is `6109a3a0d8995e81c27cd172bcb7d84faf7c2b2fcb067006e3b0d6e6cc6638f3`.
+
+## Interpretation and limits
+
+The earlier `validation/v0.7/RETRIEVAL_RESULT.md` remains an immutable historical result. Its
+44 irrelevant candidates and pending hosted-CI note describe that revision, while this document
+records the v1.0.1 state.
+
+The benchmark is small and includes repository-local and synthetic tasks. It demonstrates stable
+behavior against declared gates, not superiority to manual selection or other tools. It does not
+establish broad user demand, automatic context completeness, secret detection, export approval, or
+improved answers from external AI models. Candidate search remains lexical and advisory.
+
+The static Python graph also does not promise complete language semantics. Dynamic imports,
+reflection, wildcard-import binding, package re-export chains, and aliases created by assignment may
+remain unresolved. Exact-path selection and human review remain the supported fallback.


### PR DESCRIPTION
## 관련 Issue

Refs #153

## 변경 이유

v1.0.1을 develop에 다시 병합한 뒤 문서 PR #148, #149, #150이 main에만 반영되어 두 브랜치의 문서 기준이 달라졌습니다. 새 문서 작업을 저장소 규칙대로 develop에서 시작하려면 이 차이를 먼저 해소해야 합니다.

## 변경 내용

- v1.0.1 릴리스 검증 문서를 develop에 반영합니다.
- README의 언어 명령 구문과 wordmark 변경을 develop에 반영합니다.
- main에서 이미 검토된 후속 문서 내용만 동기화합니다.

## 검증

- [x] 관련 acceptance 또는 regression test가 기존 변경에 포함되어 있습니다.
- [x] main에서 로컬 테스트와 CI를 통과한 변경입니다.
- [x] 타입 검사와 lint 범위를 바꾸지 않습니다.
- [x] 실제 조직·저장소·자격 증명·제한 정보를 포함하지 않았습니다.

실행한 명령과 결과:

```text
main의 PR #148, #149, #150 병합 및 CI 통과
```

## 제외 범위와 남은 제한

새 문서 내용과 제품 기능은 추가하지 않습니다. README 리팩터링은 #152에서 별도로 처리합니다.