### PR TITLE
docs(release): prepare v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-18
+
+### Fixed
+
+- Exclude every indexed item from a file when the user leaves that file out during review (#170).
+- Recognize Korean test requests when deciding whether to include test-file candidates (#171).
+- Clarify that choosing a file path opens its outline and only explicitly selected definitions add
+  source code to the brief (#172).
+- Attribute decorators, base classes, and default-value expressions to the enclosing scope instead
+  of treating them as calls from the function or class body (#173).
+- Reject Windows reparse points while validating project sources, local state, and output paths.
+
 ## [1.0.2] - 2026-08-17
 
 ### Changed

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="릴리스 v1.0.2"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="릴리스 v1.0.3"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.2
+siloBrief 1.0.3
 ```
 
 ### 실습 예제
@@ -191,7 +191,7 @@ siloBrief는 등록된 제외 경로를 읽지 않고, 색인을 만들 때 심�
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.2이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.0.3이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="Release v1.0.2"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="Release v1.0.3"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.2
+siloBrief 1.0.3
 ```
 
 ### Practice project
@@ -192,7 +192,7 @@ organization's disclosure rules before sharing it.
 
 ## Validation status
 
-The latest public release is v1.0.2 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.0.3 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.2"
+version = "1.0.3"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.2\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.3\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -72,8 +72,8 @@ SAFETY_EXPECTATIONS = {
     "README.ko.md": ("제외 경로", "심볼릭 링크", "보안 검사기"),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.0.2", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.0.2", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.0.3", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.0.3", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -161,6 +161,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.3] - 2026-08-18", changelog)
         self.assertIn("## [1.0.2] - 2026-08-17", changelog)
         self.assertIn("## [1.0.1] - 2026-08-12", changelog)
         self.assertIn("## [1.0.0] - 2026-08-11", changelog)
@@ -186,8 +187,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.2"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.2")
+        self.assertEqual(pyproject.count('version = "1.0.3"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.3")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())


### PR DESCRIPTION
## 관련 Issue

- Refs #178

## 변경 이유

`develop`에서 검증한 수정 사항을 v1.0.3 배포본으로 확정하려면 패키지 버전과 공개 문서의 버전 표기를 같은 값으로 맞춰야 합니다.

## 변경 내용

- `pyproject.toml`의 패키지 버전을 1.0.3으로 갱신
- 영어와 한국어 README의 릴리즈 배지, 설치 확인 예시, 최신 버전 안내를 갱신
- 2026-08-18 v1.0.3 변경 기록을 CHANGELOG에 추가
- 버전과 릴리즈 문서를 검사하는 테스트 기대값을 갱신

## 검증

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `python -m unittest discover -s tests` (194 tests passed, 7 skipped)
- wheel과 sdist 빌드
- 격리 환경에 wheel 재설치 후 전체 테스트 통과
- 설치본 `sb --version`에서 `siloBrief 1.0.3` 확인

## 제외 범위

- 새 명령이나 외부 런타임 의존성 추가
- 색인과 로컬 상태 파일 형식 변경
- 이번 릴리즈 범위를 벗어난 기능 수정