### PR TITLE
fix(review): exclude all nodes selected by file path

### DIFF
--- a/src/silobrief/review.py
+++ b/src/silobrief/review.py
@@ -142,7 +142,11 @@ def review_selection(
     option_by_number = _option_map(options, nodes)
     selected_ids = {_selected_id(number, option_by_number) for number in selected_numbers}
     selected_ids.update(_resolve_selector(selector, nodes, modules) for selector in added)
-    excluded_ids = {_resolve_selector(selector, nodes, modules) for selector in excluded}
+    excluded_ids = {
+        node_id
+        for selector in excluded
+        for node_id in _resolve_excluded_selector(selector, nodes, modules)
+    }
     selected_ids.difference_update(excluded_ids)
     if not selected_ids:
         raise ReviewError("start selection is empty")
@@ -206,6 +210,18 @@ def _resolve_selector(
         return selector
     if selector in modules:
         return modules[selector]
+    raise ReviewError(f"unknown node ID or path selector: {selector}")
+
+
+def _resolve_excluded_selector(
+    selector: str,
+    nodes: dict[str, IndexNode],
+    modules: dict[str, str],
+) -> set[str]:
+    if selector in nodes:
+        return {selector}
+    if selector in modules:
+        return {node.id for node in nodes.values() if node.path == selector}
     raise ReviewError(f"unknown node ID or path selector: {selector}")
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -276,6 +276,31 @@ class ReviewSelectionTests(unittest.TestCase):
         self.assertEqual([item.id for item in result.selected], ["root"])
         self.assertEqual(result.expanded, ())
 
+    def test_file_path_exclusion_removes_every_node_from_that_file(self) -> None:
+        root = node("root", "src/root.py", "function", "root")
+        blocked_module = node("blocked-module", "src/blocked.py", "module", "blocked")
+        blocked_class = node("blocked-class", "src/blocked.py", "class", "Blocked")
+        blocked_function = node("blocked-function", "src/blocked.py", "function", "run")
+        source_index = index(
+            root,
+            blocked_module,
+            blocked_class,
+            blocked_function,
+            edges=(IndexEdge("root", "call", "run", "blocked-function"),),
+        )
+
+        result = review_selection(
+            source_index,
+            candidate_options((ranked(root, 5), ranked(blocked_class, 4))),
+            selected_numbers=(1, 2),
+            added=("src/blocked.py", "blocked-function"),
+            excluded=("src/blocked.py",),
+            fields=FIELDS,
+        )
+
+        self.assertEqual([item.id for item in result.selected], ["root"])
+        self.assertEqual(result.expanded, ())
+
     def test_allows_direct_selection_when_ranked_candidates_are_empty(self) -> None:
         module = node("module", "src/work.py", "module", "work")
         function = node("function", "src/work.py", "function", "run")


### PR DESCRIPTION
## 관련 Issue

Refs #170

## 변경 이유

파일 경로를 제외해도 해당 파일의 모듈 항목만 빠지고 함수와 클래스는 선택 결과나 연관 코드에 남아 있었습니다. 사용자가 파일 전체를 빼려는 의도와 실제 결과가 달랐습니다.

## 변경 내용

- 제외 값이 파일 경로이면 같은 경로의 모듈, 클래스와 함수를 모두 찾습니다.
- 직접 선택된 항목과 연관 코드에서 해당 파일의 항목을 함께 제거합니다.
- 고유 ID를 입력한 경우에는 기존처럼 그 항목만 제외합니다.
- 파일 경로 제외 동작을 확인하는 회귀 테스트를 추가했습니다.

## 검증

```text
python -m unittest discover -s tests -t .
Ran 187 tests: OK (skipped=7)

python -m ruff check src/silobrief/review.py tests/test_review.py
All checks passed!

python -m ruff format --check src/silobrief/review.py tests/test_review.py
2 files already formatted

python -m mypy src tests
Success: no issues found in 56 source files

git diff --check
No errors
```

## 제외 범위와 남은 제한

파일을 추가할 때의 선택 방식과 후보 검색 점수는 바꾸지 않았습니다.