### PR TITLE
docs(readme): publish generated-example quick start

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -63,22 +63,19 @@ cd silobrief-practice
 생성된 `README.md`를 따라 코드 수정, 함수 추가, 오래된 기능 삭제 과제를 하나씩 진행할 수
 있습니다.
 
-### 기존 프로젝트에서 사용하기
-
-합성 예제 프로젝트인 [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md)를 작업용
-디렉터리에 복사하고, 복사한 프로젝트의 루트에서 다음 명령을 실행합니다.
+같은 디렉터리에서 첫 번째 과제를 시작합니다.
 
 ```console
 sb setup .
-sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
-sb search "Update retry_request to retry HTTP 503 but not 500."
-sb brief "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
+sb log parcel_practice/labels.py --comment "Callers pass uppercase positionally."
+sb search "Append an optional separator to format_label. Preserve positional callers and apply uppercase last."
+sb brief "Append an optional separator to format_label. Preserve positional callers and apply uppercase last. Return a readable diff and focused unittests." --out .silobrief/exports/task-01-modify.md
 ```
 
-`setup`은 작업 공간을 준비합니다. `ignore`는 색인에서 제외할 경로를 등록하고, `init`은 나머지
-Python 파일을 분석합니다. `search`는 관련 코드 후보를 보여 줍니다. `brief`는 같은 후보를
-바탕으로 검토를 시작하고 Markdown 파일을 만듭니다.
+`setup`은 작업 공간을 준비하고, `init`은 Python 파일을 분석합니다. `log`는 공개를 승인한
+프로젝트 정보를 기록합니다. `search`는 관련 코드 후보를 보여 주고, `brief`는 검토를 시작해
+Markdown 파일을 만듭니다.
 
 ## 작동 방식
 

--- a/README.md
+++ b/README.md
@@ -62,22 +62,19 @@ cd silobrief-practice
 
 The generated `README.md` guides you through one modification, one addition, and one removal task.
 
-### Use an existing project
-
-Copy the synthetic [`parcel-sync-fixture`](examples/parcel-sync-fixture/README.md) to a working
-directory, then run these commands from the copied project root:
+Start the first task from the same directory:
 
 ```console
 sb setup .
-sb ignore private_adapter --as "External delivery adapter" --alias delivery-boundary
 sb init
-sb search "Update retry_request to retry HTTP 503 but not 500."
-sb brief "Update retry_request to retry HTTP 503 but not 500. Return a unified diff and tests." --out .silobrief/exports/retry-brief.md
+sb log parcel_practice/labels.py --comment "Callers pass uppercase positionally."
+sb search "Append an optional separator to format_label. Preserve positional callers and apply uppercase last."
+sb brief "Append an optional separator to format_label. Preserve positional callers and apply uppercase last. Return a readable diff and focused unittests." --out .silobrief/exports/task-01-modify.md
 ```
 
-`setup` prepares local state. `ignore` registers a path that must stay outside the index, and `init`
-indexes the remaining Python files. `search` shows ranked candidates. `brief` uses the same
-candidates and starts the review that produces the Markdown file.
+`setup` prepares local state, and `init` indexes the Python files. `log` records approved project
+context. `search` shows ranked candidates, and `brief` starts the review that produces the Markdown
+file.
 
 ## How it works
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -85,6 +85,12 @@ VALIDATION_LINKS = (
     "validation/v0.9/FIELD_TRIAL.md",
     "validation/v1.0.1/RELEASE_VERIFICATION.md",
 )
+PRACTICE_FLOW_EXPECTATIONS = (
+    "sb example ./silobrief-practice",
+    "sb log parcel_practice/labels.py",
+    "Append an optional separator to format_label.",
+    ".silobrief/exports/task-01-modify.md",
+)
 
 
 class ReleaseDocumentationTests(unittest.TestCase):
@@ -115,7 +121,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
         for relative_path, sections in README_SECTION_EXPECTATIONS.items():
             with self.subTest(path=relative_path):
                 text = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
-                for fragment in (*PUBLIC_COMMANDS, FIXTURE_README, *sections):
+                for fragment in (*PUBLIC_COMMANDS, *sections):
                     self.assertIn(fragment, text)
                 for exit_code in (0, 2, 3, 4):
                     self.assertIn(f"| `{exit_code}` |", text)
@@ -131,6 +137,14 @@ class ReleaseDocumentationTests(unittest.TestCase):
                 text = (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
                 for fragment in fragments:
                     self.assertIn(fragment, text)
+
+    def test_readmes_continue_with_the_generated_practice_project(self) -> None:
+        for readme_name in README_SECTION_EXPECTATIONS:
+            with self.subTest(path=readme_name):
+                text = (REPOSITORY_ROOT / readme_name).read_text(encoding="utf-8")
+                for fragment in PRACTICE_FLOW_EXPECTATIONS:
+                    self.assertIn(fragment, text)
+                self.assertNotIn(FIXTURE_README, text)
 
     def test_readmes_keep_safety_and_validation_facts(self) -> None:
         for relative_path, safety_fragments in SAFETY_EXPECTATIONS.items():


### PR DESCRIPTION
## Related Issue

Refs #159

## Why

Publish the verified README quick-start correction from #160 to the default branch.

## What changed

- remove the `parcel-sync-fixture` copy step from both READMEs
- continue the quick start directly from the project created by `sb example`
- update documentation regression coverage for the generated-example flow

## Validation

- `pytest`: 183 passed, 7 skipped
- `ruff check`: passed
- `ruff format --check`: passed
- `mypy`: passed
- PR #160 CI: passed on all four supported Python/OS combinations

## Scope

This promotion does not change the fixture project, CLI behavior, or Read the Docs implementation work.