### PR TITLE
release: siloBrief v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-18
+
+### Fixed
+
+- Exclude every indexed item from a file when the user leaves that file out during review (#170).
+- Recognize Korean test requests when deciding whether to include test-file candidates (#171).
+- Clarify that choosing a file path opens its outline and only explicitly selected definitions add
+  source code to the brief (#172).
+- Attribute decorators, base classes, and default-value expressions to the enclosing scope instead
+  of treating them as calls from the function or class body (#173).
+- Reject Windows reparse points while validating project sources, local state, and output paths.
+
 ## [1.0.2] - 2026-08-17
 
 ### Changed

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="릴리스 v1.0.2"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="릴리스 v1.0.3"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.2
+siloBrief 1.0.3
 ```
 
 ### 실습 예제
@@ -191,7 +191,7 @@ siloBrief는 등록된 제외 경로를 읽지 않고, 색인을 만들 때 심�
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.2이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.0.3이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.2"><img src="https://img.shields.io/badge/release-v1.0.2-4f46e5" alt="Release v1.0.2"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="Release v1.0.3"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.2
+siloBrief 1.0.3
 ```
 
 ### Practice project
@@ -192,7 +192,7 @@ organization's disclosure rules before sharing it.
 
 ## Validation status
 
-The latest public release is v1.0.2 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.0.3 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.2"
+version = "1.0.3"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/silobrief/boundaries.py
+++ b/src/silobrief/boundaries.py
@@ -5,6 +5,7 @@ import stat
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
+from silobrief.path_safety import has_link_like_component, is_link_like
 from silobrief.state import (
     STATE_DIRECTORY,
     BoundaryData,
@@ -123,8 +124,12 @@ def _boundary_path(root: Path, start: Path, path_text: str) -> str:
         raise SetupError("boundary path must not contain ..")
 
     try:
+        if has_link_like_component(start):
+            raise SetupError("current directory must not contain a symbolic link or reparse point")
         current = start.resolve(strict=True)
         current.relative_to(root)
+    except SetupError:
+        raise
     except (OSError, ValueError) as error:
         raise SetupError("current directory is outside the project root") from error
 
@@ -132,8 +137,8 @@ def _boundary_path(root: Path, start: Path, path_text: str) -> str:
     candidate = current
     for part in parts:
         candidate /= part
-        if candidate.is_symlink():
-            raise SetupError("boundary path must not contain symbolic links")
+        if is_link_like(candidate):
+            raise SetupError("boundary path must not contain symbolic links or reparse points")
     if not candidate.is_file() and not candidate.is_dir():
         raise SetupError("boundary path must be an existing file or directory")
 

--- a/src/silobrief/chat_review.py
+++ b/src/silobrief/chat_review.py
@@ -377,8 +377,10 @@ def _read_symbol_numbers(
     value = _read_line(
         localized(
             language,
-            "Select function or class numbers (Enter to include the whole file only): ",
-            "함수나 클래스 번호를 선택하세요 (파일 전체만 고르려면 Enter): ",
+            "Select function or class numbers to include their source code "
+            "(press Enter to include file details only, without source code): ",
+            "소스코드를 포함할 함수나 클래스 번호를 선택하세요 "
+            "(소스코드 없이 파일 정보만 포함하려면 Enter): ",
         ),
         input_stream,
         output_stream,

--- a/src/silobrief/example_project.py
+++ b/src/silobrief/example_project.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from silobrief.path_safety import has_link_like_component
+
 
 class ExampleProjectError(Exception):
     pass
@@ -218,8 +220,8 @@ class ChooseReferenceTests(unittest.TestCase):
 
 
 def create_example_project(target: Path) -> int:
-    if target.is_symlink():
-        raise ExampleProjectError("example path must not be a symbolic link")
+    if has_link_like_component(target):
+        raise ExampleProjectError("example path must not contain a symbolic link or reparse point")
     if target.exists():
         if not target.is_dir():
             raise ExampleProjectError("example path must be a directory")

--- a/src/silobrief/notes.py
+++ b/src/silobrief/notes.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
+from silobrief.path_safety import has_link_like_component, is_link_like
 from silobrief.state import (
     ConfigData,
     HumanNoteData,
@@ -51,16 +52,20 @@ def _note_path(root: Path, start: Path, path_text: str) -> str:
         raise SetupError("note path must not contain ..")
 
     try:
+        if has_link_like_component(start):
+            raise SetupError("current directory must not contain a symbolic link or reparse point")
         current = start.resolve(strict=True)
         current.relative_to(root)
+    except SetupError:
+        raise
     except (OSError, ValueError) as error:
         raise SetupError("current directory is outside the project root") from error
 
     candidate = current
     for part in (part for part in normalized.parts if part not in ("", ".")):
         candidate /= part
-        if candidate.is_symlink():
-            raise SetupError("note path must not contain symbolic links")
+        if is_link_like(candidate):
+            raise SetupError("note path must not contain symbolic links or reparse points")
     if not candidate.is_file() and not candidate.is_dir():
         raise SetupError("note path must be an existing file or directory")
 

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TextIO
 
 from silobrief.language import Language, localized
+from silobrief.path_safety import has_link_like_component, is_link_like
 from silobrief.renderer import RenderedBrief
 from silobrief.sources import SourceCollectionError, SourceSnapshot, snapshot_sources
 from silobrief.state import STATE_DIRECTORY, SetupError, load_config
@@ -118,8 +119,8 @@ def _output_path(root: Path, start: Path, output_text: str) -> Path:
 
     candidate = requested if requested.is_absolute() else resolved_start / requested
     candidate = candidate.absolute()
-    if candidate.is_symlink():
-        raise OutputBlockedError("output path must not be a symbolic link")
+    if is_link_like(candidate):
+        raise OutputBlockedError("output path must not be a symbolic link or reparse point")
     if candidate.exists():
         raise OutputBlockedError("output path already exists")
 
@@ -128,8 +129,8 @@ def _output_path(root: Path, start: Path, output_text: str) -> Path:
 
 
 def _available_path(destination: Path, root: Path) -> Path:
-    if destination.is_symlink():
-        raise OutputBlockedError("output path must not be a symbolic link")
+    if is_link_like(destination):
+        raise OutputBlockedError("output path must not be a symbolic link or reparse point")
     if destination.exists():
         raise OutputBlockedError("output path already exists")
     _require_allowed_location(destination, root)
@@ -142,7 +143,7 @@ def _uses_foreign_windows_path(path: str, *, platform: str) -> bool:
 
 
 def _real_directory(path: Path, label: str) -> Path:
-    if path.is_symlink() or not path.is_dir():
+    if has_link_like_component(path) or not path.is_dir():
         raise OutputBlockedError(f"{label} must be a real directory")
     try:
         return path.resolve(strict=True)
@@ -154,8 +155,8 @@ def _real_parent(parent: Path) -> Path:
     current = Path(parent.anchor)
     for part in parent.parts[1:]:
         current /= part
-        if current.is_symlink():
-            raise OutputBlockedError("output path contains a symbolic link")
+        if is_link_like(current):
+            raise OutputBlockedError("output path contains a symbolic link or reparse point")
     if not parent.is_dir():
         raise OutputBlockedError("output parent must be an existing directory")
     try:
@@ -171,7 +172,7 @@ def _require_allowed_location(destination: Path, root: Path) -> None:
         return
 
     exports = root / STATE_DIRECTORY / "exports"
-    if exports.is_symlink() or not exports.is_dir():
+    if is_link_like(exports) or not exports.is_dir():
         raise OutputBlockedError("project exports must be a real directory")
     try:
         resolved_exports = exports.resolve(strict=True)

--- a/src/silobrief/path_safety.py
+++ b/src/silobrief/path_safety.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+_REPARSE_POINT = int(getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def is_link_like(path: Path) -> bool:
+    try:
+        return is_link_like_stat(path.stat(follow_symlinks=False))
+    except OSError:
+        return False
+
+
+def is_link_like_stat(metadata: os.stat_result) -> bool:
+    attributes = int(getattr(metadata, "st_file_attributes", 0))
+    return stat.S_ISLNK(metadata.st_mode) or bool(attributes & _REPARSE_POINT)
+
+
+def has_link_like_component(path: Path) -> bool:
+    absolute = path.absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        if is_link_like(current):
+            return True
+    return False

--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -202,11 +202,26 @@ class _StructureVisitor(ast.NodeVisitor):
                 end_line,
             )
         )
+        self._visit_definition_header(node)
         self._contexts.append(qualified_name)
         try:
-            self.generic_visit(node)
+            for statement in node.body:
+                self.visit(statement)
         finally:
             self._contexts.pop()
+
+    def _visit_definition_header(
+        self, node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for field, value in ast.iter_fields(node):
+            if field == "body":
+                continue
+            if isinstance(value, ast.AST):
+                self.visit(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self.visit(item)
 
     @property
     def _context(self) -> str | None:

--- a/src/silobrief/ranking.py
+++ b/src/silobrief/ranking.py
@@ -20,7 +20,7 @@ _MAX_IMPLEMENTATION_CANDIDATES = 7
 _MAX_TEST_CANDIDATES = _MAX_CANDIDATES - _MAX_IMPLEMENTATION_CANDIDATES
 _LEADING_ACTION_BONUS = 8
 _EXACT_MODULE_BONUS = 4
-_TEST_QUERY_TOKENS = frozenset({"test", "tests", "pytest", "unittest"})
+_TEST_QUERY_TOKENS = frozenset({"test", "tests", "pytest", "unittest", "테스트"})
 _WORD_PATTERN = re.compile(r"[^\W_]+", re.UNICODE)
 
 

--- a/src/silobrief/review.py
+++ b/src/silobrief/review.py
@@ -142,7 +142,11 @@ def review_selection(
     option_by_number = _option_map(options, nodes)
     selected_ids = {_selected_id(number, option_by_number) for number in selected_numbers}
     selected_ids.update(_resolve_selector(selector, nodes, modules) for selector in added)
-    excluded_ids = {_resolve_selector(selector, nodes, modules) for selector in excluded}
+    excluded_ids = {
+        node_id
+        for selector in excluded
+        for node_id in _resolve_excluded_selector(selector, nodes, modules)
+    }
     selected_ids.difference_update(excluded_ids)
     if not selected_ids:
         raise ReviewError("start selection is empty")
@@ -206,6 +210,18 @@ def _resolve_selector(
         return selector
     if selector in modules:
         return modules[selector]
+    raise ReviewError(f"unknown node ID or path selector: {selector}")
+
+
+def _resolve_excluded_selector(
+    selector: str,
+    nodes: dict[str, IndexNode],
+    modules: dict[str, str],
+) -> set[str]:
+    if selector in nodes:
+        return {selector}
+    if selector in modules:
+        return {node.id for node in nodes.values() if node.path == selector}
     raise ReviewError(f"unknown node ID or path selector: {selector}")
 
 

--- a/src/silobrief/sources.py
+++ b/src/silobrief/sources.py
@@ -6,6 +6,10 @@ import stat
 from dataclasses import dataclass
 from pathlib import Path
 
+from silobrief.path_safety import (
+    has_link_like_component,
+    is_link_like_stat,
+)
 from silobrief.state import ConfigData
 
 _DIGEST_DOMAIN = b"silobrief-source-snapshot-v1\0"
@@ -88,7 +92,7 @@ def compare_snapshots(before: SourceSnapshot, after: SourceSnapshot) -> SourceCh
 
 
 def _validated_root(root: Path) -> Path:
-    if root.is_symlink() or not root.is_dir():
+    if has_link_like_component(root) or not root.is_dir():
         raise SourceCollectionError("project root must be a real directory")
     try:
         return root.resolve(strict=True)
@@ -114,8 +118,10 @@ def _walk_sources(
         raise SourceCollectionError(
             f"cannot inspect source directory {label}: {_error_reason(error)}"
         ) from error
-    if stat.S_ISLNK(metadata.st_mode):
-        warnings.append(SourceWarning(path=relative_directory, reason="symbolic link skipped"))
+    if is_link_like_stat(metadata):
+        warnings.append(
+            SourceWarning(path=relative_directory, reason=_link_warning_reason(metadata))
+        )
         return
     if not stat.S_ISDIR(metadata.st_mode):
         label = relative_directory or "."
@@ -135,10 +141,13 @@ def _walk_sources(
         if _is_excluded(relative_path, entry.name, default_excludes, boundaries):
             continue
         try:
-            if entry.is_symlink():
-                warnings.append(SourceWarning(path=relative_path, reason="symbolic link skipped"))
+            metadata = entry.stat(follow_symlinks=False)
+            if is_link_like_stat(metadata):
+                warnings.append(
+                    SourceWarning(path=relative_path, reason=_link_warning_reason(metadata))
+                )
                 continue
-            if entry.is_dir(follow_symlinks=False):
+            if stat.S_ISDIR(metadata.st_mode):
                 _walk_sources(
                     Path(entry.path),
                     relative_path,
@@ -148,7 +157,7 @@ def _walk_sources(
                     warnings=warnings,
                 )
                 continue
-            if relative_path.endswith(".py") and entry.is_file(follow_symlinks=False):
+            if relative_path.endswith(".py") and stat.S_ISREG(metadata.st_mode):
                 files.append(_read_regular_source(Path(entry.path), relative_path))
         except OSError as error:
             raise SourceCollectionError(
@@ -173,7 +182,7 @@ def _is_excluded(
 def _read_regular_source(path: Path, relative_path: str) -> SourceFile:
     try:
         before = path.stat(follow_symlinks=False)
-        if not stat.S_ISREG(before.st_mode):
+        if is_link_like_stat(before) or not stat.S_ISREG(before.st_mode):
             raise SourceCollectionError(f"source entry changed before read: {relative_path}")
         with path.open("rb") as stream:
             content = stream.read()
@@ -199,11 +208,17 @@ def _same_file_state(left: os.stat_result, right: os.stat_result) -> bool:
     return (
         stat.S_ISREG(left.st_mode)
         and stat.S_ISREG(right.st_mode)
+        and not is_link_like_stat(left)
+        and not is_link_like_stat(right)
         and left.st_dev == right.st_dev
         and left.st_ino == right.st_ino
         and left.st_size == right.st_size
         and left.st_mtime_ns == right.st_mtime_ns
     )
+
+
+def _link_warning_reason(metadata: os.stat_result) -> str:
+    return "symbolic link skipped" if stat.S_ISLNK(metadata.st_mode) else "reparse point skipped"
 
 
 def _snapshot_digest(files: tuple[SourceFile, ...]) -> str:

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -13,6 +13,7 @@ from silobrief.language import (
     default_language_settings,
     parse_language_settings,
 )
+from silobrief.path_safety import has_link_like_component, is_link_like
 
 STATE_DIRECTORY = ".silobrief"
 _BOUNDARY_ALIAS_PATTERN = re.compile(r"[a-z0-9-]{1,40}")
@@ -63,7 +64,7 @@ def setup_project(project: Path) -> bool:
     root = _project_root(project)
     state = root / STATE_DIRECTORY
 
-    if state.exists() or state.is_symlink():
+    if state.exists() or is_link_like(state):
         _validate_state(state)
         return False
 
@@ -88,14 +89,15 @@ def setup_project(project: Path) -> bool:
         _write_json(state / "notes.json", NotesData(notes=[], notes_version=1))
         _write_json(state / "language.json", default_language_settings())
     except OSError as error:
-        shutil.rmtree(state, ignore_errors=True)
+        if not is_link_like(state):
+            shutil.rmtree(state, ignore_errors=True)
         raise SetupError(f"cannot initialize {STATE_DIRECTORY}: {error}") from error
     return True
 
 
 def _project_root(project: Path) -> Path:
-    if project.is_symlink():
-        raise SetupError("project root must not be a symbolic link")
+    if has_link_like_component(project):
+        raise SetupError("project root must not contain a symbolic link or reparse point")
     if not project.is_dir():
         raise SetupError("project root must be an existing directory")
 
@@ -106,6 +108,8 @@ def _project_root(project: Path) -> Path:
 
 
 def find_project_root(start: Path) -> Path:
+    if has_link_like_component(start):
+        raise SetupError("current directory must not contain a symbolic link or reparse point")
     if not start.is_dir():
         raise SetupError("command must run from an existing directory")
     try:
@@ -115,7 +119,7 @@ def find_project_root(start: Path) -> Path:
 
     for candidate in (current, *current.parents):
         state = candidate / STATE_DIRECTORY
-        if state.exists() or state.is_symlink():
+        if state.exists() or is_link_like(state):
             _validate_state(state)
             return candidate
     raise SetupError(f"cannot find {STATE_DIRECTORY}; run sb setup first")
@@ -139,7 +143,7 @@ def save_notes(root: Path, notes: NotesData) -> None:
 
 def load_language_settings(root: Path) -> LanguageSettings:
     path = root / STATE_DIRECTORY / "language.json"
-    if not path.exists() and not path.is_symlink():
+    if not path.exists() and not is_link_like(path):
         return default_language_settings()
     try:
         return parse_language_settings(_read_object(path))
@@ -161,7 +165,7 @@ def save_index(root: Path, content: bytes) -> None:
 
 def mark_index_stale(root: Path) -> None:
     index = root / STATE_DIRECTORY / "index.json"
-    if not index.exists() and not index.is_symlink():
+    if not index.exists() and not is_link_like(index):
         return
     data = _read_object(index)
     if data.get("stale") is True:
@@ -216,7 +220,7 @@ def _write_bytes_atomic(path: Path, content: bytes) -> None:
 
 
 def _validate_state(state: Path) -> ConfigData:
-    if state.is_symlink() or not state.is_dir():
+    if is_link_like(state) or not state.is_dir():
         raise SetupError(f"{STATE_DIRECTORY} must be a real directory")
 
     config = _parse_config(_read_object(state / "config.json"))
@@ -224,18 +228,18 @@ def _validate_state(state: Path) -> ConfigData:
     _parse_notes(_read_object(state / "notes.json"))
 
     language = state / "language.json"
-    if language.exists() or language.is_symlink():
+    if language.exists() or is_link_like(language):
         try:
             parse_language_settings(_read_object(language))
         except ValueError as error:
             raise SetupError(str(error)) from error
 
     exports = state / "exports"
-    if exports.is_symlink() or not exports.is_dir():
+    if is_link_like(exports) or not exports.is_dir():
         raise SetupError("exports must be a real directory")
 
     index = state / "index.json"
-    if index.exists() or index.is_symlink():
+    if index.exists() or is_link_like(index):
         try:
             index_data = _read_object(index)
         except SetupError as error:
@@ -351,7 +355,7 @@ def _is_version_one(value: object) -> bool:
 
 
 def _read_object(path: Path) -> dict[str, object]:
-    if path.is_symlink() or not path.is_file():
+    if is_link_like(path) or not path.is_file():
         raise SetupError(f"{path.name} must be a real file")
 
     try:

--- a/src/silobrief/stored_index.py
+++ b/src/silobrief/stored_index.py
@@ -17,6 +17,7 @@ from silobrief.index import (
     render_index_json,
     stable_node_id,
 )
+from silobrief.path_safety import is_link_like
 from silobrief.state import STATE_DIRECTORY, is_valid_boundary_alias
 
 _DIGEST = re.compile(r"[0-9a-f]{64}")
@@ -31,7 +32,7 @@ class StoredIndexError(ValueError):
 
 def load_stored_index(root: Path) -> IndexData:
     path = root / STATE_DIRECTORY / "index.json"
-    if path.is_symlink() or not path.is_file():
+    if is_link_like(path) or not path.is_file():
         raise StoredIndexError("index.json must be a real file; run sb init")
     try:
         content = path.read_bytes()

--- a/tests/test_chat_review.py
+++ b/tests/test_chat_review.py
@@ -177,7 +177,7 @@ class ChatReviewTests(unittest.TestCase):
             "retry",
             source_index(),
             source_notes(),
-            input_stream=TtyBuffer("y\n1\n\n\nn\nn\nn\nn\nn\n"),
+            input_stream=TtyBuffer("y\n1\nsrc/service.py\n\n\n\nn\nn\nn\nn\nn\n"),
             output_stream=output,
             cli_language="ko",
         )
@@ -193,6 +193,11 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("[r1] 함수 helper.run", visible)
         self.assertIn("선택한 코드가 이 함수를 호출함", visible)
         self.assertIn("선택한 코드가 이 함수를 불러옴(import)", visible)
+        self.assertIn(
+            "소스코드를 포함할 함수나 클래스 번호를 선택하세요 "
+            "(소스코드 없이 파일 정보만 포함하려면 Enter):",
+            visible,
+        )
         self.assertNotIn("연관 맥락", visible)
 
     def test_allows_every_disclosure_field_to_be_declined(self) -> None:
@@ -253,6 +258,11 @@ class ChatReviewTests(unittest.TestCase):
         self.assertIn("Functions and classes in `src/guided.py`:", visible)
         self.assertIn("1. class Service", visible)
         self.assertIn("2. function Service.run", visible)
+        self.assertIn(
+            "Select function or class numbers to include their source code "
+            "(press Enter to include file details only, without source code):",
+            visible,
+        )
         outline = visible.split("Functions and classes in `src/guided.py`:\n", 1)[1].split(
             "Select function or class numbers", 1
         )[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.2\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.3\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -72,8 +72,8 @@ SAFETY_EXPECTATIONS = {
     "README.ko.md": ("제외 경로", "심볼릭 링크", "보안 검사기"),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.0.2", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.0.2", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.0.3", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.0.3", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -161,6 +161,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.3] - 2026-08-18", changelog)
         self.assertIn("## [1.0.2] - 2026-08-17", changelog)
         self.assertIn("## [1.0.1] - 2026-08-12", changelog)
         self.assertIn("## [1.0.0] - 2026-08-11", changelog)
@@ -186,8 +187,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.2"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.2")
+        self.assertEqual(pyproject.count('version = "1.0.3"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.3")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest import mock
 
 from silobrief.cli import main
+from tests.windows_junctions import directory_junction
 
 
 class TtyBuffer(io.StringIO):
@@ -209,6 +210,19 @@ class ExampleCommandTests(unittest.TestCase):
             message = self.assert_example_error(link)
 
             self.assertIn("symbolic link", message)
+            self.assertEqual(list(target.iterdir()), [])
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_rejects_a_directory_junction_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            target.mkdir()
+
+            with directory_junction(root / "practice", target) as junction:
+                message = self.assert_example_error(junction)
+
+            self.assertIn("reparse point", message)
             self.assertEqual(list(target.iterdir()), [])
 
     def test_generation_does_not_change_the_working_directory(self) -> None:

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 from silobrief.cli import main
 from silobrief.state import SetupError
+from tests.windows_junctions import directory_junction
 
 
 @contextlib.contextmanager
@@ -318,6 +319,21 @@ class IgnoreCommandTests(unittest.TestCase):
                     with self.subTest(path=path_text):
                         self.assert_ignore_error([path_text, "--as", "Must fail"])
                         self.assertEqual(state_snapshot(project), before)
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_ignore_rejects_a_directory_junction_component(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "project"
+            actual = project / "actual"
+            actual.mkdir(parents=True)
+            (actual / "private.py").write_text("pass\n", encoding="utf-8")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            before = state_snapshot(project)
+
+            with directory_junction(project / "linked", actual), working_directory(project):
+                self.assert_ignore_error(["linked/private.py", "--as", "Must fail"])
+
+            self.assertEqual(state_snapshot(project), before)
 
     def test_ignore_rejects_invalid_stored_boundary_schema(self) -> None:
         invalid_boundaries = [

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -70,7 +70,7 @@ TASKS = (
         "must keep current output. When both prefix and separator are non-empty, place the "
         "separator between prefix and reference. Preserve uppercase behavior. Return a minimal "
         "patch and focused unittests.",
-        "y\n1 2\n\n\ny\ny\ny\ny\ny\ny\ny\nWRITE\n",
+        "y\n1\nsrc/parcel_lab/labels.py\n1 2\n\n\ny\ny\ny\ny\ny\ny\ny\nWRITE\n",
     ),
     Task(
         "T03-REMOVE",

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 from silobrief.cli import main
 from silobrief.state import SetupError
+from tests.windows_junctions import directory_junction
 
 
 @contextlib.contextmanager
@@ -175,6 +176,22 @@ class HumanNotesTests(unittest.TestCase):
                     with self.subTest(path=path_text):
                         self.assert_log_error([path_text, "--comment", "Must fail"])
                         self.assertEqual(notes.read_bytes(), before)
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_log_rejects_a_directory_junction_component(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "project"
+            actual = project / "actual"
+            actual.mkdir(parents=True)
+            (actual / "service.py").write_text("pass\n", encoding="utf-8")
+            self.assertEqual(main(["setup", str(project)]), 0)
+            notes = project / ".silobrief" / "notes.json"
+            before = notes.read_bytes()
+
+            with directory_junction(project / "linked", actual), working_directory(project):
+                self.assert_log_error(["linked/service.py", "--comment", "Must fail"])
+
+            self.assertEqual(notes.read_bytes(), before)
 
     def test_state_rejects_invalid_note_entries(self) -> None:
         invalid_notes: list[object] = [

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,6 +17,7 @@ from silobrief.renderer import BriefInput, RenderedBrief, render_brief
 from silobrief.source_review import ApprovedSourceExcerpt
 from silobrief.sources import snapshot_sources
 from silobrief.state import load_config, setup_project
+from tests.windows_junctions import directory_junction
 
 
 class TtyBuffer(io.StringIO):
@@ -326,6 +328,27 @@ class ApprovedOutputTests(unittest.TestCase):
                             output_stream=TtyBuffer(),
                         )
             self.assertEqual(target.read_text(encoding="utf-8"), "target content")
+            self.assertFalse((outside / "result.md").exists())
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_rejects_a_junction_in_the_output_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = project_in(directory)
+            exports = project / ".silobrief" / "exports"
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+
+            with directory_junction(exports / "linked-parent", outside):
+                with self.assertRaisesRegex(OutputBlockedError, "reparse point"):
+                    approve_and_write(
+                        project,
+                        ".silobrief/exports/linked-parent/result.md",
+                        rendered_brief(),
+                        start=project,
+                        input_stream=TtyBuffer("WRITE\n"),
+                        output_stream=TtyBuffer(),
+                    )
+
             self.assertFalse((outside / "result.md").exists())
 
 

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -21,7 +21,7 @@ from silobrief.cli import main
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
-INDEX_SHA256 = "8809c96fed66de0d08d600c8797943269c12ae3b2bb3216325f533fff11b34ad"
+INDEX_SHA256 = "ed42e65a4a650fbe93577193fb7a4c8f5129a8b210939f5071cc088183126541"
 BRIEF_SHA256 = "065e297861d5839a20a06607bf282a5bb19224c6ced007b75893fe47d7a32533"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -118,6 +118,45 @@ class PythonStructureTests(unittest.TestCase):
             ),
         )
 
+    def test_attributes_definition_header_calls_to_the_enclosing_context(self) -> None:
+        source = source_file(
+            "definitions.py",
+            (
+                b"def outer():\n"
+                b"    @decorate(factory())\n"
+                b"    def inner(value: Value = default()) -> result_type():\n"
+                b"        return body()\n"
+                b"    @class_decorator(class_factory())\n"
+                b"    class Child(base_factory(), metaclass=meta_factory()):\n"
+                b"        class_body()\n"
+                b"    async def async_inner(value=async_default()):\n"
+                b"        return async_body()\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        contexts = {call.target: call.context for call in module.calls}
+        self.assertEqual(
+            contexts,
+            {
+                "decorate": "outer",
+                "factory": "outer",
+                "default": "outer",
+                "result_type": "outer",
+                "body": "outer.inner",
+                "class_decorator": "outer",
+                "class_factory": "outer",
+                "base_factory": "outer",
+                "meta_factory": "outer",
+                "class_body": "outer.Child",
+                "async_default": "outer",
+                "async_body": "outer.async_inner",
+            },
+        )
+        self.assertEqual(len(module.calls), len(contexts))
+        self.assertIn(SymbolUse("outer", "Value", 3, 22), module.references)
+
     def test_omits_source_text_comments_docstrings_and_string_literals(self) -> None:
         source = source_file(
             "canaries.py",

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -212,12 +212,15 @@ class LexicalRankingTests(unittest.TestCase):
 
         without_tests = rank_candidates("match behavior", source_index, notes())
         with_tests = rank_candidates("match behavior tests", source_index, notes())
+        with_korean_tests = rank_candidates("match behavior 테스트", source_index, notes())
 
         self.assertEqual(len(without_tests), 7)
         self.assertTrue(all(not item.node.path.startswith("tests/") for item in without_tests))
         self.assertEqual(len(with_tests), 10)
         self.assertTrue(all(not item.node.path.startswith("tests/") for item in with_tests[:7]))
         self.assertTrue(all(item.node.path.startswith("tests/") for item in with_tests[7:]))
+        self.assertEqual(len(with_korean_tests), 10)
+        self.assertTrue(all(item.node.path.startswith("tests/") for item in with_korean_tests[7:]))
 
     def test_ignores_module_and_import_only_matches(self) -> None:
         module = node(

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -276,6 +276,31 @@ class ReviewSelectionTests(unittest.TestCase):
         self.assertEqual([item.id for item in result.selected], ["root"])
         self.assertEqual(result.expanded, ())
 
+    def test_file_path_exclusion_removes_every_node_from_that_file(self) -> None:
+        root = node("root", "src/root.py", "function", "root")
+        blocked_module = node("blocked-module", "src/blocked.py", "module", "blocked")
+        blocked_class = node("blocked-class", "src/blocked.py", "class", "Blocked")
+        blocked_function = node("blocked-function", "src/blocked.py", "function", "run")
+        source_index = index(
+            root,
+            blocked_module,
+            blocked_class,
+            blocked_function,
+            edges=(IndexEdge("root", "call", "run", "blocked-function"),),
+        )
+
+        result = review_selection(
+            source_index,
+            candidate_options((ranked(root, 5), ranked(blocked_class, 4))),
+            selected_numbers=(1, 2),
+            added=("src/blocked.py", "blocked-function"),
+            excluded=("src/blocked.py",),
+            fields=FIELDS,
+        )
+
+        self.assertEqual([item.id for item in result.selected], ["root"])
+        self.assertEqual(result.expanded, ())
+
     def test_allows_direct_selection_when_ranked_candidates_are_empty(self) -> None:
         module = node("module", "src/work.py", "module", "work")
         function = node("function", "src/work.py", "function", "run")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest import mock
 
 from silobrief.cli import main
+from tests.windows_junctions import directory_junction
 
 DEFAULT_EXCLUDES = [
     ".git/",
@@ -232,6 +233,27 @@ class SetupCommandTests(unittest.TestCase):
 
             self.assertIn("real directory", message)
             self.assertEqual(list(project.iterdir()), [])
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_setup_rejects_project_and_state_directory_junctions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target"
+            target.mkdir()
+
+            with directory_junction(root / "project-link", target) as project_link:
+                message = self.assert_setup_error(project_link)
+                self.assertIn("reparse point", message)
+            self.assertFalse((target / ".silobrief").exists())
+
+            state_source = root / "state-source"
+            state_source.mkdir()
+            self.assertEqual(main(["setup", str(state_source)]), 0)
+            project = root / "project"
+            project.mkdir()
+            with directory_junction(project / ".silobrief", state_source / ".silobrief"):
+                message = self.assert_setup_error(project)
+                self.assertIn("real directory", message)
 
     def test_setup_rejects_state_file_and_partial_state_without_changes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -12,6 +12,7 @@ import silobrief.sources as sources
 from silobrief.boundaries import register_boundary
 from silobrief.sources import SourceWarning, compare_snapshots, snapshot_sources
 from silobrief.state import load_config, setup_project
+from tests.windows_junctions import directory_junction
 
 
 def file_digest(path: Path) -> str:
@@ -184,6 +185,28 @@ class SourceSnapshotTests(unittest.TestCase):
                     SourceWarning(path="linked.py", reason="symbolic link skipped"),
                 ),
             )
+
+    @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
+    def test_snapshot_skips_directory_junctions_without_reading_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "project"
+            project.mkdir()
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "secret.py").write_bytes(b"JUNCTION_CANARY\n")
+            setup_project(project)
+            config = load_config(project)
+
+            with directory_junction(project / "linked", outside):
+                snapshot = snapshot_sources(project, config)
+
+            self.assertEqual(snapshot.files, ())
+            self.assertEqual(
+                snapshot.warnings,
+                (SourceWarning(path="linked", reason="reparse point skipped"),),
+            )
+            self.assertNotIn(b"JUNCTION_CANARY", repr(snapshot).encode())
 
 
 if __name__ == "__main__":

--- a/tests/windows_junctions.py
+++ b/tests/windows_junctions.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def directory_junction(link: Path, target: Path) -> Iterator[Path]:
+    if os.name != "nt":
+        raise OSError("directory junctions require Windows")
+    result = subprocess.run(
+        ["cmd.exe", "/d", "/c", "mklink", "/j", str(link), str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise OSError("cannot create a directory junction for this test")
+    try:
+        yield link
+    finally:
+        try:
+            os.rmdir(link)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## 릴리즈

검증을 마친 siloBrief 1.0.3을 `develop`에서 `main`으로 반영합니다.

## 변경 내용

- 검토 중 제외한 파일의 함수와 클래스가 선택 결과에 남지 않도록 수정합니다.
- 한국어 테스트 요청에서도 테스트 파일 후보를 최대 10개까지 제안합니다.
- 파일 경로를 입력하면 파일 전체가 아니라 정의 목록을 열고, 사용자가 고른 코드만 포함한다고 안내합니다.
- 데코레이터, 기본값과 상속 표현식의 호출 관계를 함수나 클래스 본문과 분리합니다.
- Windows 재분석 지점이 프로젝트 소스, 로컬 상태, 출력 경로 검사를 우회하지 못하도록 차단합니다.
- 패키지 버전과 공개 문서를 1.0.3으로 갱신합니다.

## 검증

- PR #179의 Ubuntu 및 Windows, Python 3.10 및 3.14 CI 통과
- Ruff lint 및 format check 통과
- mypy strict 통과
- unittest 194개 통과, 환경 의존 7개 건너뜀
- wheel 및 sdist 빌드 통과
- 격리 환경에 wheel을 설치한 뒤 전체 테스트와 `sb --version` 확인

## 범위

새 명령, 외부 런타임 의존성, 색인과 로컬 상태 파일 형식은 변경하지 않습니다.

이 PR은 저장소 규칙에 따라 merge commit으로 병합합니다. 병합 후 `v1.0.3` 태그와 GitHub Release를 만들고 PyPI Trusted Publishing workflow를 실행합니다.

Refs #178