### PR TITLE
fix(ranking): recognize Korean test requests

### DIFF
--- a/src/silobrief/ranking.py
+++ b/src/silobrief/ranking.py
@@ -20,7 +20,7 @@ _MAX_IMPLEMENTATION_CANDIDATES = 7
 _MAX_TEST_CANDIDATES = _MAX_CANDIDATES - _MAX_IMPLEMENTATION_CANDIDATES
 _LEADING_ACTION_BONUS = 8
 _EXACT_MODULE_BONUS = 4
-_TEST_QUERY_TOKENS = frozenset({"test", "tests", "pytest", "unittest"})
+_TEST_QUERY_TOKENS = frozenset({"test", "tests", "pytest", "unittest", "테스트"})
 _WORD_PATTERN = re.compile(r"[^\W_]+", re.UNICODE)
 
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -212,12 +212,15 @@ class LexicalRankingTests(unittest.TestCase):
 
         without_tests = rank_candidates("match behavior", source_index, notes())
         with_tests = rank_candidates("match behavior tests", source_index, notes())
+        with_korean_tests = rank_candidates("match behavior 테스트", source_index, notes())
 
         self.assertEqual(len(without_tests), 7)
         self.assertTrue(all(not item.node.path.startswith("tests/") for item in without_tests))
         self.assertEqual(len(with_tests), 10)
         self.assertTrue(all(not item.node.path.startswith("tests/") for item in with_tests[:7]))
         self.assertTrue(all(item.node.path.startswith("tests/") for item in with_tests[7:]))
+        self.assertEqual(len(with_korean_tests), 10)
+        self.assertTrue(all(item.node.path.startswith("tests/") for item in with_korean_tests[7:]))
 
     def test_ignores_module_and_import_only_matches(self) -> None:
         module = node(


### PR DESCRIPTION
## 관련 Issue

Refs #171

## 변경 이유

테스트 코드가 필요한 요청인지 판단하는 단어가 영어로만 등록돼 있었습니다. 같은 요청을 한국어로 입력하면 일반 구현 후보 7개만 보여 주고 테스트 파일은 제외했습니다.

## 변경 내용

- 테스트 요청을 판단하는 단어에 한국어 `테스트`를 추가했습니다.
- 한국어 요청에서도 구현 후보 7개와 테스트 후보 3개를 함께 보여 주는지 확인합니다.
- 영어 `test`, `tests`, `pytest`, `unittest` 동작은 그대로 유지합니다.

## 검증

```text
python -m unittest discover -s tests -t .
Ran 186 tests: OK (skipped=7)

python -m ruff check src/silobrief/ranking.py tests/test_ranking.py
All checks passed!

python -m ruff format --check src/silobrief/ranking.py tests/test_ranking.py
2 files already formatted

python -m mypy src tests
Success: no issues found in 56 source files

git diff --check
No errors
```

## 제외 범위와 남은 제한

자연어 번역이나 형태소 분석은 추가하지 않았습니다. 기존 단어 기반 검색과 점수 계산 방식도 바꾸지 않았습니다.