### PR TITLE
refactor(parser): record projected import scopes

### DIFF
--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import ast
+import io
+import symtable
+import tokenize
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
@@ -52,6 +55,13 @@ class Definition:
 
 
 @dataclass(frozen=True, slots=True)
+class ImportBindingScope:
+    context: str | None
+    conditional: bool = False
+    deferred: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class ImportEntry:
     module: str | None
     name: str | None
@@ -61,6 +71,7 @@ class ImportEntry:
     line: int
     column: int
     conditional: bool = False
+    projected_binding_scopes: tuple[ImportBindingScope, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,6 +114,8 @@ def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
 def extract_module_structure(source: SourceFile) -> ModuleStructure:
     try:
         tree = ast.parse(source.content, filename=source.path, mode="exec")
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(source.content).readline)
+        symbols = symtable.symtable(source.content.decode(encoding), source.path, "exec")
     except SyntaxError as error:
         raise PythonParseError(
             path=source.path,
@@ -111,7 +124,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
             reason=error.msg,
         ) from error
 
-    visitor = _StructureVisitor()
+    visitor = _StructureVisitor(symbols)
     visitor.visit(tree)
     return ModuleStructure(
         path=source.path,
@@ -124,13 +137,17 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
 
 
 class _StructureVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
+    def __init__(self, symbols: symtable.SymbolTable) -> None:
         self.definitions: list[Definition] = []
         self.imports: list[ImportEntry] = []
         self.calls: list[SymbolUse] = []
         self.references: list[SymbolUse] = []
         self.declarations: list[ScopeDeclaration] = []
         self._contexts: list[str] = []
+        self._context_kinds: list[DefinitionKind] = []
+        self._context_conditionals: list[bool] = []
+        self._scope_declarations: list[dict[str, DeclarationKind]] = []
+        self._symbol_tables = [symbols]
         self._conditional_depth = 0
         self._synthetic_scopes: list[set[str]] = []
         self._lookup_limit: tuple[int, int] | None = None
@@ -157,6 +174,9 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
+                    projected_binding_scopes=self._projected_import_scopes(
+                        imported.asname or imported.name.split(".", 1)[0]
+                    ),
                 )
             )
 
@@ -173,6 +193,9 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
+                    projected_binding_scopes=self._projected_import_scopes(
+                        imported.asname or imported.name
+                    ),
                 )
             )
 
@@ -286,6 +309,10 @@ class _StructureVisitor(ast.NodeVisitor):
         finally:
             self._lookup_limit = previous_limit
         self._contexts.append(qualified_name)
+        self._context_kinds.append(kind)
+        self._context_conditionals.append(self._conditional_depth > 0)
+        self._scope_declarations.append({})
+        self._symbol_tables.append(_child_symbol_table(self._symbol_tables[-1], node, kind))
         previous_conditional_depth = self._conditional_depth
         self._conditional_depth = 0
         try:
@@ -293,7 +320,11 @@ class _StructureVisitor(ast.NodeVisitor):
                 self.visit(statement)
         finally:
             self._conditional_depth = previous_conditional_depth
+            self._scope_declarations.pop()
+            self._context_conditionals.pop()
+            self._context_kinds.pop()
             self._contexts.pop()
