### PR TITLE
refactor(parser): record Python scope metadata

### DIFF
--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -7,6 +7,7 @@ from typing import Literal, TypeAlias
 from silobrief.sources import SourceFile, SourceSnapshot
 
 DefinitionKind: TypeAlias = Literal["class", "function"]
+DeclarationKind: TypeAlias = Literal["global", "nonlocal"]
 
 
 class PythonParseError(Exception):
@@ -46,6 +47,8 @@ class Definition:
     column: int
     start_line: int
     end_line: int
+    parameters: tuple[str, ...] = ()
+    conditional: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,12 +60,25 @@ class ImportEntry:
     context: str | None
     line: int
     column: int
+    conditional: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class SymbolUse:
     context: str | None
     target: str
+    line: int
+    column: int
+    skip_class_scope: bool = False
+    synthetic_local: bool = False
+    lookup_limit: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeDeclaration:
+    kind: DeclarationKind
+    name: str
+    context: str | None
     line: int
     column: int
 
@@ -74,6 +90,7 @@ class ModuleStructure:
     imports: tuple[ImportEntry, ...]
     calls: tuple[SymbolUse, ...]
     references: tuple[SymbolUse, ...]
+    declarations: tuple[ScopeDeclaration, ...]
 
 
 def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
@@ -102,6 +119,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
         imports=tuple(visitor.imports),
         calls=tuple(visitor.calls),
         references=tuple(visitor.references),
+        declarations=tuple(visitor.declarations),
     )
 
 
@@ -111,7 +129,11 @@ class _StructureVisitor(ast.NodeVisitor):
         self.imports: list[ImportEntry] = []
         self.calls: list[SymbolUse] = []
         self.references: list[SymbolUse] = []
+        self.declarations: list[ScopeDeclaration] = []
         self._contexts: list[str] = []
+        self._conditional_depth = 0
+        self._synthetic_scopes: list[set[str]] = []
+        self._lookup_limit: tuple[int, int] | None = None
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._visit_definition(node, "class", is_async=False)
@@ -134,6 +156,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     context=self._context,
                     line=line,
                     column=column,
+                    conditional=self._conditional_depth > 0,
                 )
             )
 
@@ -149,6 +172,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     context=self._context,
                     line=line,
                     column=column,
+                    conditional=self._conditional_depth > 0,
                 )
             )
 
@@ -158,7 +182,7 @@ class _StructureVisitor(ast.NodeVisitor):
             self.visit(node.func)
         else:
             line, column = _location(node)
-            self.calls.append(SymbolUse(self._context, target, line, column))
+            self.calls.append(self._symbol_use(target, line, column))
 
         for argument in node.args:
             self.visit(argument)
@@ -170,14 +194,65 @@ class _StructureVisitor(ast.NodeVisitor):
             target = _dotted_name(node)
             if target is not None:
                 line, column = _location(node)
-                self.references.append(SymbolUse(self._context, target, line, column))
+                self.references.append(self._symbol_use(target, line, column))
                 return
         self.generic_visit(node)
 
     def visit_Name(self, node: ast.Name) -> None:
         if isinstance(node.ctx, ast.Load):
             line, column = _location(node)
