### PR TITLE
release: siloBrief v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-17
+
 ### Changed
 
 - Explain prompt requirements, candidate matches, and optional connected code in plain language,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Explain prompt requirements, candidate matches, and optional connected code in plain language,
+  with color cues in interactive terminals and uncolored redirected output.
+
 ## [1.0.1] - 2026-08-12
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="릴리스 v1.0.1"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="릴리스 v1.0.2"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.1
+siloBrief 1.0.2
 ```
 
 ### 실습 예제
@@ -191,7 +191,7 @@ siloBrief는 등록된 제외 경로를 읽지 않고, 색인을 만들 때 심�
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.1이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.0.2이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.1"><img src="https://img.shields.io/badge/release-v1.0.1-4f46e5" alt="Release v1.0.1"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="Release v1.0.2"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.1
+siloBrief 1.0.2
 ```
 
 ### Practice project
@@ -192,7 +192,7 @@ organization's disclosure rules before sharing it.
 
 ## Validation status
 
-The latest public release is v1.0.1 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.0.2 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.1"
+version = "1.0.2"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/silobrief/candidate_search.py
+++ b/src/silobrief/candidate_search.py
@@ -5,6 +5,7 @@ from silobrief.language import Language, localized
 from silobrief.ranking import RankEvidence, rank_candidates
 from silobrief.review import CandidateOption, ReviewError, candidate_options
 from silobrief.state import NotesData
+from silobrief.terminal import styled
 
 
 class CandidateSearchError(ValueError):