+            self._symbol_tables.pop()
 
     def _visit_definition_header(
         self, node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
@@ -317,6 +348,44 @@ class _StructureVisitor(ast.NodeVisitor):
         self.declarations.extend(
             ScopeDeclaration(kind, name, self._context, line, column) for name in node.names
         )
+        if self._scope_declarations:
+            self._scope_declarations[-1].update(dict.fromkeys(node.names, kind))
+
+    def _projected_import_scopes(self, name: str) -> tuple[ImportBindingScope, ...]:
+        if not self._context_kinds:
+            return ()
+        declaration = self._scope_declarations[-1].get(name)
+        if declaration is None:
+            return ()
+
+        source_kind = self._context_kinds[-1]
+        deferred = source_kind == "function"
+        conditional = self._conditional_depth > 0
+        conditional = conditional or (
+            self._context_conditionals[-1] if source_kind == "class" else True
+        )
+        if declaration == "global":
+            for kind, definition_conditional in zip(
+                self._context_kinds[:-1], self._context_conditionals[:-1], strict=True
+            ):
+                if kind == "function":
+                    conditional = deferred = True
+                conditional = conditional or definition_conditional
+            return (ImportBindingScope(None, conditional, deferred),)
+
+        for index in range(len(self._contexts) - 2, -1, -1):
+            kind = self._context_kinds[index]
+            if kind == "function":
+                try:
+                    owns_name = self._symbol_tables[index + 1].lookup(name).is_local()
+                except KeyError:
+                    owns_name = False
+                if owns_name:
+                    return (ImportBindingScope(self._contexts[index], conditional, deferred),)
+                conditional = deferred = True
+            else:
+                conditional = conditional or self._context_conditionals[index]
+        return ()
 
     def _symbol_use(self, target: str, line: int, column: int) -> SymbolUse:
         root = target.split(".", 1)[0]
@@ -371,6 +440,22 @@ class _StructureVisitor(ast.NodeVisitor):
     @property
     def _context(self) -> str | None:
         return self._contexts[-1] if self._contexts else None
+
+
+def _child_symbol_table(
+    parent: symtable.SymbolTable,
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+    kind: DefinitionKind,
+) -> symtable.SymbolTable:
+    for child in parent.get_children():
+        if child.get_name() == node.name and child.get_lineno() == node.lineno:
+            if child.get_type() == kind:
+                return child
+            try:
+                return _child_symbol_table(child, node, kind)
+            except RuntimeError:
+                pass
+    raise RuntimeError(f"missing symbol table for {kind} {node.name} at line {node.lineno}")
 
 
 def _dotted_name(node: ast.expr) -> str | None:

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import sys
 import unittest
 from unittest import mock
 
 from silobrief.python_structure import (
     Definition,
+    ImportBindingScope,
     ImportEntry,
     PythonParseError,
     ScopeDeclaration,
@@ -82,6 +84,32 @@ class PythonStructureTests(unittest.TestCase):
         self.assertEqual(module.imports, ())
         self.assertEqual(module.calls, ())
         self.assertEqual(module.references, ())
+
+    @unittest.skipIf(sys.version_info < (3, 12), "PEP 695 requires Python 3.12")
+    def test_follows_type_parameter_symbol_tables_to_generic_definitions(self) -> None:
+        source = source_file(
+            "generics.py",
+            (
+                b"class Box[T]:\n"
+                b"    import package\n"
+                b"    def transform[U](self, value: U) -> T:\n"
+                b"        import helper\n"
+                b"        return value\n"
+                b"def identity[T](value: T) -> T:\n"
+                b"    return value\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            tuple(item.qualified_name for item in module.definitions),
+            ("Box", "Box.transform", "identity"),
+        )
+        self.assertEqual(
+            tuple(item.context for item in module.imports),
+            ("Box", "Box.transform"),
+        )
 
     def test_extracts_import_variants_in_source_order(self) -> None:
         source = source_file(
@@ -163,6 +191,140 @@ class PythonStructureTests(unittest.TestCase):
                 ScopeDeclaration("nonlocal", "value", "outer.use_nonlocal", 5, 9),
                 ScopeDeclaration("global", "value", "outer.use_global", 8, 9),
             ),
+        )
+
+    def test_projects_class_imports_to_declared_binding_scopes(self) -> None:
+        source = source_file(
+            "class_bindings.py",
+            (
+                b"class ModuleBindings:\n"
+                b"    global client, service, package\n"
+                b"    import package.client as client\n"
+                b"    from package import service\n"
+                b"    import package.client\n"
+                b"    import package.local as local\n"
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class ClosureBindings:\n"
+                b"        nonlocal selected\n"
+                b"        from package import selected\n"
+                b"    return ClosureBindings\n"
+                b"def delayed():\n"
+                b"    class ModuleBinding:\n"
+                b"        global delayed_client\n"
+                b"        import package.client as delayed_client\n"
+                b"    return ModuleBinding\n"
+                b"def function_binding():\n"
+                b"    global function_client\n"
+                b"    import package.client as function_client\n"
+                b"def owner():\n"
+                b"    owned = None\n"
+                b"    def middle():\n"
+                b"        class ClosureBinding:\n"
+                b"            nonlocal owned\n"
+                b"            import package.client as owned\n"
+                b"    return middle\n"
+                b"def function_owner():\n"
+                b"    function_owned = None\n"
+                b"    def configure():\n"
+                b"        nonlocal function_owned\n"
+                b"        import package.client as function_owned\n"
+                b"    return configure\n"
+                b"class Mismatch:\n"
+                b"    global another_name\n"
+                b"    import package.client as mismatch\n"
+                b"def chain_owner():\n"
+                b"    chained = None\n"
+                b"    def middle():\n"
+                b"        nonlocal chained\n"
+                b"        class ClosureBinding:\n"
+                b"            nonlocal chained\n"
+                b"            import package.client as chained\n"
+                b"    return middle\n"
+                b"def late_owner():\n"
+                b"    class ClosureBinding:\n"
+                b"        nonlocal late\n"
+                b"        import package.client as late\n"
+                b"    late = None\n"
+                b"    return ClosureBinding\n"
+            ),
+        )
+
+        compile(source.content, source.path, "exec")
+        (module,) = extract_structures(source_snapshot(source))
+        imports = {item.alias or item.name or item.module: item for item in module.imports}
+
+        for name in ("client", "service"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    imports[name].projected_binding_scopes,
+                    (ImportBindingScope(None),),
+                )
+        dotted = next(
+            item for item in module.imports if item.module == "package.client" and not item.alias
+        )
+        self.assertEqual(dotted.projected_binding_scopes, (ImportBindingScope(None),))
+        self.assertEqual(
+            imports["selected"].projected_binding_scopes,
+            (ImportBindingScope("outer"),),
+        )
+        self.assertEqual(
+            imports["delayed_client"].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["function_client"].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["owned"].projected_binding_scopes,
+            (ImportBindingScope("owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["function_owned"].projected_binding_scopes,
+            (ImportBindingScope("function_owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["chained"].projected_binding_scopes,
+            (ImportBindingScope("chain_owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["late"].projected_binding_scopes,
+            (ImportBindingScope("late_owner"),),
+        )
+        for name in ("local", "mismatch"):
+            with self.subTest(name=name):
+                self.assertEqual(imports[name].projected_binding_scopes, ())
+
+    def test_preserves_conditions_on_nested_class_import_projections(self) -> None:
+        source = source_file(
+            "conditional_bindings.py",
+            (
+                b"if ENABLED:\n"
+                b"    class ModuleBindings:\n"
+                b"        global client\n"
+                b"        import package.client as client\n"
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class Container:\n"
+                b"        if ENABLED:\n"
+                b"            class ClosureBindings:\n"
+                b"                nonlocal selected\n"
+                b"                from package import selected\n"
+                b"    return Container\n"
+            ),
+        )
+
+        compile(source.content, source.path, "exec")
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.imports[0].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True),),
+        )
+        self.assertEqual(
+            module.imports[1].projected_binding_scopes,
+            (ImportBindingScope("outer", conditional=True),),
         )
 
     def test_marks_conditional_bindings_without_leaking_into_definition_bodies(self) -> None:


### PR DESCRIPTION
## 왜 필요한가

`global`과 `nonlocal`로 선언한 import는 작성된 함수나 클래스가 아니라 모듈 또는 바깥 함수의 이름을 바꾼다. 기존 구조 분석 결과에는 import가 작성된 context만 있어 #182의 index 해석기가 실제 binding 범위와 실행 시점을 다시 추측해야 했다.

## 변경 내용

- `ImportEntry`에 실제 바깥 binding 범위를 나타내는 `projected_binding_scopes`를 추가했다.
- Python 표준 `symtable`을 사용해 `nonlocal` 이름을 실제로 소유한 함수까지 찾는다.
- 함수 호출을 거쳐 실행되는 projection은 `conditional`과 `deferred`로 구분한다. `deferred`는 대상 범위의 줄 순서로 실행 시점을 판단할 수 없다는 뜻이다.
- 일반 import의 원래 context는 그대로 유지한다.
- Python 3.12 이상의 generic class와 function이 만드는 type-parameter symbol table도 따라간다.

이 PR은 구조 메타데이터만 추가하며 현재 index edge 결과는 바꾸지 않는다. #182에서 이 정보를 사용해 call/reference 대상을 연결한다.

## 확인

- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m mypy src tests`
- `python -m unittest discover -s tests -q` — 200 passed, 7 skipped
- 별도 읽기 전용 검토에서 class/function `global`, 실제 `nonlocal` owner, 중간 함수, 조건부 클래스, PEP 695 generic 사례를 재검증했다.

## 제외 범위

- call/reference target 선택
- 일반 대입문의 값 추적
- 함수 호출 순서를 따지는 전체 데이터 흐름 분석
- index schema 변경

Refs #186
Related to #182
