### PR TITLE
fix(index): honor Python lexical scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep indexing Pyodide and notebook-style Python files that use top-level asynchronous syntax
   while preserving scope metadata (#188).
+- Resolve definitions, imports, method receivers, and boundary placeholders using Python lexical
+  scopes and source-order rebinding rules (#182). Existing projects should run `sb init` after
+  upgrading to rebuild the derived index with corrected graph edges.
 
 ## [1.0.3] - 2026-08-18
 

--- a/src/silobrief/boundary_placeholders.py
+++ b/src/silobrief/boundary_placeholders.py
@@ -71,6 +71,9 @@ class BoundaryMatcher:
                 return self._match_module(f"{origin}{suffix}")
         return None
 
+    def match_resolved(self, target: str) -> BoundaryPlaceholder | None:
+        return self._match_module(target)
+
     def _visible_origins(self, context: str | None) -> tuple[tuple[str, str], ...]:
         contexts: list[str | None] = []
         current = context

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -11,7 +11,7 @@ from silobrief.boundary_placeholders import (
     BoundaryPlaceholder,
     import_target,
 )
-from silobrief.python_structure import ImportEntry, ModuleStructure, SymbolUse
+from silobrief.python_structure import Definition, ImportEntry, ModuleStructure, SymbolUse
 from silobrief.search_tokens import extract_scoped_source_text_tokens, normalize_search_tokens
 from silobrief.sources import SourceFile, SourceSnapshot
 from silobrief.state import BoundaryData, ConfigData
@@ -66,6 +66,18 @@ class _ImportBinding:
     context: str | None
     visible: str
     target: str
+    line: int
+    column: int
+    conditional: bool
+    deferred: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ScopeBinding:
+    target_id: str | None = None
+    imported_target: str | None = None
+    falls_through: bool = False
+    unknown: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -263,42 +275,283 @@ def _add_use_edges(
 ) -> None:
     for use in uses:
         source_id = _context_id(context, use.context)
-        placeholder = context.boundary_matcher.match_use(use.target, use.context)
-        target: str | BoundaryPlaceholder = placeholder or use.target
-        target_id = (
-            None
-            if placeholder is not None
-            else _resolve_target(context, use.context, use.target, global_targets)
+        target, target_id = _resolve_use_target(
+            context,
+            use.context,
+            use.target,
+            use.line,
+            use.column,
+            use.skip_class_scope,
+            use.synthetic_local,
+            use.lookup_limit,
+            global_targets,
         )
         edges.add(IndexEdge(source_id, kind, target, target_id))
 
 
-def _resolve_target(
+def _resolve_use_target(
     context: _ModuleContext,
     source_context: str | None,
     target: str,
+    line: int,
+    column: int,
+    skip_class_scope: bool,
+    synthetic_local: bool,
+    lookup_limit: tuple[int, int] | None,
     global_targets: dict[str, str],
-) -> str | None:
-    if source_context is not None and target.startswith("self."):
-        owner, separator, _ = source_context.rpartition(".")
-        if separator:
-            candidate = f"{owner}.{target.removeprefix('self.')}"
-            if candidate in context.context_ids:
-                return context.context_ids[candidate]
+) -> tuple[str | BoundaryPlaceholder, str | None]:
+    if synthetic_local:
+        return target, None
+    use_position = (*lookup_limit, -1) if lookup_limit is not None else (line, column, 2)
+    possible: list[_ScopeBinding] = []
+    saw_binding = False
+    for scope in _lexical_scopes(context, source_context, target, line, skip_class_scope):
+        bindings = _resolve_scope_bindings(
+            context,
+            scope,
+            source_context,
+            target,
+            line,
+            use_position,
+        )
+        if bindings is None:
+            continue
+        saw_binding = True
+        for binding in bindings:
+            if binding.imported_target is None:
+                continue
+            placeholder = context.boundary_matcher.match_resolved(binding.imported_target)
+            if placeholder is not None:
+                return placeholder, None
+        possible.extend(binding for binding in bindings if not binding.falls_through)
+        if not any(binding.falls_through for binding in bindings):
+            return _binding_result(target, possible, global_targets)
+    direct_placeholder = context.boundary_matcher.match_resolved(target)
+    if direct_placeholder is not None:
+        return direct_placeholder, None
+    if saw_binding:
+        possible.append(_ScopeBinding())
+        return _binding_result(target, possible, global_targets)
+    return target, None
 
-    if source_context is not None:
-        parts = source_context.split(".")
-        for length in range(len(parts) - 1, -1, -1):
-            prefix = ".".join(parts[:length])
-            candidate = f"{prefix}.{target}" if prefix else target
-            if candidate in context.context_ids:
-                return context.context_ids[candidate]
-    if target in context.context_ids:
-        return context.context_ids[target]
-    imported_target = _resolve_import_binding(context, source_context, target)
-    if imported_target is not None:
-        return global_targets.get(imported_target)
-    return global_targets.get(target)
+
+def _lexical_scopes(
+    context: _ModuleContext,
+    source_context: str | None,
+    target: str,
+    line: int,
+    skip_class_scope: bool,
+) -> tuple[str | None, ...]:
+    if source_context is None:
+        return (None,)
+    root = target.split(".", 1)[0]
+    result: list[str | None] = []
+    current: str | None = source_context
+    nonlocal_lookup = False
+    while current is not None:
+        definition = _definition_at(context, current, line)
+        kind = definition.kind if definition is not None else None
+        hidden_class = skip_class_scope and kind == "class"
+        visible = kind == "function" or current == source_context and not hidden_class
+        if visible:
+            result.append(current)
+            if _has_declaration(context, current, line, root, "global"):
+                if not nonlocal_lookup:
+                    result.append(None)
+                return tuple(result)
+            if _has_declaration(context, current, line, root, "nonlocal"):
+                nonlocal_lookup = True
+        current = _structural_parent(current)
+    if not nonlocal_lookup:
+        result.append(None)
+    return tuple(result)
+
+
+def _resolve_scope_bindings(
+    context: _ModuleContext,
+    scope: str | None,
+    source_context: str | None,
+    target: str,
+    line: int,
+    use_position: tuple[int, int, int],
+) -> tuple[_ScopeBinding, ...] | None:
+    root = target.split(".", 1)[0]
+    scope_definition = _definition_at(context, scope, line) if scope is not None else None
+    candidates: list[tuple[tuple[int, int, int], _ScopeBinding, bool]] = []
+    deferred_bindings: list[_ScopeBinding] = []
+    for candidate_definition in context.structure.definitions:
+        if (
+            _structural_parent(candidate_definition.qualified_name) != scope
+            or candidate_definition.name != root
+            or not _inside_definition(scope_definition, candidate_definition.line)
+        ):
+            continue
+        suffix = target[len(root) :]
+        if suffix and candidate_definition.kind == "class":
+            target_id = context.context_ids.get(f"{candidate_definition.qualified_name}{suffix}")
+        elif suffix:
+            target_id = None
+        else:
+            target_id = stable_node_id(
+                context.structure.path,
+                candidate_definition.kind,
+                candidate_definition.qualified_name,
+            )
+        candidates.append(
+            (
+                (candidate_definition.line, candidate_definition.column, 0),
+                _ScopeBinding(target_id=target_id, unknown=target_id is None),
+                candidate_definition.conditional,
+            )
+        )
+    for import_binding in context.import_bindings:
+        if import_binding.context != scope or not _inside_definition(
+            scope_definition, import_binding.line
+        ):
+            continue
+        imported_target = _imported_target(import_binding, target)
+        if imported_target is None:
+            continue
+        candidate = (
+            (import_binding.line, import_binding.column, 1),
+            _ScopeBinding(imported_target=imported_target),
+            import_binding.conditional,
+        )
+        if import_binding.deferred:
+            deferred_bindings.append(candidate[1])
+        else:
+            candidates.append(candidate)
+    if (parameter := _parameter_binding(context, scope, target, line)) is not None:
+        candidates.append(((0, 0, 0), parameter, False))
+
+    direct_scope = scope == source_context
+    declared = _has_declaration(context, scope, line, root, "global") or _has_declaration(
+        context, scope, line, root, "nonlocal"
+    )
+    falls_through = declared or (
+        direct_scope and scope_definition is not None and scope_definition.kind == "class"
+    )
+    visible_candidates = candidates
+    if direct_scope:
+        visible_candidates = [candidate for candidate in candidates if candidate[0] <= use_position]
+    if visible_candidates:
+        if direct_scope:
+            possible = list(_possible_bindings(visible_candidates, falls_through))
+        else:
+            entry_position = _scope_entry_position(context, scope, source_context, line)
+            missing = _ScopeBinding(falls_through=falls_through)
+            if entry_position is None:
+                possible = [missing, *(item[1] for item in candidates)]
+            else:
+                before = [item for item in visible_candidates if item[0] < entry_position]
+                possible = list(_possible_bindings(before, falls_through)) if before else [missing]
+                possible.extend(item[1] for item in visible_candidates if item[0] >= entry_position)
+        possible.extend(deferred_bindings)
+        return tuple(dict.fromkeys(possible))
+
+    if (
+        direct_scope
+        and candidates
+        and not declared
+        and (scope is None or scope_definition is not None and scope_definition.kind == "function")
+    ):
+        return tuple(dict.fromkeys([_ScopeBinding(), *deferred_bindings]))
+    if deferred_bindings:
+        return tuple(dict.fromkeys([_ScopeBinding(falls_through=True), *deferred_bindings]))
+    return None
+
+
+def _possible_bindings(
+    candidates: list[tuple[tuple[int, int, int], _ScopeBinding, bool]],
+    missing_falls_through: bool = False,
+) -> tuple[_ScopeBinding, ...]:
+    possible: list[_ScopeBinding] = []
+    for _, binding, conditional in sorted(candidates, key=lambda candidate: candidate[0]):
+        if conditional:
+            if not possible:
+                possible.append(_ScopeBinding(falls_through=missing_falls_through))
+            possible.append(binding)
+        else:
+            possible = [binding]
+    return tuple(dict.fromkeys(possible))
+
+
+def _binding_result(
+    target: str,
+    bindings: list[_ScopeBinding],
+    global_targets: dict[str, str],
+) -> tuple[str, str | None]:
+    concrete = tuple(
+        binding
+        for binding in dict.fromkeys(bindings)
+        if binding.target_id is not None or binding.imported_target is not None or binding.unknown
+    )
+    if len(concrete) != 1 or concrete[0].unknown:
+        return target, None
+    if concrete[0].imported_target is not None:
+        return target, global_targets.get(concrete[0].imported_target)
+    return target, concrete[0].target_id
+
+
+def _scope_entry_position(
+    context: _ModuleContext,
+    scope: str | None,
+    source_context: str | None,
+    line: int,
+) -> tuple[int, int, int] | None:
+    if source_context is None:
+        return None
+    prefix = f"{scope}." if scope is not None else ""
+    if not source_context.startswith(prefix):
+        return None
+    child = source_context[len(prefix) :].split(".", 1)[0]
+    definition = _definition_at(context, f"{prefix}{child}", line)
+    if definition is None:
+        return None
+    if definition.kind == "class" and source_context != definition.qualified_name:
+        return (definition.end_line + 1, definition.column, 2)
+    return (definition.line, definition.column, 2)
+
+
+def _parameter_binding(
+    context: _ModuleContext,
+    scope: str | None,
+    target: str,
+    line: int,
+) -> _ScopeBinding | None:
+    if scope is None:
+        return None
+    receiver, separator, member = target.partition(".")
+    definition = _definition_at(context, scope, line)
+    if definition is None or receiver not in definition.parameters:
+        return None
+    if not separator or receiver not in {"self", "cls"}:
+        return _ScopeBinding(unknown=True)
+    owner = _structural_parent(scope)
+    owner_definition = _definition_at(context, owner, line) if owner is not None else None
+    if owner_definition is None or owner_definition.kind != "class":
+        return _ScopeBinding(unknown=True)
+    target_id = context.context_ids.get(f"{owner}.{member}")
+    return _ScopeBinding(target_id=target_id, unknown=target_id is None)
+
+
+def _structural_parent(context: str) -> str | None:
+    return context.rpartition(".")[0] or None
+
+
+def _definition_at(
+    context: _ModuleContext,
+    qualified_name: str,
+    line: int,
+) -> Definition | None:
+    for definition in context.structure.definitions:
+        if definition.qualified_name == qualified_name and _inside_definition(definition, line):
+            return definition
+    return None
+
+
+def _inside_definition(definition: Definition | None, line: int) -> bool:
+    return definition is None or definition.start_line <= line <= definition.end_line
 
 
 def _context_id(context: _ModuleContext, qualified_name: str | None) -> str:
@@ -328,21 +581,32 @@ def _import_bindings(
     source_path: str,
     imports: tuple[ImportEntry, ...],
 ) -> tuple[_ImportBinding, ...]:
-    bindings: dict[str | None, dict[str, str]] = {}
-    for imported in imports:
-        target = _resolved_import_target(module_name, source_path, imported)
-        visible = _visible_import_binding(imported)
-        if target is None or visible is None:
-            continue
-        bindings.setdefault(imported.context, {})[visible] = target
-
     result: list[_ImportBinding] = []
-    for context in sorted(bindings, key=lambda value: value or ""):
-        for visible, target in sorted(
-            bindings[context].items(),
-            key=lambda item: (-len(item[0].split(".")), item[0], item[1]),
-        ):
-            result.append(_ImportBinding(context, visible, target))
+    for imported in imports:
+        resolved_target = _resolved_import_target(module_name, source_path, imported)
+        visible = _visible_import_binding(imported)
+        if resolved_target is None or visible is None:
+            continue
+        target = _import_binding_target(imported, resolved_target)
+        scopes = (
+            (imported.context, imported.conditional, False),
+            *(
+                (item.context, item.conditional, item.deferred)
+                for item in imported.projected_binding_scopes
+            ),
+        )
+        for scope, conditional, deferred in scopes:
+            result.append(
+                _ImportBinding(
+                    scope,
+                    visible,
+                    target,
+                    imported.line,
+                    imported.column,
+                    conditional,
+                    deferred,
+                )
+            )
     return tuple(result)
 
 
@@ -378,28 +642,39 @@ def _visible_import_binding(imported: ImportEntry) -> str | None:
         return None if imported.name == "*" else imported.name
     if imported.module is None:
         return None
-    return imported.module
+    return imported.module.split(".", 1)[0]
 
 
-def _resolve_import_binding(
+def _import_binding_target(imported: ImportEntry, resolved_target: str) -> str:
+    if imported.alias is None and imported.name is None:
+        return resolved_target.split(".", 1)[0]
+    return resolved_target
+
+
+def _imported_target(binding: _ImportBinding, target: str) -> str | None:
+    if target == binding.visible:
+        return binding.target
+    if target.startswith(f"{binding.visible}."):
+        return f"{binding.target}{target[len(binding.visible) :]}"
+    return None
+
+
+def _has_declaration(
     context: _ModuleContext,
-    source_context: str | None,
-    target: str,
-) -> str | None:
-    current = source_context
-    while True:
-        for binding in context.import_bindings:
-            if binding.context != current:
-                continue
-            if target == binding.visible:
-                return binding.target
-            if target.startswith(f"{binding.visible}."):
-                return f"{binding.target}{target[len(binding.visible) :]}"
-        if current is None:
-            return None
-        current, separator, _ = current.rpartition(".")
-        if not separator:
-            current = None
+    scope: str | None,
+    line: int,
+    name: str,
+    kind: Literal["global", "nonlocal"],
+) -> bool:
+    definition = _definition_at(context, scope, line) if scope is not None else None
+    return any(
+        declaration.kind == kind
+        and declaration.context == scope
+        and declaration.name == name
+        and definition is not None
+        and definition.start_line <= declaration.line <= definition.end_line
+        for declaration in context.structure.declarations
+    )
 
 
 def _import_search_values(

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import unittest
 
+from silobrief.boundary_placeholders import BoundaryPlaceholder
 from silobrief.index import build_index, render_index_json
 from silobrief.python_structure import extract_structures
 from silobrief.sources import SourceFile, SourceSnapshot
@@ -134,6 +135,553 @@ class BoundaryPlaceholderTests(unittest.TestCase):
         for forbidden in (b"private_zone", b"HiddenThing", b"local_hidden"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, first)
+
+    def test_method_boundary_lookup_skips_the_class_namespace(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"from private_zone import send\n"
+                b"class Service:\n"
+                b"    from public_api import send\n"
+                b"    def run(self):\n"
+                b"        return send()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "Service.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_class_global_does_not_hide_an_enclosing_function_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def outer():\n"
+                b"    import private_zone as selected\n"
+                b"    class Service:\n"
+                b"        global selected\n"
+                b"        import public_zone as selected\n"
+                b"        def run(self):\n"
+                b"            return selected.HiddenClient()\n"
+                b"    return Service\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "outer.Service.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_parameter_shadows_a_module_boundary_import(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            b"from private_zone import send\ndef run(send):\n    return send()\n",
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "send")
+        self.assertIsNone(call.target_id)
+
+    def test_receiver_import_shadows_the_enclosing_method_parameter(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"class Service:\n"
+                b"    def helper(self):\n"
+                b"        return 'public'\n"
+                b"    def run(self):\n"
+                b"        from private_zone import client as self\n"
+                b"        def inner():\n"
+                b"            return self.helper()\n"
+                b"        return inner\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        inner = next(node for node in index.nodes if node.qualified_name == "Service.run.inner")
+        call = next(
+            edge for edge in index.edges if edge.source_id == inner.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_global_declaration_skips_an_enclosing_function_import(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as service\n"
+                b"def outer():\n"
+                b"    import public_api as service\n"
+                b"    def inner():\n"
+                b"        global service\n"
+                b"        return service.send()\n"
+                b"    return inner\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        inner = next(node for node in index.nodes if node.qualified_name == "outer.inner")
+        call = next(
+            edge for edge in index.edges if edge.source_id == inner.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_source_order_resolves_boundary_import_and_local_definition(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def imported_last():\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    from private_zone import client as service\n"
+                b"    return service()\n"
+                b"def defined_last():\n"
+                b"    from private_zone import client as service\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    return service()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+        imported_call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes["imported_last"].id and edge.kind == "call"
+        )
+        defined_call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes["defined_last"].id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            imported_call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(imported_call.target_id)
+        self.assertEqual(defined_call.target, "service")
+        self.assertEqual(defined_call.target_id, nodes["defined_last.service"].id)
+        self.assertNotIn(b"private_zone", render_index_json(index))
+
+    def test_lexical_bindings_shadow_a_raw_boundary_name(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def use_local():\n"
+                b"    def private():\n"
+                b"        return 'local'\n"
+                b"    return private()\n"
+                b"def use_parameter(private):\n"
+                b"    return private()\n"
+                b"def use_public_import():\n"
+                b"    from public_api import helper as private\n"
+                b"    return private()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-code",
+            description="Approved private code",
+            path="private.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+        calls = {
+            node_name: next(
+                edge
+                for edge in index.edges
+                if edge.source_id == nodes[node_name].id and edge.kind == "call"
+            )
+            for node_name in ("use_local", "use_parameter", "use_public_import")
+        }
+
+        self.assertEqual(calls["use_local"].target, "private")
+        self.assertEqual(
+            calls["use_local"].target_id,
+            nodes["use_local.private"].id,
+        )
+        for node_name in ("use_parameter", "use_public_import"):
+            with self.subTest(node_name=node_name):
+                self.assertEqual(calls[node_name].target, "private")
+                self.assertIsNone(calls[node_name].target_id)
+        self.assertNotIn(b'"alias": "private-code"', render_index_json(index))
+
+    def test_conditional_boundary_import_is_redacted_conservatively(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose(use_private):\n"
+                b"    if use_private:\n"
+                b"        from private_zone import HiddenClient as service\n"
+                b"    else:\n"
+                b"        def service():\n"
+                b"            return 'public'\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+        rendered = render_index_json(index)
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_try_boundary_import_is_redacted_conservatively(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose():\n"
+                b"    try:\n"
+                b"        from private_zone import HiddenClient as service\n"
+                b"    except ImportError:\n"
+                b"        def service():\n"
+                b"            return 'public'\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+        rendered = render_index_json(index)
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_later_rebinding_does_not_hide_a_boundary_possible_for_a_closure(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose():\n"
+                b"    from private_zone import HiddenClient as service\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    run()\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        self.assertNotIn(b"private_zone", render_index_json(index))
+
+    def test_conditional_class_and_global_bindings_fall_back_to_a_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as backend\n"
+                b"def choose(flag):\n"
+                b"    global backend\n"
+                b"    if flag:\n"
+                b"        import public_zone as backend\n"
+                b"    def run():\n"
+                b"        return backend.HiddenClient()\n"
+                b"    return run\n"
+                b"class Service:\n"
+                b"    if ENABLE_PUBLIC:\n"
+                b"        import public_zone as backend\n"
+                b"    backend.HiddenClient()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in ("choose.run", "Service"):
+            with self.subTest(qualified_name=qualified_name):
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == nodes[qualified_name].id and edge.kind == "call"
+                )
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_class_declarations_change_the_binding_seen_by_methods(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import public_zone as module_backend\n"
+                b"class GlobalService:\n"
+                b"    global module_backend\n"
+                b"    import private_zone as module_backend\n"
+                b"    def run(self):\n"
+                b"        return module_backend.HiddenClient()\n"
+                b"def make_service():\n"
+                b"    import public_zone as closure_backend\n"
+                b"    class NonlocalService:\n"
+                b"        nonlocal closure_backend\n"
+                b"        import private_zone as closure_backend\n"
+                b"        def run(self):\n"
+                b"            return closure_backend.HiddenClient()\n"
+                b"    return NonlocalService\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in ("GlobalService.run", "make_service.NonlocalService.run"):
+            with self.subTest(qualified_name=qualified_name):
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == nodes[qualified_name].id and edge.kind == "call"
+                )
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_deferred_declaration_imports_remain_possible_boundaries(self) -> None:
+        cases = (
+            (
+                b"import public_zone as backend\n"
+                b"def configure():\n"
+                b"    global backend\n"
+                b"    import private_zone as backend\n"
+                b"import public_zone as backend\n"
+                b"configure()\n"
+                b"def run():\n"
+                b"    return backend.HiddenClient()\n",
+                "run",
+            ),
+            (
+                b"def outer():\n"
+                b"    import public_zone as backend\n"
+                b"    def configure():\n"
+                b"        nonlocal backend\n"
+                b"        import private_zone as backend\n"
+                b"    import public_zone as backend\n"
+                b"    configure()\n"
+                b"    def run():\n"
+                b"        return backend.HiddenClient()\n"
+                b"    return run\n",
+                "outer.run",
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        for content, qualified_name in cases:
+            with self.subTest(qualified_name=qualified_name):
+                source = source_snapshot("service.py", content)
+                index = build_index(source, extract_structures(source), config(boundary))
+                node = next(node for node in index.nodes if node.qualified_name == qualified_name)
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == node.id and edge.kind == "call"
+                )
+
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+                rendered = render_index_json(index)
+                for forbidden in (b"private_zone", b"HiddenClient"):
+                    self.assertNotIn(forbidden, rendered)
+
+    def test_deferred_import_without_an_outer_binding_falls_back_to_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def configure():\n"
+                b"    global secret\n"
+                b"    import public_api as secret\n"
+                b"def run():\n"
+                b"    return secret.Hidden()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="secret.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        self.assertNotIn(b'"target": "secret.Hidden"', render_index_json(index))
+
+    def test_projected_import_does_not_cross_duplicate_scope_occurrences(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class Configure:\n"
+                b"        nonlocal selected\n"
+                b"        import private_zone as selected\n"
+                b"    return Configure\n"
+                b"def outer():\n"
+                b"    import public_zone as selected\n"
+                b"    def run():\n"
+                b"        return selected.send()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "outer.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "selected.send")
+        self.assertIsNone(call.target_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -214,6 +214,639 @@ class DeterministicIndexTests(unittest.TestCase):
             index.edges,
         )
 
+    def test_resolves_definitions_in_python_lexical_scopes(self) -> None:
+        source = source_file(
+            "scope_demo.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    return helper()\n"
+                b"class Worker:\n"
+                b"    def helper(self):\n"
+                b"        return 'method'\n"
+                b"    def run(self):\n"
+                b"        helper()\n"
+                b"        def inner():\n"
+                b"            return self.helper()\n"
+                b"        return inner()\n"
+                b"    @classmethod\n"
+                b"    def create(cls):\n"
+                b"        return cls.helper()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes["outer"].id,
+                "call",
+                "helper",
+                nodes["outer.helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run"].id,
+                "call",
+                "helper",
+                nodes["helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run"].id,
+                "call",
+                "inner",
+                nodes["Worker.run.inner"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run.inner"].id,
+                "call",
+                "self.helper",
+                nodes["Worker.helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.create"].id,
+                "call",
+                "cls.helper",
+                nodes["Worker.helper"].id,
+            ),
+            index.edges,
+        )
+
+    def test_resolves_imports_in_python_lexical_scopes(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from pkg import global_target as alias\n"
+                b"def outer():\n"
+                b"    from pkg import local_target as alias\n"
+                b"    def inner():\n"
+                b"        return alias()\n"
+                b"    class NestedWorker:\n"
+                b"        from pkg import class_target as alias\n"
+                b"        def run(self):\n"
+                b"            return alias()\n"
+                b"    return inner()\n"
+                b"class Worker:\n"
+                b"    from pkg import class_target as alias\n"
+                b"    value = alias()\n"
+                b"    def run(self):\n"
+                b"        return alias()\n"
+            ),
+        )
+        dependency = source_file(
+            "pkg.py",
+            (
+                b"def global_target():\n"
+                b"    return 'global'\n"
+                b"def local_target():\n"
+                b"    return 'local'\n"
+                b"def class_target():\n"
+                b"    return 'class'\n"
+            ),
+        )
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer.inner")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "local_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "Worker")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "class_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "Worker.run")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "global_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer.NestedWorker.run")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "local_target")].id,
+            ),
+            index.edges,
+        )
+
+    def test_local_import_takes_priority_over_outer_definition(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    from pkg import helper\n"
+                b"    return helper()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 'imported'\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer")].id,
+                "call",
+                "helper",
+                nodes[("pkg.py", "helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_uses_the_latest_definition_or_import_in_the_same_scope(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def imported_last():\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    from pkg import helper\n"
+                b"    callback = helper\n"
+                b"    return helper()\n"
+                b"def defined_last():\n"
+                b"    from pkg import helper\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    callback = helper\n"
+                b"    return helper()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 'imported'\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        imported = nodes[("pkg.py", "helper")]
+        local = nodes[("caller.py", "defined_last.helper")]
+
+        for kind in ("call", "reference"):
+            with self.subTest(scope="imported_last", kind=kind):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", "imported_last")].id,
+                        kind,
+                        "helper",
+                        imported.id,
+                    ),
+                    index.edges,
+                )
+            with self.subTest(scope="defined_last", kind=kind):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", "defined_last")].id,
+                        kind,
+                        "helper",
+                        local.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_calls_follow_repeated_import_rebindings(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def choose():\n"
+                b"    from first import target as selected\n"
+                b"    selected()\n"
+                b"    from second import target as selected\n"
+                b"    selected()\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        choose = nodes[("caller.py", "choose")]
+
+        self.assertIn(
+            IndexEdge(choose.id, "call", "selected", nodes[("first.py", "target")].id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(choose.id, "call", "selected", nodes[("second.py", "target")].id),
+            index.edges,
+        )
+
+    def test_nested_uses_take_the_latest_binding_before_their_definition(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as module_selected\n"
+                b"from second import target as module_selected\n"
+                b"def module_user():\n"
+                b"    return module_selected()\n"
+                b"def outer():\n"
+                b"    from first import target as local_selected\n"
+                b"    from second import target as local_selected\n"
+                b"    def inner():\n"
+                b"        return local_selected()\n"
+                b"    return inner\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name, target in (
+            ("module_user", "module_selected"),
+            ("outer.inner", "local_selected"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        target,
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_function_bodies_resolve_module_bindings_defined_later(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def run():\n"
+                b"    Later()\n"
+                b"    return selected()\n"
+                b"class Later:\n"
+                b"    pass\n"
+                b"from dependency import target as selected\n"
+            ),
+        )
+        dependency = source_file("dependency.py", b"def target():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        run = nodes[("caller.py", "run")]
+
+        self.assertIn(
+            IndexEdge(run.id, "call", "Later", nodes[("caller.py", "Later")].id), index.edges
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "selected", nodes[("dependency.py", "target")].id),
+            index.edges,
+        )
+
+    def test_declarations_are_scoped_to_each_duplicate_definition_body(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from module_api import target as selected\n"
+                b"def outer():\n"
+                b"    from local_api import target as selected\n"
+                b"    def duplicate():\n"
+                b"        global selected\n"
+                b"        return selected()\n"
+                b"    def duplicate():\n"
+                b"        return selected()\n"
+                b"    return duplicate()\n"
+            ),
+        )
+        module_api = source_file("module_api.py", b"def target():\n    return 1\n")
+        local_api = source_file("local_api.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, module_api, local_api)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        duplicate = nodes[("caller.py", "outer.duplicate")]
+
+        self.assertIn(
+            IndexEdge(duplicate.id, "call", "selected", nodes[("module_api.py", "target")].id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(duplicate.id, "call", "selected", nodes[("local_api.py", "target")].id),
+            index.edges,
+        )
+
+    def test_class_only_import_is_not_visible_to_a_method(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"class Worker:\n"
+                b"    from pkg import helper as alias\n"
+                b"    def run(self):\n"
+                b"        return alias()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes[("caller.py", "Worker.run")].id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "alias")
+        self.assertIsNone(call.target_id)
+
+    def test_dotted_import_binds_the_top_level_package_name(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def pkg():\n"
+                b"    return 'function'\n"
+                b"def run():\n"
+                b"    import pkg.sub\n"
+                b"    return pkg\n"
+            ),
+        )
+        package = source_file("pkg/__init__.py", b"VALUE = 1\n")
+        dependency = source_file("pkg/sub.py", b"VALUE = 2\n")
+        snapshot = source_snapshot(caller, package, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "run")].id,
+                "reference",
+                "pkg",
+                nodes[("pkg/__init__.py", "pkg")].id,
+            ),
+            index.edges,
+        )
+
+    def test_declaration_scope_imports_override_existing_outer_bindings(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as selected\n"
+                b"def use_global():\n"
+                b"    global selected\n"
+                b"    from second import target as selected\n"
+                b"    return selected()\n"
+                b"def outer():\n"
+                b"    from first import target as selected\n"
+                b"    def use_nonlocal():\n"
+                b"        nonlocal selected\n"
+                b"        from second import target as selected\n"
+                b"        return selected()\n"
+                b"    return use_nonlocal()\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name in ("use_global", "outer.use_nonlocal"):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        "selected",
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_class_declaration_imports_update_their_actual_outer_scopes(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as module_selected\n"
+                b"class ModuleWriter:\n"
+                b"    global module_selected\n"
+                b"    from second import target as module_selected\n"
+                b"    def use_module(self):\n"
+                b"        return module_selected()\n"
+                b"def after_module_class():\n"
+                b"    return module_selected()\n"
+                b"def outer():\n"
+                b"    from first import target as closure_selected\n"
+                b"    class ClosureWriter:\n"
+                b"        nonlocal closure_selected\n"
+                b"        from second import target as closure_selected\n"
+                b"        def use_closure(self):\n"
+                b"            return closure_selected()\n"
+                b"    def after_closure_class():\n"
+                b"        return closure_selected()\n"
+                b"    return ClosureWriter, after_closure_class\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name, target in (
+            ("ModuleWriter.use_module", "module_selected"),
+            ("after_module_class", "module_selected"),
+            ("outer.ClosureWriter.use_closure", "closure_selected"),
+            ("outer.after_closure_class", "closure_selected"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        target,
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_redefinition_uses_the_latest_definition_node_kind(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def Target():\n"
+                b"    return 'function'\n"
+                b"class Target:\n"
+                b"    def helper(self):\n"
+                b"        return 'method'\n"
+                b"    def run(self):\n"
+                b"        helper()\n"
+                b"        return self.helper()\n"
+                b"Target()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.kind, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("module", "caller")].id,
+                "call",
+                "Target",
+                nodes[("class", "Target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "self.helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(nodes[("function", "Target.run")].id, "call", "helper", None),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_function_redefinition_keeps_its_nested_function_scope(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"class Target:\n"
+                b"    pass\n"
+                b"def Target():\n"
+                b"    def helper():\n"
+                b"        return 'nested'\n"
+                b"    def run():\n"
+                b"        return helper()\n"
+                b"    return run()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.kind, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_synthetic_scopes_skip_class_bindings_and_keep_local_names_unresolved(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'module'\n"
+                b"def lambda_local():\n"
+                b"    return 'module'\n"
+                b"def comprehension_local():\n"
+                b"    return 'module'\n"
+                b"class Worker:\n"
+                b"    def helper():\n"
+                b"        return 'class'\n"
+                b"    lambda_value = (lambda: helper())()\n"
+                b"    comprehension_value = [helper() for _ in ()]\n"
+                b"    lambda_shadow = (lambda lambda_local: lambda_local())(None)\n"
+                b"    comprehension_shadow = "
+                b"[comprehension_local() for comprehension_local in ()]\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+        worker = nodes["Worker"]
+
+        self.assertIn(
+            IndexEdge(worker.id, "call", "helper", nodes["helper"].id),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(worker.id, "call", "helper", nodes["Worker.helper"].id),
+            index.edges,
+        )
+        for name in ("lambda_local", "comprehension_local"):
+            with self.subTest(name=name):
+                self.assertIn(IndexEdge(worker.id, "call", name, None), index.edges)
+                self.assertNotIn(
+                    IndexEdge(worker.id, "call", name, nodes[name].id),
+                    index.edges,
+                )
+
+    def test_definition_header_resolves_the_previous_import_binding(self) -> None:
+        caller = source_file(
+            "caller.py",
+            b"from pkg import Base\nclass Base(Base):\n    pass\n",
+        )
+        dependency = source_file("pkg.py", b"class Base:\n    pass\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.kind, node.qualified_name): node for node in index.nodes}
+        caller_module = nodes[("caller.py", "module", "caller")]
+
+        self.assertIn(
+            IndexEdge(
+                caller_module.id,
+                "reference",
+                "Base",
+                nodes[("pkg.py", "class", "Base")].id,
+            ),
+            index.edges,
+        )
+
     def test_json_is_identical_for_equivalent_input_order(self) -> None:
         first_source = source_file(
             "a.py",

--- a/tests/test_source_review.py
+++ b/tests/test_source_review.py
@@ -5,10 +5,12 @@ import io
 import unittest
 
 from silobrief.boundary_placeholders import BoundaryPlaceholder
-from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens, build_index
+from silobrief.python_structure import extract_structures
 from silobrief.review import DisclosureChoices, ReviewNode, ReviewSelection
 from silobrief.source_review import SourceReviewError, review_source_disclosure
 from silobrief.sources import SourceFile, SourceSnapshot
+from silobrief.state import DEFAULT_EXCLUDES, BoundaryData, ConfigData
 
 
 class TtyBuffer(io.StringIO):
@@ -147,6 +149,59 @@ class SourceReviewTests(unittest.TestCase):
         self.assertEqual(len(approved), 1)
         self.assertEqual(approved[0].qualified_name, "Service")
         self.assertEqual(approved[0].boundary_aliases, ("delivery-boundary",))
+
+    def test_deferred_boundary_binding_requires_expose(self) -> None:
+        source = snapshot(
+            source_file(
+                "service.py",
+                (
+                    b"import public_zone as backend\n"
+                    b"def configure():\n"
+                    b"    global backend\n"
+                    b"    import private_zone as backend\n"
+                    b"import public_zone as backend\n"
+                    b"configure()\n"
+                    b"def run():\n"
+                    b"    return backend.HiddenClient()\n"
+                ),
+            )
+        )
+        source_index = build_index(
+            source,
+            extract_structures(source),
+            ConfigData(
+                boundaries=[
+                    BoundaryData(
+                        alias="private-service",
+                        description="Approved private service",
+                        path="private_zone.py",
+                    )
+                ],
+                default_excludes=list(DEFAULT_EXCLUDES),
+                schema_version=1,
+            ),
+        )
+        run = next(node for node in source_index.nodes if node.qualified_name == "run")
+        selection = ReviewSelection((review_node(run),), (), FIELDS)
+
+        declined = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nnot-expose\n"),
+            output_stream=TtyBuffer(),
+        )
+        approved = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nEXPOSE\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(declined, ())
+        self.assertEqual(len(approved), 1)
+        self.assertEqual(approved[0].boundary_aliases, ("private-service",))
 
     def test_parse_failure_does_not_remove_valid_candidate(self) -> None:
         broken = node("broken", "bad.py", "function", "broken")


### PR DESCRIPTION
### 무엇을 고쳤나

`call`과 `reference` 대상을 점으로 구분된 이름만 따라가던 방식에서 Python의 실제 이름 탐색 순서를 따르는 방식으로 바꿨습니다.

- 중첩 함수의 지역 정의와 import를 바깥 전역보다 먼저 찾습니다.
- 메서드의 무수식 이름은 클래스 namespace를 바깥 함수 범위처럼 보지 않습니다.
- 중첩 함수가 캡처한 `self`와 `cls`는 소유 클래스의 메서드로 연결합니다.
- 같은 범위의 재정의와 반복 import는 소스 순서를 반영합니다.
- 조건 분기, `global`, `nonlocal`, lambda, comprehension, 정의 선언부를 각각의 평가 범위에 맞게 처리합니다.
- 경계 코드일 가능성이 하나라도 남으면 대상을 확정하지 않고 placeholder와 `EXPOSE` 확인을 유지합니다.

범위 정보 수집과 최상위 비동기 문법 처리는 먼저 병합한 #184, #187, #189를 사용합니다. 이 버전으로 올린 뒤에는 기존 색인을 그대로 쓰지 말고 `sb init`을 다시 실행해야 합니다.

Refs #182

### 확인한 내용

- Ruff lint와 format 통과
- mypy strict 통과
- unittest 234개 통과, 7개 환경상 skip
- 기존 graph retrieval baseline 유지: hits@10 11/12, 정답 심볼 14/17
- 외부 프로젝트 12개를 고정한 비교에서 3개 과제의 edge가 개선됐고 기존 관련 코드 제안은 사라지지 않음
- 역순 입력에서도 index와 관련 코드 결과가 같고, 제외 경로 canary가 노출되지 않음
- production 변경량 398줄

### 이번 PR에 넣지 않은 내용

동적 import와 runtime dispatch의 완전한 해석, 일반 변수 대입의 전체 데이터 흐름, 같은 이름으로 여러 번 정의된 항목의 node 분리는 다루지 않았습니다. one-hop 관련 코드 제안이 실제 검토에 도움이 되는지는 #185에서 별도 실험합니다.