@@ -25,35 +26,106 @@ def search_candidates(
 
 
 def render_candidate_results(
-    options: tuple[CandidateOption, ...], *, language: Language = "en"
+    options: tuple[CandidateOption, ...],
+    *,
+    language: Language = "en",
+    color: bool = False,
+    interactive: bool = False,
 ) -> str:
-    lines = [localized(language, "Candidates:", "후보:")]
+    lines = [
+        styled(localized(language, "Candidates:", "코드 후보:"), "1;36", enabled=color),
+        localized(
+            language,
+            "These files, functions, and classes appear related to the request.",
+            "요청과 관련 있어 보이는 파일, 함수, 클래스입니다.",
+        ),
+        localized(
+            language,
+            "If names are repeated, compare their file paths.",
+            "같은 이름이 여러 번 나오면 파일 경로를 비교하세요.",
+        ),
+        localized(
+            language,
+            "Relevance is based on matching names, paths, code descriptions, notes, and "
+            "connections.",
+            "관련도는 이름, 파일 경로, 코드 설명, 메모, 연결 관계를 바탕으로 계산합니다.",
+        ),
+    ]
+    if interactive:
+        lines.append(
+            localized(
+                language,
+                "Choose what to include in the brief. If nothing fits, press Enter and enter "
+                "a file path directly.",
+                "문서에 넣을 항목을 고르세요. 원하는 항목이 없으면 Enter를 누른 뒤 "
+                "파일 경로로 직접 찾을 수 있습니다.",
+            )
+        )
+    lines.append("")
     if not options:
-        lines.append(localized(language, "- none", "- 없음"))
+        lines.append(
+            localized(language, "No matching code was found.", "일치하는 코드를 찾지 못했습니다.")
+        )
     for option in options:
         node = option.node
         lines.append(
-            f"{option.number}. {node.path} | {node.kind} {node.qualified_name} "
-            f"| score={option.score}"
+            f"{styled(f'[{option.number}]', '1;32', enabled=color)} "
+            f"{_render_kind(node.kind, language=language)} "
+            f"{styled(node.qualified_name, '1', enabled=color)}"
         )
+        lines.append(f"    {localized(language, 'File', '파일')}: {node.path}")
         lines.append(
-            f"   {localized(language, 'matches', '일치 항목')}: "
+            f"    {localized(language, 'Why it matched', '찾은 이유')}: "
             f"{_render_matches(option.evidence, language=language)}"
         )
         lines.append(
-            f"   {localized(language, 'connections', '연결 수')}: {option.evidence.connected_nodes}"
+            f"    {localized(language, 'Relevance', '관련도')}: "
+            f"{styled(str(option.score), '1;33', enabled=color)}"
+            f"{localized(language, ' points', '점')}"
+            f"  |  {localized(language, 'Directly connected items', '직접 연결된 코드')}: "
+            f"{option.evidence.connected_nodes}{localized(language, '', '개')}"
         )
+        lines.append("")
     return "\n".join(lines) + "\n"
 
 
 def _render_matches(evidence: RankEvidence, *, language: Language) -> str:
     fields = (
-        (localized(language, "path", "경로"), evidence.path_matches),
-        (localized(language, "symbol", "심볼"), evidence.symbol_matches),
+        (localized(language, "file path", "파일 경로"), evidence.path_matches),
+        (localized(language, "name", "이름"), evidence.symbol_matches),
         ("import", evidence.import_matches),
-        ("docstring", evidence.docstring_matches),
+        (localized(language, "code description", "코드 설명"), evidence.docstring_matches),
         (localized(language, "comment", "주석"), evidence.comment_matches),
-        (localized(language, "note", "메모"), evidence.note_matches),
+        (localized(language, "user note", "사용자 메모"), evidence.note_matches),
     )
-    matches = [f"{label}={','.join(tokens)}" for label, tokens in fields if tokens]
+    grouped: dict[tuple[str, ...], list[str]] = {}
+    for label, tokens in fields:
+        if tokens:
+            grouped.setdefault(tokens, []).append(label)
+    matches = [
+        localized(
+            language,
+            f"{_english_join(labels)} {'contains' if len(labels) == 1 else 'contain'} "
+            f'"{", ".join(tokens)}"',
+            f'{", ".join(labels)}에서 "{", ".join(tokens)}" 일치',
+        )
+        for tokens, labels in grouped.items()
+    ]
     return "; ".join(matches) if matches else localized(language, "none", "없음")
+
+
+def _english_join(values: list[str]) -> str:
+    if len(values) == 1:
+        return values[0]
+    if len(values) == 2:
+        return " and ".join(values)
+    return f"{', '.join(values[:-1])}, and {values[-1]}"
+
+
+def _render_kind(kind: str, *, language: Language) -> str:
+    labels = {
+        "module": localized(language, "module", "파일(모듈)"),
+        "class": localized(language, "class", "클래스"),
+        "function": localized(language, "function", "함수"),
+    }
+    return labels[kind]

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -35,6 +35,7 @@ from silobrief.source_review import (
 )
 from silobrief.sources import SourceSnapshot
 from silobrief.state import NotesData
+from silobrief.terminal import styled, supports_color
 
 
 class ChatReviewError(ValueError):
@@ -85,7 +86,8 @@ def review_brief(
     _show_candidates(options, output_stream, cli_language)
     selected_numbers = _read_numbers(input_stream, output_stream, cli_language)
     related = _related_candidates(index, options, selected_numbers)
-    _show_related_candidates(related, output_stream, cli_language)
+    if selected_numbers:
+        _show_related_candidates(related, output_stream, cli_language)
     added = _read_additions(
         index,
         options,
@@ -96,7 +98,11 @@ def review_brief(
         cli_language,
     )
     excluded = _read_selectors(
-        localized(cli_language, "Exclude path or node ID", "제외할 경로 또는 노드 ID"),
+        localized(
+            cli_language,
+            "File path or unique ID to leave out of the brief",
+            "문서에서 뺄 파일 경로나 고유 ID",
+        ),
         input_stream,
         output_stream,
         cli_language,
@@ -150,27 +156,44 @@ def review_brief(
 def _show_candidates(
     options: tuple[CandidateOption, ...], output: TextIO, language: Language
 ) -> None:
-    _write(output, render_candidate_results(options, language=language))
+    _write(
+        output,
+        render_candidate_results(
+            options,
+            language=language,
+            color=supports_color(output),
+            interactive=True,
+        ),
+    )
 
 
 def _confirm_request(input_stream: TextIO, output_stream: TextIO, language: Language) -> None:
+    notice = styled(
+        localized(language, "[Notice]", "[주의]"),
+        "1;33",
+        enabled=supports_color(output_stream),
+    )
     _write(
         output_stream,
-        localized(
+        f"{notice} "
+        + localized(
             language,
-            "Request completeness:\n"
-            "- work goal\n"
-            "- required deliverables\n"
-            "- completion or acceptance criteria\n",
-            "요청 내용 확인:\n- 작업 목표\n- 필요한 결과물\n- 완료 또는 승인 기준\n",
+            "Your prompt works best when it includes:\n"
+            "- the goal of the task\n"
+            "- the output you need\n"
+            "- how you will decide it is complete\n\n",
+            "프롬프트에는 다음 내용이 들어가면 좋습니다:\n"
+            "- 작업 목표\n"
+            "- 필요한 결과물\n"
+            "- 완료 또는 승인 기준\n\n",
         ),
     )
     if (
         _read_line(
             localized(
                 language,
-                "Continue with this complete request? [y/N]: ",
-                "이 요청으로 계속할까요? [y/N]: ",
+                "Continue with this prompt? [y/N]: ",
+                "이 프롬프트로 계속할까요? [y/N]: ",
             ),
             input_stream,
             output_stream,
@@ -190,7 +213,11 @@ def _read_numbers(
     input_stream: TextIO, output_stream: TextIO, language: Language
 ) -> tuple[int, ...]:
     value = _read_line(
-        localized(language, "Select candidate numbers: ", "후보 번호를 선택하세요: "),
+        localized(
+            language,
+            "Candidate numbers to include (example: 1 3, Enter to search by path): ",
+            "포함할 후보 번호 (예: 1 3, 파일 경로로 찾으려면 Enter): ",
+        ),
         input_stream,
         output_stream,
     )
@@ -233,14 +260,18 @@ def _read_additions(
     selectors: list[str] = []
     direct_selectors: list[str] = []
     current_related = related
+    if current_related:
+        _write(
+            output_stream,
+            localized(
+                language,
+                "Enter one r-number at a time. You can also enter a file path or unique ID.\n",
+                "r번호를 하나씩 입력하세요. 목록에 없으면 파일 경로나 고유 ID를 "
+                "입력할 수 있습니다.\n",
+            ),
+        )
     while selector := _read_line(
-        localized(
-            language,
-            "Add related number (rN), path, or node ID (blank to finish): ",
-            "추가할 연관 번호(rN), 경로 또는 노드 ID (끝내려면 Enter): ",
-        ),
-        input_stream,
-        output_stream,
+        _addition_prompt(current_related, language), input_stream, output_stream
     ):
         related_id = _related_selector(selector, current_related, language)
         if related_id is not None:
@@ -265,7 +296,7 @@ def _read_additions(
                         localized(
                             language,
                             f"unknown symbol number: {number}",
-                            f"알 수 없는 심볼 번호: {number}",
+                            f"알 수 없는 함수 또는 클래스 번호: {number}",
                         )
                     )
                 node_id = symbol_options[number - 1].node.id
@@ -296,10 +327,24 @@ def _related_selector(
             localized(
                 language,
                 f"unknown related candidate: {selector}",
-                f"알 수 없는 연관 후보: {selector}",
+                f"알 수 없는 추가 코드 번호: {selector}",
             )
         )
     return related[number - 1].id
+
+
+def _addition_prompt(related: tuple[ReviewNode, ...], language: Language) -> str:
+    if related:
+        return localized(
+            language,
+            "Code to add (example: r1, Enter to finish): ",
+            "추가할 코드 (예: r1, 끝내려면 Enter): ",
+        )
+    return localized(
+        language,
+        "File path or unique ID to add (Enter to finish): ",
+        "추가할 파일 경로나 고유 ID (끝내려면 Enter): ",
+    )
 
 
 def _show_symbol_options(
@@ -310,12 +355,20 @@ def _show_symbol_options(
 ) -> None:
     _write(
         output,
-        localized(language, f"Symbols in `{path}`:\n", f"`{path}`의 심볼:\n"),
+        localized(
+            language,
+            f"Functions and classes in `{path}`:\n",
+            f"`{path}`에서 선택할 함수와 클래스:\n",
+        ),
     )
     if not options:
         _write(output, localized(language, "- none\n", "- 없음\n"))
     for option in options:
-        _write(output, f"{option.number}. {option.node.kind} {option.node.qualified_name}\n")
+        _write(
+            output,
+            f"{option.number}. {_kind_label(option.node.kind, language)} "
+            f"{option.node.qualified_name}\n",
+        )
 
 
 def _read_symbol_numbers(
@@ -324,8 +377,8 @@ def _read_symbol_numbers(
     value = _read_line(
         localized(
             language,
-            "Select symbol numbers from this file (blank for module only): ",
-            "이 파일에서 심볼 번호를 선택하세요 (모듈만 고르려면 Enter): ",
+            "Select function or class numbers (Enter to include the whole file only): ",
+            "함수나 클래스 번호를 선택하세요 (파일 전체만 고르려면 Enter): ",
         ),
         input_stream,
         output_stream,
@@ -339,7 +392,7 @@ def _read_symbol_numbers(
             localized(
                 language,
                 "symbol numbers must be space-separated positive integers",
-                "심볼 번호는 공백으로 구분한 양의 정수여야 합니다",
+                "함수 또는 클래스 번호는 공백으로 구분한 양의 정수여야 합니다",
             )
         ) from error
     if any(number < 1 for number in numbers):
@@ -347,7 +400,7 @@ def _read_symbol_numbers(
             localized(
                 language,
                 "symbol numbers must be space-separated positive integers",
-                "심볼 번호는 공백으로 구분한 양의 정수여야 합니다",
+                "함수 또는 클래스 번호는 공백으로 구분한 양의 정수여야 합니다",
             )
         )
     return numbers
@@ -377,24 +430,59 @@ def _related_candidates(
 def _show_related_candidates(
     related: tuple[ReviewNode, ...], output: TextIO, language: Language
 ) -> None:
+    color = supports_color(output)
     _write(
         output,
-        localized(language, "Related context (not selected):\n", "연관 맥락 (미선택):\n"),
+        styled(
+            localized(
+                language,
+                "Other code connected to your selection (optional):\n",
+                "함께 확인할 코드 (선택 사항):\n",
+            ),
+            "1;36",
+            enabled=color,
+        ),
     )
     if not related:
-        _write(output, localized(language, "- none\n", "- 없음\n"))
-    for number, node in enumerate(related, start=1):
-        relations = ", ".join(node.relations)
         _write(
             output,
-            f"r{number}. {node.path} | {node.kind} {node.qualified_name} | {relations}\n",
+            localized(
+                language,
+                "No directly connected code was found.\n",
+                "직접 연결된 다른 코드를 찾지 못했습니다.\n",
+            ),
+        )
+        return
+    _write(
+        output,
+        localized(
+            language,
+            "These items are directly connected to your selection through function calls, "
+            "references, imports, or class and file membership. They are not in the brief yet. "
+            "Add only what you need.\n\n",
+            "방금 고른 코드와 호출, 참조, import 또는 포함 관계로 직접 연결된 항목입니다. "
+            "아직 문서에는 들어가지 않았습니다. 필요한 코드만 추가하세요.\n\n",
+        ),
+    )
+    for number, node in enumerate(related, start=1):
+        _write(
+            output,
+            f"{styled(f'[r{number}]', '1;32', enabled=color)} "
+            f"{_kind_label(node.kind, language)} "
+            f"{styled(node.qualified_name, '1', enabled=color)}\n"
+            f"     {localized(language, 'File', '파일')}: {node.path}\n"
+            f"     {localized(language, 'Relationship', '선택한 코드와의 관계')}: "
+            f"{_relation_labels(node.relations, node.kind, language)}\n\n",
         )
 
 
 def _show_selected_context(selection: ReviewSelection, output: TextIO, language: Language) -> None:
-    _write(output, localized(language, "Selected context:\n", "선택한 맥락:\n"))
+    _write(output, localized(language, "Code selected for the brief:\n", "문서에 넣을 코드:\n"))
     for node in selection.selected:
-        _write(output, f"- {node.path} | {node.kind} {node.qualified_name}\n")
+        _write(
+            output,
+            f"- {_kind_label(node.kind, language)} {node.qualified_name} ({node.path})\n",
+        )
 
 
 def _read_fields(
@@ -402,31 +490,51 @@ def _read_fields(
 ) -> DisclosureChoices:
     return DisclosureChoices(
         paths=_read_choice(
-            localized(language, "Include relative paths?", "상대 경로를 포함할까요?"),
+            localized(
+                language,
+                "Include selected file paths?",
+                "선택한 코드의 파일 경로를 문서에 포함할까요?",
+            ),
             input_stream,
             output_stream,
             language,
         ),
         symbols=_read_choice(
-            localized(language, "Include symbols?", "심볼을 포함할까요?"),
+            localized(
+                language,
+                "Include selected function and class names?",
+                "선택한 함수와 클래스 이름을 문서에 포함할까요?",
+            ),
             input_stream,
             output_stream,
             language,
         ),
         public_libraries=_read_choice(
-            localized(language, "Include public libraries?", "공개 라이브러리를 포함할까요?"),
+            localized(
+                language,
+                "Include public library names?",
+                "사용한 공개 라이브러리 이름을 문서에 포함할까요?",
+            ),
             input_stream,
             output_stream,
             language,
         ),
         human_notes=_read_choice(
-            localized(language, "Include human notes?", "사용자 메모를 포함할까요?"),
+            localized(
+                language,
+                "Include notes saved with sb log?",
+                "sb log로 저장한 메모를 문서에 포함할까요?",
+            ),
             input_stream,
             output_stream,
             language,
         ),
         boundary_placeholders=_read_choice(
-            localized(language, "Include boundary placeholders?", "경계 정보를 포함할까요?"),
+            localized(
+                language,
+                "Include public boundary descriptions saved with sb ignore?",
+                "sb ignore로 저장한 공개용 경계 설명을 문서에 포함할까요?",
+            ),
             input_stream,
             output_stream,
             language,
@@ -463,6 +571,76 @@ def _write(output: TextIO, value: str) -> None:
         output.write(value)
     except OSError as error:
         raise ChatReviewError("interactive terminal output failed") from error
+
+
+def _kind_label(kind: str, language: Language) -> str:
+    labels = {
+        "module": localized(language, "module", "파일(모듈)"),
+        "class": localized(language, "class", "클래스"),
+        "function": localized(language, "function", "함수"),
+    }
+    return labels[kind]
+
+
+def _relation_labels(relations: tuple[str, ...], kind: str, language: Language) -> str:
+    english_noun = {
+        "module": "this module",
+        "class": "this class",
+        "function": "this function",
+    }[kind]
+    korean_object = {
+        "module": "이 파일(모듈)을",
+        "class": "이 클래스를",
+        "function": "이 함수를",
+    }[kind]
+    korean_subject = {
+        "module": "이 파일(모듈)이",
+        "class": "이 클래스가",
+        "function": "이 함수가",
+    }[kind]
+    labels = {
+        "calls": localized(
+            language,
+            f"the selected code calls {english_noun}",
+            f"선택한 코드가 {korean_object} 호출함",
+        ),
+        "called-by": localized(
+            language,
+            f"{english_noun} calls the selected code",
+            f"{korean_subject} 선택한 코드를 호출함",
+        ),
+        "imports": localized(
+            language,
+            f"the selected code imports {english_noun}",
+            f"선택한 코드가 {korean_object} 불러옴(import)",
+        ),
+        "imported-by": localized(
+            language,
+            f"{english_noun} imports the selected code",
+            f"{korean_subject} 선택한 코드를 불러옴(import)",
+        ),
+        "references": localized(
+            language,
+            f"the selected code refers to {english_noun}",
+            f"선택한 코드가 {korean_object} 참조함",
+        ),
+        "referenced-by": localized(
+            language,
+            f"{english_noun} refers to the selected code",
+            f"{korean_subject} 선택한 코드를 참조함",
+        ),
+        "contains": localized(
+            language,
+            f"the selected code contains {english_noun}",
+            f"선택한 코드가 {korean_object} 포함함",
+        ),
+        "contained-by": localized(
+            language,
+            f"{english_noun} contains the selected code",
+            f"{korean_subject} 선택한 코드를 포함함",
+        ),
+    }
+    return "; ".join(labels[relation] for relation in relations)
 
 
 def _brief_input(

--- a/src/silobrief/cli.py
+++ b/src/silobrief/cli.py
@@ -37,6 +37,7 @@ from silobrief.state import (
     setup_project,
 )
 from silobrief.stored_index import StoredIndexError
+from silobrief.terminal import supports_color
 
 _SOURCE_DISCLOSURE_WARNING_EN = (
     "warning: non-ignored Python files are analyzed locally; source excerpts you select and "
@@ -472,7 +473,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             settings = load_language_settings(root)
             cli_language = settings["cli_language"]
             search_output = render_candidate_results(
-                search_candidates(prompt, index, notes), language=cli_language
+                search_candidates(prompt, index, notes),
+                language=cli_language,
+                color=supports_color(sys.stdout),
             )
         except IndexStateError as error:
             print(f"sb: {localized(cli_language, 'error', '오류')}: {error}", file=sys.stderr)

--- a/src/silobrief/terminal.py
+++ b/src/silobrief/terminal.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from typing import TextIO
+
+
+def supports_color(stream: TextIO) -> bool:
+    if "NO_COLOR" in os.environ or os.environ.get("TERM") == "dumb":
+        return False
+    try:
+        stream.fileno()
+    except (AttributeError, OSError, ValueError):
+        return False
+    return stream.isatty()
+
+
+def styled(value: str, code: str, *, enabled: bool) -> str:
+    if not enabled:
+        return value
+    return f"\033[{code}m{value}\033[0m"

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -275,7 +275,7 @@ class ChatCommandTests(unittest.TestCase):
             destination = project / output
             self.assertEqual(result, 0)
             self.assertEqual(stderr, "")
-            self.assertIn("Symbols in `package/service.py`:", stdout)
+            self.assertIn("Functions and classes in `package/service.py`:", stdout)
             self.assertIn("1. function run", stdout)
             generated = destination.read_text(encoding="utf-8")
             self.assertIn("def run():", generated)

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -133,10 +133,12 @@ class ChatReviewTests(unittest.TestCase):
             self.assertIn(approved, rendered.markdown)
 
         visible = output.getvalue()
+        self.assertIn("[Notice] Your prompt works best when it includes:", visible)
+        self.assertIn("- how you will decide it is complete", visible)
         self.assertIn("src/service.py", visible)
         self.assertIn("src/helper.py", visible)
-        self.assertIn("path=retry", visible)
-        self.assertIn("connections: 1", visible)
+        self.assertIn('file path and user note contain "retry"', visible)
+        self.assertIn("Directly connected items: 1", visible)
         hidden_values = (
             "source-body-canary|internal-real-name|.models.SyncResult|src/second.py|"
             "second-hop-canary|unselected-note-canary|root-id"
@@ -157,14 +159,41 @@ class ChatReviewTests(unittest.TestCase):
         )
 
         visible = output.getvalue()
-        self.assertIn("Related context (not selected):", visible)
-        self.assertIn("r1. src/helper.py", visible)
-        self.assertIn("calls, imports", visible)
+        self.assertIn("Other code connected to your selection (optional):", visible)
+        self.assertIn("[r1] function helper.run", visible)
+        self.assertIn("File: src/helper.py", visible)
+        self.assertIn("the selected code calls this function", visible)
+        self.assertIn("the selected code imports this function", visible)
         self.assertIn("src/service.py", rendered.markdown)
         self.assertNotIn("src/helper.py", rendered.markdown)
         self.assertNotIn("helper.run", rendered.markdown)
         self.assertNotIn("json", rendered.markdown)
         self.assertEqual(disclosure_counts(rendered), (1, 1, 1, 2, 1))
+
+    def test_korean_review_explains_candidates_and_connected_code(self) -> None:
+        output = TtyBuffer()
+
+        review_brief(
+            "retry",
+            source_index(),
+            source_notes(),
+            input_stream=TtyBuffer("y\n1\n\n\nn\nn\nn\nn\nn\n"),
+            output_stream=output,
+            cli_language="ko",
+        )
+
+        visible = output.getvalue()
+        self.assertIn("[주의] 프롬프트에는 다음 내용이 들어가면 좋습니다:", visible)
+        self.assertIn("이 프롬프트로 계속할까요? [y/N]:", visible)
+        self.assertIn("코드 후보:", visible)
+        self.assertIn("[1] 파일(모듈) service", visible)
+        self.assertIn('파일 경로, 사용자 메모에서 "retry" 일치', visible)
+        self.assertIn("관련도: 9점", visible)
+        self.assertIn("함께 확인할 코드 (선택 사항):", visible)
+        self.assertIn("[r1] 함수 helper.run", visible)
+        self.assertIn("선택한 코드가 이 함수를 호출함", visible)
+        self.assertIn("선택한 코드가 이 함수를 불러옴(import)", visible)
+        self.assertNotIn("연관 맥락", visible)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
         rendered = review_brief(
@@ -219,15 +248,16 @@ class ChatReviewTests(unittest.TestCase):
 
         visible = output.getvalue()
         self.assertEqual(rendered, selected_by_id)
-        self.assertIn("Candidates:\n- none", visible)
-        self.assertIn("Symbols in `src/guided.py`:", visible)
+        self.assertIn("Candidates:\n", visible)
+        self.assertIn("No matching code was found.", visible)
+        self.assertIn("Functions and classes in `src/guided.py`:", visible)
         self.assertIn("1. class Service", visible)
         self.assertIn("2. function Service.run", visible)
-        outline = visible.split("Symbols in `src/guided.py`:\n", 1)[1].split(
-            "Select symbol numbers", 1
+        outline = visible.split("Functions and classes in `src/guided.py`:\n", 1)[1].split(
+            "Select function or class numbers", 1
         )[0]
         self.assertNotIn("module guided", outline)
-        self.assertNotIn("Symbols in", node_id_output.getvalue())
+        self.assertNotIn("Functions and classes in", node_id_output.getvalue())
         self.assertIn("class Service", visible)
         self.assertIn("src/guided.py", rendered.markdown)
         self.assertIn("function: Service.run", rendered.markdown)
@@ -289,7 +319,8 @@ class ChatReviewTests(unittest.TestCase):
             output_stream=output,
         )
 
-        self.assertIn("r1. src/guided.py | class Service | contains", output.getvalue())
+        self.assertIn("[r1] class Service", output.getvalue())
+        self.assertIn("the selected code contains this class", output.getvalue())
         self.assertIn("module: guided", rendered.markdown)
         self.assertIn("class: Service", rendered.markdown)
         self.assertNotIn("function: helper", rendered.markdown)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.1\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.2\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -72,8 +72,8 @@ SAFETY_EXPECTATIONS = {
     "README.ko.md": ("제외 경로", "심볼릭 링크", "보안 검사기"),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.0.1", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.0.1", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.0.2", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.0.2", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -161,6 +161,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.2] - 2026-08-17", changelog)
         self.assertIn("## [1.0.1] - 2026-08-12", changelog)
         self.assertIn("## [1.0.0] - 2026-08-11", changelog)
         self.assertIn(f"## [0.6.0] - {V0_6_RELEASE_DATE}", changelog)
@@ -185,8 +186,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.1"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.1")
+        self.assertEqual(pyproject.count('version = "1.0.2"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.2")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -112,7 +112,7 @@ class LanguageCommandTests(unittest.TestCase):
                 stdout = io.StringIO()
                 with contextlib.redirect_stdout(stdout):
                     self.assertEqual(main(["search", "retry request"]), 0)
-                self.assertTrue(stdout.getvalue().startswith("후보:\n"))
+                self.assertTrue(stdout.getvalue().startswith("코드 후보:\n"))
 
                 stdout = io.StringIO()
                 with contextlib.redirect_stdout(stdout), self.assertRaises(SystemExit) as caught:

--- a/tests/test_search_command.py
+++ b/tests/test_search_command.py
@@ -53,9 +53,11 @@ class SearchCommandTests(unittest.TestCase):
 
             output = first_stdout.getvalue()
             self.assertIn("Candidates:\n", output)
-            self.assertIn("package/service.py | function run", output)
-            self.assertIn("symbol=run", output)
-            self.assertIn("import=delivery,urllib3", output)
+            self.assertIn("[1] function run", output)
+            self.assertIn("File: package/service.py", output)
+            self.assertIn('name contains "run"', output)
+            self.assertIn('import contains "delivery, urllib3"', output)
+            self.assertIn("Relevance:", output)
             self.assertNotIn("private-boundary-canary", output)
 
     def test_rejects_empty_prompt(self) -> None:

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import io
+import os
+import unittest
+from unittest import mock
+
+from silobrief.terminal import styled, supports_color
+
+
+class ColorTty(io.StringIO):
+    def fileno(self) -> int:
+        return 1
+
+    def isatty(self) -> bool:
+        return True
+
+
+class TerminalTests(unittest.TestCase):
+    def test_uses_ansi_styles_only_for_an_interactive_terminal(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(supports_color(ColorTty()))
+            self.assertFalse(supports_color(io.StringIO()))
+            self.assertEqual(styled("value", "1;33", enabled=True), "\033[1;33mvalue\033[0m")
+            self.assertEqual(styled("value", "1;33", enabled=False), "value")
+
+    def test_no_color_environment_variable_disables_styles(self) -> None:
+        with mock.patch.dict(os.environ, {"NO_COLOR": "1"}, clear=True):
+            self.assertFalse(supports_color(ColorTty()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 릴리즈

검증을 마친 siloBrief 1.0.2를 `develop`에서 `main`으로 반영합니다.

## 변경 내용

- 프롬프트에 작업 목표, 결과물과 완료 기준을 적으면 좋다는 점을 처음부터 안내합니다.
- 코드 후보를 종류, 이름, 파일, 일치 이유, 관련도와 직접 연결 수로 나눠 보여 줍니다.
- 선택한 코드와 연결된 `rN` 항목이 선택 사항이며 아직 문서에 포함되지 않았음을 설명합니다.
- 내부 관계명을 호출, 참조, import와 포함 관계를 설명하는 문장으로 바꿉니다.
- 한국어와 영어 화면을 함께 정리하고, 대화형 터미널에서만 핵심 값에 색을 표시합니다.
- 패키지 버전과 공개 문서를 1.0.2로 갱신합니다.

## 검증

- PR #165와 #167의 Ubuntu 및 Windows, Python 3.10 및 3.14 CI 통과
- Ruff lint 및 format check 통과
- mypy strict 통과
- unittest 186개 통과, 환경 의존 7개 건너뜀
- wheel 및 sdist 빌드 통과
- 격리 환경에서 wheel 설치와 핵심 CLI smoke test 통과

## 범위

검색 점수, 후보 선정 규칙, 색인 형식과 런타임 의존성은 바꾸지 않습니다.

이 PR은 저장소 규칙에 따라 merge commit으로 병합합니다. 병합 후 `v1.0.2` 태그와 GitHub Release를 만들고 PyPI Trusted Publishing workflow를 실행합니다.

Refs #166