-            self.references.append(SymbolUse(self._context, node.id, line, column))
+            self.references.append(self._symbol_use(node.id, line, column))
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self._visit_synthetic(node.body, set(_argument_names(node.args)))
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, (node.key, node.value))
+
+    def visit_If(self, node: ast.If) -> None:
+        self._visit_conditional(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_conditional(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_conditional(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self._visit_conditional(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._visit_conditional(node)
+
+    def visit_TryStar(self, node: ast.AST) -> None:
+        self._visit_conditional(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self._visit_conditional(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_conditional(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_conditional(node)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self._record_declarations("global", node)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self._record_declarations("nonlocal", node)
 
     def _visit_definition(
         self,
@@ -200,14 +275,24 @@ class _StructureVisitor(ast.NodeVisitor):
                 column,
                 start_line,
                 end_line,
+                _function_parameters(node),
+                self._conditional_depth > 0,
             )
         )
-        self._visit_definition_header(node)
+        previous_limit = self._lookup_limit
+        self._lookup_limit = (line, column)
+        try:
+            self._visit_definition_header(node)
+        finally:
+            self._lookup_limit = previous_limit
         self._contexts.append(qualified_name)
+        previous_conditional_depth = self._conditional_depth
+        self._conditional_depth = 0
         try:
             for statement in node.body:
                 self.visit(statement)
         finally:
+            self._conditional_depth = previous_conditional_depth
             self._contexts.pop()
 
     def _visit_definition_header(
@@ -222,6 +307,66 @@ class _StructureVisitor(ast.NodeVisitor):
                 for item in value:
                     if isinstance(item, ast.AST):
                         self.visit(item)
+
+    def _record_declarations(
+        self,
+        kind: DeclarationKind,
+        node: ast.Global | ast.Nonlocal,
+    ) -> None:
+        line, column = _location(node)
+        self.declarations.extend(
+            ScopeDeclaration(kind, name, self._context, line, column) for name in node.names
+        )
+
+    def _symbol_use(self, target: str, line: int, column: int) -> SymbolUse:
+        root = target.split(".", 1)[0]
+        return SymbolUse(
+            self._context,
+            target,
+            line,
+            column,
+            skip_class_scope=bool(self._synthetic_scopes),
+            synthetic_local=any(root in scope for scope in reversed(self._synthetic_scopes)),
+            lookup_limit=self._lookup_limit,
+        )
+
+    def _visit_synthetic(self, node: ast.AST, names: set[str]) -> None:
+        self._synthetic_scopes.append(names)
+        try:
+            self.visit(node)
+        finally:
+            self._synthetic_scopes.pop()
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        results: tuple[ast.expr, ...],
+    ) -> None:
+        first, *remaining = generators
+        self.visit(first.iter)
+        names = _bound_names(first.target)
+        self._synthetic_scopes.append(names)
+        try:
+            self.visit(first.target)
+            for condition in first.ifs:
+                self.visit(condition)
+            for generator in remaining:
+                self.visit(generator.iter)
+                names.update(_bound_names(generator.target))
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result in results:
+                self.visit(result)
+        finally:
+            self._synthetic_scopes.pop()
+
+    def _visit_conditional(self, node: ast.AST) -> None:
+        self._conditional_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._conditional_depth -= 1
 
     @property
     def _context(self) -> str | None:
@@ -239,6 +384,32 @@ def _dotted_name(node: ast.expr) -> str | None:
     parts.append(current.id)
     parts.reverse()
     return ".".join(parts)
+
+
+def _function_parameters(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[str, ...]:
+    return () if isinstance(node, ast.ClassDef) else _argument_names(node.args)
+
+
+def _argument_names(arguments: ast.arguments) -> tuple[str, ...]:
+    names = [argument.arg for argument in (*arguments.posonlyargs, *arguments.args)]
+    if arguments.vararg is not None:
+        names.append(arguments.vararg.arg)
+    names.extend(argument.arg for argument in arguments.kwonlyargs)
+    if arguments.kwarg is not None:
+        names.append(arguments.kwarg.arg)
+    return tuple(names)
+
+
+def _bound_names(node: ast.expr) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return set().union(*(_bound_names(item) for item in node.elts))
+    if isinstance(node, ast.Starred):
+        return _bound_names(node.value)
+    return set()
 
 
 def _location(node: ast.stmt | ast.expr) -> tuple[int, int]:

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -8,6 +8,7 @@ from silobrief.python_structure import (
     Definition,
     ImportEntry,
     PythonParseError,
+    ScopeDeclaration,
     SymbolUse,
     extract_structures,
 )
@@ -52,8 +53,28 @@ class PythonStructureTests(unittest.TestCase):
             (
                 Definition("class", "Outer", "Outer", False, 1, 1, 1, 7),
                 Definition("class", "Inner", "Outer.Inner", False, 2, 5, 2, 3),
-                Definition("function", "method", "Outer.method", False, 4, 5, 4, 5),
-                Definition("function", "fetch", "Outer.fetch", True, 6, 5, 6, 7),
+                Definition(
+                    "function",
+                    "method",
+                    "Outer.method",
+                    False,
+                    4,
+                    5,
+                    4,
+                    5,
+                    ("self",),
+                ),
+                Definition(
+                    "function",
+                    "fetch",
+                    "Outer.fetch",
+                    True,
+                    6,
+                    5,
+                    6,
+                    7,
+                    ("self",),
+                ),
                 Definition("function", "top", "top", False, 8, 1, 8, 10),
                 Definition("function", "nested", "top.nested", False, 9, 5, 9, 10),
             ),
@@ -118,6 +139,75 @@ class PythonStructureTests(unittest.TestCase):
             ),
         )
 
+    def test_extracts_global_and_nonlocal_declarations_by_context(self) -> None:
+        source = source_file(
+            "scopes.py",
+            (
+                b"value = 1\n"
+                b"def outer():\n"
+                b"    value = 2\n"
+                b"    def use_nonlocal():\n"
+                b"        nonlocal value\n"
+                b"        return value\n"
+                b"    def use_global():\n"
+                b"        global value\n"
+                b"        return value\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.declarations,
+            (
+                ScopeDeclaration("nonlocal", "value", "outer.use_nonlocal", 5, 9),
+                ScopeDeclaration("global", "value", "outer.use_global", 8, 9),
+            ),
+        )
+
+    def test_marks_conditional_bindings_without_leaking_into_definition_bodies(self) -> None:
+        source = source_file(
+            "branches.py",
+            (
+                b"def choose(flag):\n"
+                b"    if flag:\n"
+                b"        import private_api as service\n"
+                b"    else:\n"
+                b"        def service():\n"
+                b"            import body_dependency\n"
+                b"    import direct_dependency\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        imports = {(item.module, item.context): item.conditional for item in module.imports}
+        service = next(item for item in module.definitions if item.name == "service")
+
+        self.assertTrue(imports[("private_api", "choose")])
+        self.assertFalse(imports[("body_dependency", "choose.service")])
+        self.assertFalse(imports[("direct_dependency", "choose")])
+        self.assertTrue(service.conditional)
+
+    def test_marks_lambda_and_comprehension_lookup_scopes(self) -> None:
+        source = source_file(
+            "synthetic.py",
+            (
+                b"class Worker:\n"
+                b"    lambda_value = (lambda local: local())(None)\n"
+                b"    values = [item() for item in items()]\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        calls = {call.target: call for call in module.calls}
+
+        self.assertTrue(calls["local"].skip_class_scope)
+        self.assertTrue(calls["local"].synthetic_local)
+        self.assertFalse(calls["items"].skip_class_scope)
+        self.assertFalse(calls["items"].synthetic_local)
+        self.assertTrue(calls["item"].skip_class_scope)
+        self.assertTrue(calls["item"].synthetic_local)
+
     def test_attributes_definition_header_calls_to_the_enclosing_context(self) -> None:
         source = source_file(
             "definitions.py",
@@ -155,7 +245,10 @@ class PythonStructureTests(unittest.TestCase):
             },
         )
         self.assertEqual(len(module.calls), len(contexts))
-        self.assertIn(SymbolUse("outer", "Value", 3, 22), module.references)
+        self.assertIn(
+            SymbolUse("outer", "Value", 3, 22, lookup_limit=(3, 5)),
+            module.references,
+        )
 
     def test_omits_source_text_comments_docstrings_and_string_literals(self) -> None:
         source = source_file(


### PR DESCRIPTION
### 관련 이슈

Refs #183

### 변경 이유

Issue #182의 이름 해석기는 조건 분기, lambda, comprehension, 함수 선언부를 구분해야 한다. 기존 구조 분석 결과에는 이 판단에 필요한 정보가 없었다. 실제 graph resolver 변경과 분리해 저장소의 PR 크기 기준도 지킨다.

### 변경 내용

- 함수 매개변수와 `global`, `nonlocal` 선언을 context별로 기록한다.
- 조건문, 예외 처리, 반복문 안의 definition과 import를 conditional binding으로 표시한다.
- lambda와 comprehension 내부 symbol use에 class scope 건너뛰기와 synthetic local 여부를 기록한다.
- decorator, 기본값, base class 등 정의 선언부의 평가 시점을 표시한다.
- 새 메타데이터의 구조 분석 테스트를 추가한다.

### 확인

- `python -m unittest discover -s tests -t . -q` (216 passed, 7 skipped)
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy`
- `git diff --check`

### 제외 범위

이 PR은 index graph의 call/reference target을 바꾸지 않는다. 실제 resolver 수정은 #182에서 진행한다. 전체 제어 흐름 분석과 일반 변수 값 추적도 포함하지 않는다.