### PR TITLE
docs(release): prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-17
+
 ### Changed
 
 - Explain prompt requirements, candidate matches, and optional connected code in plain language,

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="릴리스 v1.0.1"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="릴리스 v1.0.2"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.1
+siloBrief 1.0.2
 ```
 
 ### 실습 예제
@@ -191,7 +191,7 @@ siloBrief는 등록된 제외 경로를 읽지 않고, 색인을 만들 때 심�
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.1이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.0.2이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="Release v1.0.1"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="Release v1.0.2"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.1
+siloBrief 1.0.2
 ```
 
 ### Practice project
@@ -192,7 +192,7 @@ organization's disclosure rules before sharing it.
 
 ## Validation status
 
-The latest public release is v1.0.1 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.0.2 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.1"
+version = "1.0.2"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.1\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.2\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -72,8 +72,8 @@ SAFETY_EXPECTATIONS = {
     "README.ko.md": ("제외 경로", "심볼릭 링크", "보안 검사기"),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.0.1", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.0.1", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.0.2", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.0.2", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -161,6 +161,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.2] - 2026-08-17", changelog)
         self.assertIn("## [1.0.1] - 2026-08-12", changelog)
         self.assertIn("## [1.0.0] - 2026-08-11", changelog)
         self.assertIn(f"## [0.6.0] - {V0_6_RELEASE_DATE}", changelog)
@@ -185,8 +186,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.1"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.1")
+        self.assertEqual(pyproject.count('version = "1.0.2"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.2")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())


### PR DESCRIPTION
## 변경 사항

- 패키지 버전을 1.0.2로 올립니다.
- 영문 및 한국어 README의 배지, 버전 예시와 최신 공개 버전 표기를 갱신합니다.
- `sb brief` 안내와 후보 표시 개선을 CHANGELOG의 v1.0.2 항목으로 확정합니다.
- 공개 버전 메타데이터를 확인하는 회귀 테스트를 1.0.2에 맞춥니다.

## 검증

- Ruff lint 및 format check 통과
- mypy strict 통과
- unittest 186개 통과, 환경 의존 7개 건너뜀
- wheel 및 sdist 빌드 통과
- 격리된 Windows 가상환경에서 wheel 설치 후 `pip check`, `sb --version`, `sb example`, `sb setup`, `sb init`, `sb search` 통과

로컬 빌드 파일의 SHA-256:

- `silobrief-1.0.2-py3-none-any.whl`: `0bf0a17cc03a786af80f791bd7ea0d2cfb5a8cc4f1d61947c0d1e10a97da3251`
- `silobrief-1.0.2.tar.gz`: `38115a9d445bb636a611a16d0c18f0ada9e652500d118cf3e258a5d761038017`

## 범위 밖

검색 점수, 후보 선정 규칙, 색인 형식과 런타임 의존성은 바꾸지 않습니다.

Refs #166