### PR TITLE
fix(cli): clarify file-level source selection

### DIFF
--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -377,8 +377,10 @@ def _read_symbol_numbers(
     value = _read_line(
         localized(
             language,
-            "Select function or class numbers (Enter to include the whole file only): ",
-            "함수나 클래스 번호를 선택하세요 (파일 전체만 고르려면 Enter): ",
+            "Select function or class numbers to include their source code "
+            "(press Enter to include file details only, without source code): ",
+            "소스코드를 포함할 함수나 클래스 번호를 선택하세요 "
+            "(소스코드 없이 파일 정보만 포함하려면 Enter): ",
         ),
         input_stream,
         output_stream,

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -177,7 +177,7 @@ class ChatReviewTests(unittest.TestCase):
             "retry",
             source_index(),
             source_notes(),
-            input_stream=TtyBuffer("y\n1\n\n\nn\nn\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n1\nsrc/service.py\n\n\n\nn\nn\nn\nn\nn\n"),
             output_stream=output,
             cli_language="ko",
         )
@@ -193,6 +193,11 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("[r1] 함수 helper.run", visible)
         self.assertIn("선택한 코드가 이 함수를 호출함", visible)
         self.assertIn("선택한 코드가 이 함수를 불러옴(import)", visible)
+        self.assertIn(
+            "소스코드를 포함할 함수나 클래스 번호를 선택하세요 "
+            "(소스코드 없이 파일 정보만 포함하려면 Enter):",
+            visible,
+        )
         self.assertNotIn("연관 맥락", visible)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
@@ -253,6 +258,11 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("Functions and classes in `src/guided.py`:", visible)
         self.assertIn("1. class Service", visible)
         self.assertIn("2. function Service.run", visible)
+        self.assertIn(
+            "Select function or class numbers to include their source code "
+            "(press Enter to include file details only, without source code):",
+            visible,
+        )
         outline = visible.split("Functions and classes in `src/guided.py`:\n", 1)[1].split(
             "Select function or class numbers", 1
         )[0]


### PR DESCRIPTION
## 관련 Issue

Refs #172

## 변경 이유

파일 경로를 고른 뒤 Enter를 누르면 파일 전체가 들어간다는 안내가 나왔지만, 실제 문서에는 파일 정보만 들어가고 소스코드는 포함되지 않았습니다. 처음 사용하는 사람은 어떤 내용이 문서에 들어가는지 잘못 이해할 수 있었습니다.

## 변경 내용

- 영어 안내에 Enter를 누르면 파일 정보만 포함되고 소스코드는 제외된다고 적었습니다.
- 한국어 안내도 같은 의미로 맞췄습니다.
- 실제 검토 화면에서 두 문구가 표시되는지 회귀 테스트로 확인합니다.

## 검증

```text
python -m unittest discover -s tests -t .
Ran 186 tests: OK (skipped=7)

python -m ruff check src/silobrief/chat_review.py tests/test_chat_review.py
All checks passed!

python -m ruff format --check src/silobrief/chat_review.py tests/test_chat_review.py
2 files already formatted

python -m mypy src tests
Success: no issues found in 56 source files

git diff --check
No errors
```

## 제외 범위와 남은 제한

파일 단위 선택의 동작과 생성 문서 형식은 바꾸지 않았습니다. 이번 수정은 한영 안내 문구와 회귀 테스트만 다룹니다.