### PR TITLE
fix(index): separate definition headers from bodies

### DIFF
--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -202,11 +202,26 @@ class _StructureVisitor(ast.NodeVisitor):
                 end_line,
             )
         )
+        self._visit_definition_header(node)
         self._contexts.append(qualified_name)
         try:
-            self.generic_visit(node)
+            for statement in node.body:
+                self.visit(statement)
         finally:
             self._contexts.pop()
+
+    def _visit_definition_header(
+        self, node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for field, value in ast.iter_fields(node):
+            if field == "body":
+                continue
+            if isinstance(value, ast.AST):
+                self.visit(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self.visit(item)
 
     @property
     def _context(self) -> str | None:

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -70,7 +70,7 @@ TASKS = (
         "must keep current output. When both prefix and separator are non-empty, place the "
         "separator between prefix and reference. Preserve uppercase behavior. Return a minimal "
         "patch and focused unittests.",
-        "y\n1 2\n\n\ny\ny\ny\ny\ny\ny\ny\nWRITE\n",
+        "y\n1\nsrc/parcel_lab/labels.py\n1 2\n\n\ny\ny\ny\ny\ny\ny\ny\nWRITE\n",
     ),
     Task(
         "T03-REMOVE",

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -21,7 +21,7 @@ from silobrief.cli import main
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
-INDEX_SHA256 = "8809c96fed66de0d08d600c8797943269c12ae3b2bb3216325f533fff11b34ad"
+INDEX_SHA256 = "ed42e65a4a650fbe93577193fb7a4c8f5129a8b210939f5071cc088183126541"
 BRIEF_SHA256 = "065e297861d5839a20a06607bf282a5bb19224c6ced007b75893fe47d7a32533"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -118,6 +118,45 @@ class PythonStructureTests(unittest.TestCase):
             ),
         )
 
+    def test_attributes_definition_header_calls_to_the_enclosing_context(self) -> None:
+        source = source_file(
+            "definitions.py",
+            (
+                b"def outer():\n"
+                b"    @decorate(factory())\n"
+                b"    def inner(value: Value = default()) -> result_type():\n"
+                b"        return body()\n"
+                b"    @class_decorator(class_factory())\n"
+                b"    class Child(base_factory(), metaclass=meta_factory()):\n"
+                b"        class_body()\n"
+                b"    async def async_inner(value=async_default()):\n"
+                b"        return async_body()\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        contexts = {call.target: call.context for call in module.calls}
+        self.assertEqual(
+            contexts,
+            {
+                "decorate": "outer",
+                "factory": "outer",
+                "default": "outer",
+                "result_type": "outer",
+                "body": "outer.inner",
+                "class_decorator": "outer",
+                "class_factory": "outer",
+                "base_factory": "outer",
+                "meta_factory": "outer",
+                "class_body": "outer.Child",
+                "async_default": "outer",
+                "async_body": "outer.async_inner",
+            },
+        )
+        self.assertEqual(len(module.calls), len(contexts))
+        self.assertIn(SymbolUse("outer", "Value", 3, 22), module.references)
+
     def test_omits_source_text_comments_docstrings_and_string_literals(self) -> None:
         source = source_file(
             "canaries.py",


### PR DESCRIPTION
## 관련 Issue

Refs #173

## 변경 이유

함수와 클래스를 분석할 때 decorator, 기본 인자, annotation과 상속 표현식까지 본문 안에서 실행된 관계로 기록했습니다. 이 관계는 후보 점수와 연관 코드 제안에 쓰이므로 실제 코드 구조와 다른 결과를 만들 수 있었습니다.

## 변경 내용

- 함수와 클래스의 선언부를 바깥 문맥에서 먼저 분석합니다.
- 정의 내부 문맥에서는 본문만 분석합니다.
- 동기 함수, 비동기 함수, 중첩 함수, decorator, 기본값, annotation과 클래스 상속 표현식을 회귀 테스트로 확인합니다.
- 관계 색인 변경에 맞춰 공개 데모 해시를 갱신했습니다.
- 모델 검증 자료는 파일 경로와 심볼을 직접 선택하게 바꿔 기존 결과물을 유지했습니다.

## 검증

```text
python -m unittest discover -s tests -t .
Ran 187 tests: OK (skipped=7)

python -m ruff check src tests
All checks passed!

python -m ruff format --check src tests
56 files already formatted

python -m mypy src tests
Success: no issues found in 56 source files

git diff --check
No errors
```

## 제외 범위와 남은 제한

동적 import와 런타임 호출을 완전히 해석하지 않습니다. 색인 스키마와 관계 종류도 이번 수정에서 바꾸지 않았습니다.