### PR TITLE
docs(readme): continue quick start with generated example

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -63,22 +63,19 @@ cd silobrief-practice
 생성된 `README.md`를 따라 코드 수정, 함수 추가, 오래된 기능 삭제 과제를 하나씩 진행할 수
 있습니다.
 
-### 기존 프로젝트에서 사용하기
-
-합성 예제 프로젝트인 [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md)를 작업용
-디렉터리에 복사하고, 복사한 프로젝트의 루트에서 다음 명령을 실행합니다.
+같은 디렉터리에서 첫 번째 과제를 시작합니다.
 
 ```console
 sb setup .
-sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
-sb search "Update retry_request to retry HTTP 503 but not 500."
-sb brief "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
+sb log parcel_practice/labels.py --comment "Callers pass uppercase positionally."
+sb search "Append an optional separator to format_label. Preserve positional callers and apply uppercase last."
+sb brief "Append an optional separator to format_label. Preserve positional callers and apply uppercase last. Return a readable diff and focused unittests." --out .silobrief/exports/task-01-modify.md
 ```
 
-`setup`은 작업 공간을 준비합니다. `ignore`는 색인에서 제외할 경로를 등록하고, `init`은 나머지
-Python 파일을 분석합니다. `search`는 관련 코드 후보를 보여 줍니다. `brief`는 같은 후보를
-바탕으로 검토를 시작하고 Markdown 파일을 만듭니다.
+`setup`은 작업 공간을 준비하고, `init`은 Python 파일을 분석합니다. `log`는 공개를 승인한
+프로젝트 정보를 기록합니다. `search`는 관련 코드 후보를 보여 주고, `brief`는 검토를 시작해
+Markdown 파일을 만듭니다.
 
 ## 작동 방식
 

--- a/README.md
+++ b/README.md
@@ -62,22 +62,19 @@ cd silobrief-practice
 
 The generated `README.md` guides you through one modification, one addition, and one removal task.
 
-### Use an existing project
-
-Copy the synthetic [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md) to a working
-directory, then run these commands from the copied project root:
+Start the first task from the same directory:
 
 ```console
 sb setup .
-sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
-sb search "Update retry_request to retry HTTP 503 but not 500."
-sb brief "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
+sb log parcel_practice/labels.py --comment "Callers pass uppercase positionally."
+sb search "Append an optional separator to format_label. Preserve positional callers and apply uppercase last."
+sb brief "Append an optional separator to format_label. Preserve positional callers and apply uppercase last. Return a readable diff and focused unittests." --out .silobrief/exports/task-01-modify.md
 ```
 
-`setup` prepares local state. `ignore` registers a path that must stay outside the index, and `init`
-indexes the remaining Python files. `search` shows ranked candidates. `brief` uses the same
-candidates and starts the review that produces the Markdown file.
+`setup` prepares local state, and `init` indexes the Python files. `log` records approved project
+context. `search` shows ranked candidates, and `brief` starts the review that produces the Markdown
+file.
 
 ## How it works
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -85,6 +85,12 @@ VALIDATION_LINKS = (
     "validation/v0.9/FIELD_TRIAL.md",
     "validation/v1.0.1/RELEASE_VERIFICATION.md",
 )
+PRACTICE_FLOW_EXPECTATIONS = (
+    "sb example ./silobrief-practice",
+    "sb log parcel_practice/labels.py",
+    "Append an optional separator to format_label.",
+    ".silobrief/exports/task-01-modify.md",
+)
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
@@ -115,7 +121,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
         for relative_path, sections in README_SECTION_EXPECTATIONS.items():
             with self.subTest(path=relative_path):
                 text = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
-                for fragment in (*PUBLIC_COMMANDS, FIXTURE_README, *sections):
+                for fragment in (*PUBLIC_COMMANDS, *sections):
                     self.assertIn(fragment, text)
                 for exit_code in (0, 2, 3, 4):
                     self.assertIn(f"| `{exit_code}` |", text)
@@ -131,6 +137,14 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 text = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
                 for fragment in fragments:
                     self.assertIn(fragment, text)
+
+    def test_readmes_continue_with_the_generated_practice_project(self) -> None:
+        for readme_name in README_SECTION_EXPECTATIONS:
+            with self.subTest(path=readme_name):
+                text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")
+                for fragment in PRACTICE_FLOW_EXPECTATIONS:
+                    self.assertIn(fragment, text)
+                self.assertNotIn(FIXTURE_README, text)
 
     def test_readmes_keep_safety_and_validation_facts(self) -> None:
         for relative_path, safety_fragments in SAFETY_EXPECTATIONS.items():


### PR DESCRIPTION
## 관련 Issue

Refs #159

## 변경 이유

빠른 시작에서 `sb example`로 프로젝트를 만든 직후 별도의 `parcel-sync-fixture`를 복사하라고 안내해 실습 경로가 둘로 보였습니다. 복사 문장만 지우면 기존 명령이 생성 프로젝트에 없는 파일과 함수를 참조하는 문제도 있었습니다.

## 변경 내용

- 영문 및 한국어 README에서 별도 fixture 복사 안내를 제거했습니다.
- `sb example`로 만든 디렉터리에서 첫 과제를 바로 시작하도록 명령을 바꿨습니다.
- `parcel_practice/labels.py`와 `format_label`을 사용하는 첫 과제 내용으로 맞췄습니다.
- README가 다시 fixture 복사 흐름으로 바뀌지 않도록 의미 기반 문서 테스트를 추가했습니다.

## 검증

- [x] 관련 regression test를 추가했습니다.
- [x] 로컬 테스트를 실행했습니다.
- [x] 타입 검사와 lint를 통과했습니다.
- [x] 실제 조직·저장소·자격 증명·제한 정보를 포함하지 않았습니다.

실행한 명령과 결과:

```text
python -m unittest discover -s tests -q
Ran 183 tests: OK (skipped=7)

python -m ruff check .
All checks passed!

python -m ruff format --check .
66 files already formatted

python -m mypy
Success: no issues found in 54 source files
```

## 제외 범위와 남은 제한

`examples/parcel-sync-fixture`와 관련 테스트 fixture는 삭제하지 않았습니다. `sb example`의 생성 파일과 CLI 동작도 바꾸지 않았습니다.