### PR TITLE
docs(validation): record scope context study

### DIFF
--- a/validation/v1.0-scope-related-context/REPORT.md
+++ b/validation/v1.0-scope-related-context/REPORT.md
@@ -1,0 +1,85 @@
+# Scope-related one-hop context validation
+
+## Decision
+
+Proceed with the lexical-scope correction. The fixed-primary comparison affected three of the 12
+holdout tasks, met every gate in Issue #185, and improved the required related context in two cases.
+This result supports the scope fix only; it does not justify a graph database, multi-hop expansion,
+or an LLM-based retrieval layer.
+
+## Frozen protocol
+
+- Baseline: `e5329b29d884d40dc7d3b14ca7fa26c83a14878b`
+- Current: `ab98e39910d9dc70eacdad3fcb4df4d5e7b579de`
+- Corpus: the six v0.4 ranking holdouts and six v0.4 edge-IDF holdouts
+- Selection: each manifest's fixed primary node; ranking was not run
+- Comparison: the full canonical one-hop edge set determined the affected tasks. The product review
+  API's capped proposal set was measured separately for required-neighbor Recall@10 and the 10-item
+  cap.
+- Oracle: [oracle.json](oracle.json), frozen before result interpretation with SHA-256
+  `39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1`. Required and allowed
+  neighbors were assigned from the prompts and reference patches by a reviewer who did not read
+  either product output.
+- Runtime: CPython 3.14.3. Baseline and current were each repeated with hash seeds 0 and 1 in
+  `-S` workers.
+
+The evaluator reads canonical source snapshots from regular Git blobs at each manifest commit, so a
+checkout's symlink and line-ending policy cannot change the measured graph. It separately requires a
+clean tracked worktree and rejects any collected Python file that is untracked or differs from its
+HEAD blob. For the audit only, CRLF bytes are accepted when their sole normalization to LF matches the
+blob exactly. Existing `.silobrief` files are not inputs; their complete path-and-byte digest, Git
+status, and tracked-file digest must remain unchanged across all workers.
+
+## Results
+
+The canonical result is [results.json](results.json), SHA-256
+`0c65bd3a7d64bc5218583b08c332029e384bda63bcd42337999c92ffd0171923`.
+
+| Holdout | Observed change | Required related nodes | Static edges |
+| --- | --- | ---: | ---: |
+| `litestar-org/litestar` | Added the nested `send_wrapper` caller | 1/2 → 2/2 | 2/3 → 3/3 |
+| `sanic-org/sanic` | Added the `StartupMixin.serve` caller | 0/1 → 1/1 | 1/2 → 2/2 |
+| `psf/black` | Added the `calls` relation from `hug_power_op` to `is_simple_operand` | 0/2 → 0/2 | 7/8 → 8/8 |
+
+Across the affected cases, required-neighbor recall rose from 1/5 to 3/5. The current graph recovered
+all 13 statically resolvable oracle edges with no extra edge, so both edge precision and recall were
+13/13. Required neighbors were never lost, the aggregate unnecessary proposal count stayed at 9,
+and the related-context API never returned more than 10 items.
+
+All automatic gates passed:
+
+- affected tasks: 3, meeting the minimum of 3
+- task-level improvements: 2, meeting the minimum of 2
+- invalid current edges: 0
+- boundary canary exposures: 0
+- `setup_project` and `snapshot_sources` control proposal sets: unchanged
+- seed and input-order determinism: passed
+- frozen external inputs and post-run repository state: unchanged
+
+The Black task still lacks `Line.append` and `Leaf.clone`. Those calls use dynamically resolved
+receivers, so the current static graph cannot identify their concrete types. This is an explicit
+limit of the experiment, not evidence that the lexical-scope fix regressed the task. The oracle was
+checked against [Litestar PR 3776](https://github.com/litestar-org/litestar/pull/3776),
+[Sanic PR 3122](https://github.com/sanic-org/sanic/pull/3122) and reference fix `dc0939e`, and
+[Black PR 5272](https://github.com/psf/black/pull/5272) and reference fix `006b2a7` before the
+generated result was interpreted.
+
+## Verification
+
+Run from the repository root:
+
+```text
+python validation/v1.0-scope-related-context/evaluate.py
+python validation/v1.0-scope-related-context/evaluate.py --check
+python -m unittest tests.test_index tests.test_boundary_placeholders tests.test_source_review tests.test_python_structure
+```
+
+The first command wrote the canonical result. The second independently recomputed it and returned
+the same SHA-256. The focused lexical-scope and boundary regression gate ran 64 tests successfully.
+The complete test suite also passed 234 tests with 7 expected skips, and Ruff reported no findings.
+
+## Not now
+
+Do not add a graph database, LLM ranking, multi-hop traversal, or receiver-type inference as part of
+this work. Receiver inference may be studied later with its own narrow corpus and stop criteria if
+the missing Black neighbors prove important in more than this one task.

--- a/validation/v1.0-scope-related-context/evaluate.py
+++ b/validation/v1.0-scope-related-context/evaluate.py
@@ -1,0 +1,882 @@
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+BASELINE_COMMIT = "e5329b29d884d40dc7d3b14ca7fa26c83a14878b"
+CURRENT_COMMIT = "ab98e39910d9dc70eacdad3fcb4df4d5e7b579de"
+MANIFESTS = (
+    (
+        "ranking",
+        "v0.4-ranking-holdout",
+        "6fe09278638ccede6e4be981fcc8b2fd5fedcd9288dbcc780210032bce616736",
+    ),
+    (
+        "edge-idf",
+        "v0.4-edge-idf-holdout",
+        "1b45b645362a26a24e3d89805282b4dfd14c583b527ebe326698fbce4f0b5eaf",
+    ),
+)
+CONTROLS = (
+    ("setup_project", "src/silobrief/state.py", "setup_project"),
+    ("snapshot_sources", "src/silobrief/sources.py", "snapshot_sources"),
+)
+CANARY_ROOT = "examples/model-validation-fixture"
+CANARY_PRIMARY = ("src/parcel_lab/retry.py", "retry_request")
+CANARY_BOUNDARY = {
+    "path": "private_adapter",
+    "alias": "delivery-boundary",
+    "description": "External delivery adapter",
+}
+CANARY_FORBIDDEN = (
+    b"private_adapter",
+    b"private_adapter.client",
+    b"deliver_internal",
+    b"PRIVATE_MODEL_GATE_CANARY",
+    b"ignored-adapter-source",
+)
+CONTROL_BOUNDARIES = (
+    ("examples", "benchmark-fixtures", "Fixture corpus"),
+    ("validation", "validation-artifacts", "Reports"),
+    ("tests/test_graph_retrieval_baseline.py", "benchmark-harness", "Baseline harness"),
+    ("tests/test_graph_retrieval_comparison.py", "comparison-harness", "Comparison harness"),
+    ("tests/__init__.py", "test-package-marker", "Test package marker"),
+)
+OUTGOING_RELATION = {
+    "call": "calls",
+    "import": "imports",
+    "reference": "references",
+    "contains": "contains",
+}
+INCOMING_RELATION = {
+    "call": "called-by",
+    "import": "imported-by",
+    "reference": "referenced-by",
+    "contains": "contained-by",
+}
+RELATION_ORDER = {
+    "calls": 0,
+    "called-by": 1,
+    "imports": 2,
+    "imported-by": 3,
+    "references": 4,
+    "referenced-by": 5,
+    "contains": 6,
+    "contained-by": 7,
+}
+KIND_ORDER = {"module": 0, "class": 1, "function": 2}
+SCRUBBED_GIT_ENVIRONMENT = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+)
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+RESULT_PATH = HERE / "results.json"
+ORACLE_PATH = HERE / "oracle.json"
+ORACLE_SHA256 = "39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1"
+
+
+def sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def git(project: Path, *arguments: str, input_data: bytes | None = None) -> bytes:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith("GIT_"):
+            environment.pop(name)
+    for name in SCRUBBED_GIT_ENVIRONMENT:
+        environment.pop(name, None)
+    environment.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+        }
+    )
+    return subprocess.run(
+        (
+            "git",
+            "--no-replace-objects",
+            "--no-optional-locks",
+            "-c",
+            f"safe.directory={project.as_posix()}",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.untrackedCache=false",
+            *arguments,
+        ),
+        cwd=project,
+        env=environment,
+        check=True,
+        capture_output=True,
+        input=input_data,
+    ).stdout
+
+
+class GitLoader(importlib.abc.SourceLoader):
+    def __init__(self, commit: str, path: str, content: bytes) -> None:
+        self.commit = commit
+        self.path = path
+        self.content = content
+
+    def get_filename(self, fullname: str) -> str:
+        return f"<git:{self.commit}:{self.path}>"
+
+    def get_data(self, path: str) -> bytes:
+        return self.content
+
+
+class GitFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, commit: str, blobs: dict[str, bytes]) -> None:
+        self.commit = commit
+        self.blobs = blobs
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: object = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != "silobrief" and not fullname.startswith("silobrief."):
+            return None
+        stem = "src/" + fullname.replace(".", "/")
+        package_path = stem + "/__init__.py"
+        module_path = stem + ".py"
+        source_path = package_path if package_path in self.blobs else module_path
+        if source_path not in self.blobs:
+            return None
+        loader = GitLoader(self.commit, source_path, self.blobs[source_path])
+        return importlib.util.spec_from_loader(
+            fullname,
+            loader,
+            origin=loader.get_filename(fullname),
+            is_package=source_path == package_path,
+        )
+
+
+def product_api(commit: str) -> dict[str, Any]:
+    resolved = git(ROOT, "rev-parse", f"{commit}^{{commit}}").decode().strip()
+    if resolved != commit:
+        raise RuntimeError(f"product commit did not resolve exactly: {commit}")
+    names = git(ROOT, "ls-tree", "-r", "--name-only", commit, "--", "src/silobrief")
+    paths = names.decode().splitlines()
+    blobs = {path: git(ROOT, "show", f"{commit}:{path}") for path in paths if path.endswith(".py")}
+    sys.meta_path.insert(0, GitFinder(commit, blobs))
+    package_spec = importlib.machinery.ModuleSpec("silobrief", loader=None, is_package=True)
+    package_spec.submodule_search_locations = []
+    package = importlib.util.module_from_spec(package_spec)
+    sys.modules["silobrief"] = package
+    import silobrief.index as index_module
+    import silobrief.python_structure as structure_module
+    import silobrief.review as review_module
+    import silobrief.sources as sources_module
+    import silobrief.state as state_module
+
+    return {
+        "build_index": index_module.build_index,
+        "render_index_json": index_module.render_index_json,
+        "extract_structures": structure_module.extract_structures,
+        "DisclosureChoices": review_module.DisclosureChoices,
+        "review_selection": review_module.review_selection,
+        "SourceFile": sources_module.SourceFile,
+        "SourceSnapshot": sources_module.SourceSnapshot,
+        "snapshot_sources": sources_module.snapshot_sources,
+        "default_excludes": state_module.DEFAULT_EXCLUDES,
+    }
+
+
+def load_manifests(external_root: Path) -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    for suite, directory, expected_digest in MANIFESTS:
+        path = external_root / directory / "holdout.json"
+        content = path.read_bytes()
+        if sha256(content) != expected_digest:
+            raise RuntimeError(f"frozen manifest digest changed: {path}")
+        value = json.loads(content)
+        for position, raw_case in enumerate(value["cases"], start=1):
+            case = dict(raw_case)
+            case["suite"] = suite
+            case["position"] = position
+            case["root"] = str(external_root / directory / "repos")
+            cases.append(case)
+    return cases
+
+
+def related_value(node: Any) -> dict[str, object]:
+    return {
+        "kind": node.kind,
+        "path": node.path,
+        "qualified_name": node.qualified_name,
+        "relations": list(node.relations),
+    }
+
+
+def inside(path: str, prefix: str) -> bool:
+    clean = prefix.rstrip("/")
+    return path == clean or path.startswith(clean + "/")
+
+
+def excluded(path: str, config: dict[str, object]) -> bool:
+    default_excludes = {str(value).removesuffix("/") for value in config["default_excludes"]}
+    if any(part in default_excludes for part in path.split("/")):
+        return True
+    return any(inside(path, str(boundary["path"])) for boundary in config["boundaries"])
+
+
+def git_python_blobs(
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+    *,
+    prefix: str = "",
+) -> dict[str, tuple[str, bytes]]:
+    arguments = ["ls-tree", "-r", "-z", commit]
+    if prefix:
+        arguments.extend(("--", prefix))
+    records = git(project, *arguments).split(b"\0")
+    entries: list[tuple[str, str, str]] = []
+    clean_prefix = prefix.rstrip("/")
+    for record in records:
+        if not record:
+            continue
+        metadata, encoded_path = record.split(b"\t", 1)
+        mode, object_type, object_id = metadata.split(b" ", 2)
+        if object_type != b"blob":
+            continue
+        full_path = encoded_path.decode("utf-8", errors="surrogateescape")
+        path = (
+            full_path[len(clean_prefix) + 1 :]
+            if clean_prefix and full_path.startswith(clean_prefix + "/")
+            else full_path
+        )
+        if not path.endswith(".py") or excluded(path, config):
+            continue
+        entries.append((path, mode.decode(), object_id.decode()))
+    request = b"".join(object_id.encode() + b"\n" for _path, _mode, object_id in entries)
+    response = git(project, "cat-file", "--batch", input_data=request)
+    offset = 0
+    result: dict[str, tuple[str, bytes]] = {}
+    for path, mode, expected_id in entries:
+        header_end = response.index(b"\n", offset)
+        object_id, object_type, encoded_size = response[offset:header_end].split(b" ")
+        size = int(encoded_size)
+        content_start = header_end + 1
+        content_end = content_start + size
+        if object_id.decode() != expected_id or object_type != b"blob":
+            raise RuntimeError(f"unexpected Git object while reading {path}")
+        result[path] = (mode, response[content_start:content_end])
+        if response[content_end : content_end + 1] != b"\n":
+            raise RuntimeError(f"malformed Git batch output while reading {path}")
+        offset = content_end + 1
+    if offset != len(response):
+        raise RuntimeError("unexpected trailing Git batch output")
+    return result
+
+
+def source_digest(files: tuple[object, ...]) -> str:
+    digest = hashlib.sha256(b"silobrief-source-snapshot-v1\0")
+    for source in files:
+        path = source.path.encode("utf-8")
+        digest.update(len(path).to_bytes(8, byteorder="big"))
+        digest.update(path)
+        digest.update(bytes.fromhex(source.sha256))
+    return digest.hexdigest()
+
+
+def git_snapshot(
+    api: dict[str, Any],
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+    *,
+    prefix: str = "",
+) -> object:
+    blobs = git_python_blobs(project, commit, config, prefix=prefix)
+    files = tuple(
+        api["SourceFile"](path, content, sha256(content))
+        for path, (mode, content) in sorted(blobs.items())
+        if mode in {"100644", "100755"}
+    )
+    return api["SourceSnapshot"](files=files, warnings=(), digest=source_digest(files))
+
+
+def audit_working_snapshot(
+    api: dict[str, Any],
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+) -> dict[str, bool]:
+    tracked_status = git(project, "status", "--porcelain=v1", "-z", "--untracked-files=no")
+    if tracked_status:
+        raise RuntimeError(f"external repository has tracked changes: {project}")
+    tracked = git_python_blobs(project, commit, config)
+    snapshot = api["snapshot_sources"](project, config)
+    for source in snapshot.files:
+        expected = tracked.get(source.path)
+        if expected is None:
+            raise RuntimeError(f"working snapshot contains untracked source: {source.path}")
+        if source.content != expected[1] and source.content.replace(b"\r\n", b"\n") != expected[1]:
+            raise RuntimeError(f"working source differs from HEAD blob: {source.path}")
+    return {
+        "canonical_git_snapshot": True,
+        "tracked_clean_at_start": True,
+        "working_snapshot_inputs_frozen": True,
+    }
+
+
+def adjacent_values(index: object, primary_id: str) -> list[dict[str, object]]:
+    nodes = {node.id: node for node in index.nodes}
+    relations: dict[str, set[str]] = {}
+    for edge in index.edges:
+        target_id = edge.target_id
+        if edge.source_id not in nodes or target_id not in nodes or edge.source_id == target_id:
+            continue
+        if edge.source_id == primary_id:
+            relations.setdefault(target_id, set()).add(OUTGOING_RELATION[edge.kind])
+        if target_id == primary_id:
+            relations.setdefault(edge.source_id, set()).add(INCOMING_RELATION[edge.kind])
+    ordered = sorted(
+        relations,
+        key=lambda node_id: (
+            nodes[node_id].path,
+            KIND_ORDER[nodes[node_id].kind],
+            nodes[node_id].name,
+            nodes[node_id].qualified_name,
+            node_id,
+        ),
+    )
+    return [
+        {
+            "kind": nodes[node_id].kind,
+            "path": nodes[node_id].path,
+            "qualified_name": nodes[node_id].qualified_name,
+            "relations": sorted(relations[node_id], key=RELATION_ORDER.__getitem__),
+        }
+        for node_id in ordered
+    ]
+
+
+def evaluate_index(
+    api: dict[str, Any],
+    snapshot: Any,
+    structures: tuple[object, ...],
+    config: dict[str, object],
+    target_path: str,
+    target_name: str,
+    *,
+    forbidden: tuple[bytes, ...] = (),
+) -> dict[str, object]:
+    index = api["build_index"](snapshot, structures, config)
+    reversed_index = api["build_index"](
+        dataclasses.replace(snapshot, files=tuple(reversed(snapshot.files))),
+        tuple(reversed(structures)),
+        config,
+    )
+    index_deterministic = api["render_index_json"](index) == api["render_index_json"](
+        reversed_index
+    )
+    targets = [
+        node
+        for node in index.nodes
+        if node.path == target_path and node.qualified_name == target_name
+    ]
+    if len(targets) != 1:
+        raise RuntimeError(f"expected one fixed primary: {target_path} {target_name}")
+    fields = api["DisclosureChoices"](False, False, False, False, False)
+    selection = api["review_selection"](
+        index, (), selected_numbers=(), added=(targets[0].id,), excluded=(), fields=fields
+    )
+    reordered = api["review_selection"](
+        dataclasses.replace(
+            index,
+            nodes=tuple(reversed(index.nodes)),
+            edges=tuple(reversed(index.edges)),
+        ),
+        (),
+        selected_numbers=(),
+        added=(targets[0].id,),
+        excluded=(),
+        fields=fields,
+    )
+    related = [related_value(node) for node in selection.expanded]
+    adjacent = adjacent_values(index, targets[0].id)
+    review_deterministic = related == [
+        related_value(node) for node in reordered.expanded
+    ] and adjacent == adjacent_values(reversed_index, targets[0].id)
+    boundary_exposures = 0
+    rendered_index = api["render_index_json"](index)
+    rendered_related = json.dumps(related, ensure_ascii=False, sort_keys=True).encode()
+    rendered_adjacent = json.dumps(adjacent, ensure_ascii=False, sort_keys=True).encode()
+    rendered_snapshot = json.dumps(
+        [(source.path, source.sha256) for source in snapshot.files],
+        ensure_ascii=False,
+        sort_keys=True,
+    ).encode()
+    for boundary in config["boundaries"]:
+        prefix = boundary["path"]
+        boundary_exposures += sum(inside(source.path, prefix) for source in snapshot.files)
+        boundary_exposures += sum(inside(node.path, prefix) for node in index.nodes)
+        boundary_exposures += sum(inside(node["path"], prefix) for node in related)
+        boundary_exposures += sum(inside(node["path"], prefix) for node in adjacent)
+    raw_canary_exposures = sum(
+        value in artifact
+        for value in forbidden
+        for artifact in (
+            rendered_snapshot,
+            rendered_index,
+            rendered_related,
+            rendered_adjacent,
+        )
+    )
+    return {
+        "adjacent_edges": adjacent,
+        "boundary_canary_exposures": boundary_exposures,
+        "cap_ok": len(selection.expanded) <= 10,
+        "deterministic": index_deterministic and review_deterministic,
+        "edges": len(index.edges),
+        "nodes": len(index.nodes),
+        "primary": {"path": target_path, "qualified_name": target_name},
+        "raw_canary_exposures": raw_canary_exposures,
+        "related": related,
+    }
+
+
+def evaluate_external(api: dict[str, Any], case: dict[str, object]) -> dict[str, object]:
+    repository = str(case["repository"])
+    project = Path(str(case["root"])) / repository.rsplit("/", 1)[-1]
+    head = git(project, "rev-parse", "HEAD").decode().strip()
+    if head != case["commit"]:
+        raise RuntimeError(f"unexpected external commit for {repository}: {head}")
+    boundaries = [
+        {
+            "alias": f"holdout-boundary-{position}",
+            "description": item["description"],
+            "path": item["path"],
+        }
+        for position, item in enumerate(case.get("ignored_paths", []), start=1)
+    ]
+    config = {
+        "boundaries": boundaries,
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    input_audit = audit_working_snapshot(api, project, head, config)
+    snapshot = git_snapshot(api, project, head, config)
+    structures = api["extract_structures"](snapshot)
+    result = evaluate_index(
+        api,
+        snapshot,
+        structures,
+        config,
+        str(case["target_path"]),
+        str(case["target_qualified_name"]),
+    )
+    result.update(
+        {
+            "commit": head,
+            "input_audit": input_audit,
+            "manifest_position": case["position"],
+            "repository": repository,
+            "suite": case["suite"],
+        }
+    )
+    return result
+
+
+def control_snapshot(api: dict[str, Any], commit: str, config: dict[str, object]) -> object:
+    return git_snapshot(api, ROOT, commit, config)
+
+
+def run_worker(version: str, external_root: Path) -> bytes:
+    commit = BASELINE_COMMIT if version == "baseline" else CURRENT_COMMIT
+    api = product_api(commit)
+    cases = [evaluate_external(api, case) for case in load_manifests(external_root)]
+    boundaries = [
+        {"path": path, "alias": alias, "description": description}
+        for path, alias, description in CONTROL_BOUNDARIES
+    ]
+    config = {
+        "boundaries": boundaries,
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    snapshot = control_snapshot(api, commit, config)
+    structures = api["extract_structures"](snapshot)
+    controls = []
+    for name, path, qualified_name in CONTROLS:
+        value = evaluate_index(api, snapshot, structures, config, path, qualified_name)
+        value["name"] = name
+        controls.append(value)
+    canary_config = {
+        "boundaries": [CANARY_BOUNDARY],
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    canary_snapshot = git_snapshot(
+        api,
+        ROOT,
+        commit,
+        canary_config,
+        prefix=CANARY_ROOT,
+    )
+    canary = evaluate_index(
+        api,
+        canary_snapshot,
+        api["extract_structures"](canary_snapshot),
+        canary_config,
+        *CANARY_PRIMARY,
+        forbidden=CANARY_FORBIDDEN,
+    )
+    payload = {
+        "canary": canary,
+        "cases": cases,
+        "commit": commit,
+        "controls": controls,
+        "runtime": {
+            "implementation": sys.implementation.name,
+            "version": list(sys.version_info[:3]),
+        },
+        "version": version,
+    }
+    rendered = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode()
+    if any(value in rendered for value in CANARY_FORBIDDEN):
+        raise RuntimeError("fixture boundary canary leaked into worker result")
+    return rendered
+
+
+def directory_digest(path: Path) -> str:
+    digest = hashlib.sha256(b"present" if path.is_dir() else b"missing")
+    if not path.is_dir():
+        return digest.hexdigest()
+    for item in sorted(path.rglob("*"), key=lambda value: value.as_posix()):
+        relative = item.relative_to(path).as_posix().encode()
+        digest.update(relative + b"\0")
+        if item.is_symlink():
+            digest.update(b"link\0" + os.readlink(item).encode())
+        elif item.is_file():
+            digest.update(b"file\0" + item.read_bytes())
+        else:
+            digest.update(b"directory\0")
+    return digest.hexdigest()
+
+
+def tracked_digest(project: Path) -> str:
+    digest = hashlib.sha256()
+    for encoded in (item for item in git(project, "ls-files", "-z").split(b"\0") if item):
+        relative = encoded.decode("utf-8", errors="surrogateescape")
+        target = project / relative
+        digest.update(encoded + b"\0")
+        if target.is_file():
+            digest.update(target.read_bytes())
+        else:
+            digest.update(git(project, "ls-files", "-s", "--", relative))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def repository_state(project: Path) -> dict[str, str]:
+    status = git(project, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    return {
+        "silobrief_state_sha256": directory_digest(project / ".silobrief"),
+        "status_sha256": sha256(status),
+        "tracked_sha256": tracked_digest(project),
+    }
+
+
+def external_projects(cases: list[dict[str, object]]) -> dict[str, Path]:
+    return {
+        str(case["repository"]): Path(str(case["root"]))
+        / str(case["repository"]).rsplit("/", 1)[-1]
+        for case in cases
+    }
+
+
+def child_result(version: str, external_root: Path, seed: int) -> dict[str, object]:
+    environment = os.environ.copy()
+    for name in ("PYTHONHOME", "PYTHONPATH", "PYTHONSTARTUP"):
+        environment.pop(name, None)
+    environment.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONHASHSEED": str(seed),
+            "PYTHONNOUSERSITE": "1",
+        }
+    )
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-S",
+            str(Path(__file__)),
+            "--worker",
+            version,
+            "--external-root",
+            str(external_root),
+        ),
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        reason = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"{version} worker failed: {reason}")
+    return json.loads(completed.stdout)
+
+
+def node_key(value: dict[str, object]) -> tuple[str, str]:
+    return str(value["path"]), str(value["qualified_name"])
+
+
+def edge_keys(values: list[dict[str, object]]) -> set[tuple[str, str, str]]:
+    return {
+        (*node_key(value), str(relation)) for value in values for relation in value["relations"]
+    }
+
+
+def oracle_edges(values: list[dict[str, str]]) -> set[tuple[str, str, str]]:
+    return {(value["path"], value["qualified_name"], value["relation"]) for value in values}
+
+
+def control_signature(values: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {"name": value["name"], "primary": value["primary"], "related": value["related"]}
+        for value in values
+    ]
+
+
+def compare(
+    baseline: dict[str, object],
+    current: dict[str, object],
+    state: dict[str, dict[str, object]],
+    *,
+    cross_seed_deterministic: bool,
+) -> dict[str, object]:
+    before_cases = baseline["cases"]
+    after_cases = current["cases"]
+    identities = [(case["suite"], case["repository"]) for case in before_cases]
+    if identities != [(case["suite"], case["repository"]) for case in after_cases]:
+        raise RuntimeError("worker case order differs")
+    affected = [
+        index
+        for index, (before, after) in enumerate(zip(before_cases, after_cases, strict=True))
+        if before["adjacent_edges"] != after["adjacent_edges"]
+    ]
+    selected = affected[:4]
+    stop_early = len(affected) < 3
+    oracle_digest: str | None = None
+    measurements: list[dict[str, object]] = []
+    if not stop_early:
+        oracle_content = ORACLE_PATH.read_bytes()
+        oracle_digest = sha256(oracle_content)
+        if oracle_digest != ORACLE_SHA256:
+            raise RuntimeError("frozen oracle digest changed")
+        oracle = json.loads(oracle_content)
+        entries = {entry["repository"]: entry for entry in oracle["cases"]}
+        expected = {str(after_cases[index]["repository"]) for index in selected}
+        if set(entries) != expected:
+            raise RuntimeError("oracle cases do not match the first affected cases")
+        for index in selected:
+            before = before_cases[index]
+            after = after_cases[index]
+            entry = entries[str(after["repository"])]
+            required_nodes = {node_key(value) for value in entry["required_nodes"]}
+            required_edges = oracle_edges(entry["required_edges"])
+            allowed_edges = oracle_edges(entry["allowed_edges"])
+            if not required_edges <= allowed_edges:
+                raise RuntimeError("required oracle edges must also be allowed")
+            before_nodes = {node_key(value) for value in before["related"]}
+            after_nodes = {node_key(value) for value in after["related"]}
+            before_edges = edge_keys(before["adjacent_edges"])
+            after_edges = edge_keys(after["adjacent_edges"])
+            measurements.append(
+                {
+                    "false_edges_removed": len((before_edges - allowed_edges) - after_edges),
+                    "invalid_edges_after": len(after_edges - allowed_edges),
+                    "invalid_edges_before": len(before_edges - allowed_edges),
+                    "lost_required_nodes": len((required_nodes & before_nodes) - after_nodes),
+                    "new_required_nodes": len((required_nodes & after_nodes) - before_nodes),
+                    "related_after": len(after_nodes),
+                    "related_before": len(before_nodes),
+                    "repository": after["repository"],
+                    "required_edges_after": len(required_edges & after_edges),
+                    "required_edges_before": len(required_edges & before_edges),
+                    "required_edges_total": len(required_edges),
+                    "required_nodes_after": len(required_nodes & after_nodes),
+                    "required_nodes_before": len(required_nodes & before_nodes),
+                    "required_nodes_total": len(required_nodes),
+                    "unnecessary_after": len(after_nodes - required_nodes),
+                    "unnecessary_before": len(before_nodes - required_nodes),
+                    "valid_edges_after": len(after_edges & allowed_edges),
+                    "edges_after": len(after_edges),
+                }
+            )
+    controls_unchanged = control_signature(baseline["controls"]) == control_signature(
+        current["controls"]
+    )
+    all_values = [
+        *before_cases,
+        *after_cases,
+        *baseline["controls"],
+        *current["controls"],
+        baseline["canary"],
+        current["canary"],
+    ]
+    required_edge_total = sum(item["required_edges_total"] for item in measurements)
+    required_edge_after = sum(item["required_edges_after"] for item in measurements)
+    edge_total = sum(item["edges_after"] for item in measurements)
+    valid_edge_total = sum(item["valid_edges_after"] for item in measurements)
+    improved = sum(
+        item["new_required_nodes"] > 0 or item["false_edges_removed"] > 0 for item in measurements
+    )
+    gates = {
+        "affected_at_least_3": len(affected) >= 3,
+        "boundary_canary_zero": all(
+            item["boundary_canary_exposures"] == 0 and item["raw_canary_exposures"] == 0
+            for item in all_values
+        ),
+        "canonical_deterministic": cross_seed_deterministic
+        and all(item["deterministic"] for item in all_values),
+        "controls_unchanged": controls_unchanged,
+        "external_state_unchanged": all(
+            all(bool(value) for value in audit.values()) for audit in state.values()
+        ),
+        "frozen_external_inputs": all(
+            all(bool(value) for value in case["input_audit"].values())
+            for case in (*before_cases, *after_cases)
+        ),
+        "improved_cases_at_least_2": improved >= 2,
+        "invalid_edges_zero": sum(item["invalid_edges_after"] for item in measurements) == 0,
+        "no_required_neighbor_lost": sum(item["lost_required_nodes"] for item in measurements) == 0,
+        "related_cap_10": all(item["cap_ok"] for item in all_values),
+        "required_edge_precision_100": edge_total > 0 and valid_edge_total == edge_total,
+        "required_edge_recall_100": (
+            required_edge_total > 0 and required_edge_after == required_edge_total
+        ),
+        "unnecessary_not_increased": sum(item["unnecessary_after"] for item in measurements)
+        <= sum(item["unnecessary_before"] for item in measurements),
+        "worker_runtime_same": baseline["runtime"] == current["runtime"],
+    }
+    required_node_after = sum(item["required_nodes_after"] for item in measurements)
+    required_node_before = sum(item["required_nodes_before"] for item in measurements)
+    required_node_total = sum(item["required_nodes_total"] for item in measurements)
+    return {
+        "affected": [after_cases[index]["repository"] for index in affected],
+        "affected_first_4": [after_cases[index]["repository"] for index in selected],
+        "decision": "stop" if stop_early or not all(gates.values()) else "proceed",
+        "external_state": state,
+        "gates": gates,
+        "measurements": measurements,
+        "metrics": {
+            "affected_count": len(affected),
+            "boundary_canary_exposures": sum(
+                item["boundary_canary_exposures"] + item["raw_canary_exposures"]
+                for item in all_values
+            ),
+            "controls_unchanged": controls_unchanged,
+            "improved_cases": improved,
+            "invalid_edges_after": sum(item["invalid_edges_after"] for item in measurements),
+            "lost_required_nodes": sum(item["lost_required_nodes"] for item in measurements),
+            "maximum_related": max(len(item["related"]) for item in all_values),
+            "required_edge_precision": f"{valid_edge_total}/{edge_total}",
+            "required_edge_recall": f"{required_edge_after}/{required_edge_total}",
+            "required_node_recall_after": f"{required_node_after}/{required_node_total}",
+            "required_node_recall_before": f"{required_node_before}/{required_node_total}",
+            "unnecessary_after": sum(item["unnecessary_after"] for item in measurements),
+            "unnecessary_before": sum(item["unnecessary_before"] for item in measurements),
+        },
+        "oracle_sha256": oracle_digest,
+        "runtime": current["runtime"],
+    }
+
+
+def evaluate(external_root: Path) -> bytes:
+    cases = load_manifests(external_root)
+    projects = external_projects(cases)
+    before_state = {name: repository_state(path) for name, path in projects.items()}
+    error: BaseException | None = None
+    baseline: dict[str, object] = {}
+    current: dict[str, object] = {}
+    try:
+        baseline = child_result("baseline", external_root, 0)
+        current = child_result("current", external_root, 0)
+        baseline_second = child_result("baseline", external_root, 1)
+        current_second = child_result("current", external_root, 1)
+    except BaseException as caught:
+        error = caught
+    after_state = {name: repository_state(path) for name, path in projects.items()}
+    if before_state != after_state:
+        raise RuntimeError("evaluator changed an external repository")
+    if error is not None:
+        raise error
+    state_audit = {
+        name: {
+            "silobrief_state_unchanged": value["silobrief_state_sha256"]
+            == after_state[name]["silobrief_state_sha256"],
+            "status_unchanged": value["status_sha256"] == after_state[name]["status_sha256"],
+            "tracked_unchanged": value["tracked_sha256"] == after_state[name]["tracked_sha256"],
+        }
+        for name, value in before_state.items()
+    }
+    comparison = compare(
+        baseline,
+        current,
+        state_audit,
+        cross_seed_deterministic=(baseline == baseline_second and current == current_second),
+    )
+    value = {
+        "baseline": baseline,
+        "comparison": comparison,
+        "current": current,
+        "evaluator_sha256": sha256(Path(__file__).read_bytes()),
+        "manifest_sha256": {suite: digest for suite, _directory, digest in MANIFESTS},
+        "schema_version": 1,
+    }
+    rendered = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    if any(value in rendered for value in CANARY_FORBIDDEN):
+        raise RuntimeError("fixture boundary canary leaked into canonical result")
+    return rendered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument(
+        "--external-root",
+        type=Path,
+        default=ROOT.parent / "documents" / "validation",
+    )
+    parser.add_argument("--worker", choices=("baseline", "current"))
+    arguments = parser.parse_args()
+    if arguments.worker is not None:
+        sys.stdout.buffer.write(run_worker(arguments.worker, arguments.external_root.resolve()))
+        return 0
+    rendered = evaluate(arguments.external_root.resolve())
+    if arguments.check:
+        if not RESULT_PATH.is_file() or RESULT_PATH.read_bytes() != rendered:
+            raise RuntimeError("canonical result differs; run evaluator without --check")
+        print(f"canonical_sha256={sha256(rendered)}")
+        return 0
+    RESULT_PATH.write_bytes(rendered)
+    print(f"wrote {RESULT_PATH.relative_to(ROOT)} sha256={sha256(rendered)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/v1.0-scope-related-context/oracle.json
+++ b/validation/v1.0-scope-related-context/oracle.json
@@ -1,0 +1,183 @@
+{
+  "cases": [
+    {
+      "allowed_edges": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware",
+          "relation": "contained-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__",
+          "relation": "called-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+          "relation": "called-by"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware",
+          "relation": "contained-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__",
+          "relation": "called-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+          "relation": "called-by"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper"
+        }
+      ],
+      "repository": "litestar-org/litestar"
+    },
+    {
+      "allowed_edges": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin",
+          "relation": "contained-by"
+        },
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve",
+          "relation": "called-by"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin",
+          "relation": "contained-by"
+        },
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve",
+          "relation": "called-by"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve"
+        }
+      ],
+      "repository": "sanic-org/sanic"
+    },
+    {
+      "allowed_edges": [
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "black.linegen",
+          "relation": "imported-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "_hugging_power_ops_line_to_string",
+          "relation": "called-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "transform_line",
+          "relation": "referenced-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "black.trans",
+          "relation": "contained-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "CannotTransform",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_lookup",
+          "relation": "contains"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "contains"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "black.linegen",
+          "relation": "imported-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "_hugging_power_ops_line_to_string",
+          "relation": "called-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "transform_line",
+          "relation": "referenced-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "black.trans",
+          "relation": "contained-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "CannotTransform",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_lookup",
+          "relation": "contains"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "contains"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "src/black/lines.py",
+          "qualified_name": "Line.append"
+        },
+        {
+          "path": "src/blib2to3/pytree.py",
+          "qualified_name": "Leaf.clone"
+        }
+      ],
+      "repository": "psf/black"
+    }
+  ],
+  "frozen_before_interpretation": true,
+  "schema_version": 1
+}

--- a/validation/v1.0-scope-related-context/results.json
+++ b/validation/v1.0-scope-related-context/results.json
@@ -1,0 +1,3431 @@
+{
+  "baseline": {
+    "canary": {
+      "adjacent_edges": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ],
+      "boundary_canary_exposures": 0,
+      "cap_ok": true,
+      "deterministic": true,
+      "edges": 38,
+      "nodes": 10,
+      "primary": {
+        "path": "src/parcel_lab/retry.py",
+        "qualified_name": "retry_request"
+      },
+      "raw_canary_exposures": 0,
+      "related": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ]
+    },
+    "cases": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "99b7cc62e0c2cb8d24e5f546b7e34e17496c265e",
+        "deterministic": true,
+        "edges": 14455,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1793,
+        "primary": {
+          "path": "starlette/middleware/cors.py",
+          "qualified_name": "CORSMiddleware.allow_explicit_origin"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "encode/starlette",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "134869b74b6cba214284faa9f13d54b7247362c0",
+        "deterministic": true,
+        "edges": 12694,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 2057,
+        "primary": {
+          "path": "ninja/operation.py",
+          "qualified_name": "Operation._result_to_response"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "vitalik/django-ninja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "ec6f9c95443d323a8cee4d9ff5dd1bd9862f5fc8",
+        "deterministic": true,
+        "edges": 70351,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 8584,
+        "primary": {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_response_headers"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "litestar-org/litestar",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "5ef70112a1ff19c05324ff889dd30405b1002044",
+        "deterministic": true,
+        "edges": 12579,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 1866,
+        "primary": {
+          "path": "src/jinja2/environment.py",
+          "qualified_name": "Environment.get_or_select_template"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "pallets/jinja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        "deterministic": true,
+        "edges": 52222,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 7214,
+        "primary": {
+          "path": "src/_pytest/config/__init__.py",
+          "qualified_name": "Config.getoption"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "repository": "pytest-dev/pytest",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "92b74dcfe348d0e01e14d40d6c1fa47a4ee04a54",
+        "deterministic": true,
+        "edges": 41745,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 4066,
+        "primary": {
+          "path": "src/poetry/factory.py",
+          "qualified_name": "Factory.create_poetry"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "python-poetry/poetry",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "06ea505ce2b2042af26e96d35ebf159af7c0869d",
+        "deterministic": true,
+        "edges": 9457,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1661,
+        "primary": {
+          "path": "src/flask/sansio/app.py",
+          "qualified_name": "App.select_jinja_autoescape"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pallets/flask",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "0ed510d8dc9f6397878fe775ac7e2fbd0b13641f",
+        "deterministic": true,
+        "edges": 65073,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 7070,
+        "primary": {
+          "path": "aiohttp/web_response.py",
+          "qualified_name": "StreamResponse.last_modified"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "aio-libs/aiohttp",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a64dc641a8e4ad777a4602d2bdec53d736901472",
+        "deterministic": true,
+        "edges": 31450,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 4379,
+        "primary": {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin._get_process_states"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "sanic-org/sanic",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "9cb198944f8184df92217efc8b20d3fffa4b4fa0",
+        "deterministic": true,
+        "edges": 20372,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 2276,
+        "primary": {
+          "path": "rich/ansi.py",
+          "qualified_name": "AnsiDecoder.decode"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "Textualize/rich",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "contains"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "fa72105efac5c15c3a3c83c21ec6e6097c525325",
+        "deterministic": true,
+        "edges": 14181,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 1153,
+        "primary": {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "contains"
+            ]
+          }
+        ],
+        "repository": "psf/black",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a54529f06204ecb8f940d2506ff66dd1521917c8",
+        "deterministic": true,
+        "edges": 91396,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 13909,
+        "primary": {
+          "path": "pydantic/types.py",
+          "qualified_name": "SecretStr.__eq__"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pydantic/pydantic",
+        "suite": "edge-idf"
+      }
+    ],
+    "commit": "e5329b29d884d40dc7d3b14ca7fa26c83a14878b",
+    "controls": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_write_json",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "create_project",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "project_in",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "tests.test_stored_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "create_index",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 9080,
+        "name": "setup_project",
+        "nodes": 748,
+        "primary": {
+          "path": "src/silobrief/state.py",
+          "qualified_name": "setup_project"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_validated_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_walk_sources",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "CurrentIndexTests.test_loads_current_index_and_returns_source_warnings_read_only",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "ApprovedOutputTests.test_source_change_after_write_approval_blocks_output",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 9080,
+        "name": "snapshot_sources",
+        "nodes": 748,
+        "primary": {
+          "path": "src/silobrief/sources.py",
+          "qualified_name": "snapshot_sources"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      }
+    ],
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    },
+    "version": "baseline"
+  },
+  "comparison": {
+    "affected": [
+      "litestar-org/litestar",
+      "sanic-org/sanic",
+      "psf/black"
+    ],
+    "affected_first_4": [
+      "litestar-org/litestar",
+      "sanic-org/sanic",
+      "psf/black"
+    ],
+    "decision": "proceed",
+    "external_state": {
+      "Textualize/rich": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "aio-libs/aiohttp": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "encode/starlette": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "litestar-org/litestar": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pallets/flask": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pallets/jinja": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "psf/black": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pydantic/pydantic": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pytest-dev/pytest": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "python-poetry/poetry": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "sanic-org/sanic": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "vitalik/django-ninja": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      }
+    },
+    "gates": {
+      "affected_at_least_3": true,
+      "boundary_canary_zero": true,
+      "canonical_deterministic": true,
+      "controls_unchanged": true,
+      "external_state_unchanged": true,
+      "frozen_external_inputs": true,
+      "improved_cases_at_least_2": true,
+      "invalid_edges_zero": true,
+      "no_required_neighbor_lost": true,
+      "related_cap_10": true,
+      "required_edge_precision_100": true,
+      "required_edge_recall_100": true,
+      "unnecessary_not_increased": true,
+      "worker_runtime_same": true
+    },
+    "measurements": [
+      {
+        "edges_after": 3,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 1,
+        "related_after": 3,
+        "related_before": 2,
+        "repository": "litestar-org/litestar",
+        "required_edges_after": 3,
+        "required_edges_before": 2,
+        "required_edges_total": 3,
+        "required_nodes_after": 2,
+        "required_nodes_before": 1,
+        "required_nodes_total": 2,
+        "unnecessary_after": 1,
+        "unnecessary_before": 1,
+        "valid_edges_after": 3
+      },
+      {
+        "edges_after": 2,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 1,
+        "related_after": 2,
+        "related_before": 1,
+        "repository": "sanic-org/sanic",
+        "required_edges_after": 2,
+        "required_edges_before": 1,
+        "required_edges_total": 2,
+        "required_nodes_after": 1,
+        "required_nodes_before": 0,
+        "required_nodes_total": 1,
+        "unnecessary_after": 1,
+        "unnecessary_before": 1,
+        "valid_edges_after": 2
+      },
+      {
+        "edges_after": 8,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 0,
+        "related_after": 7,
+        "related_before": 7,
+        "repository": "psf/black",
+        "required_edges_after": 8,
+        "required_edges_before": 7,
+        "required_edges_total": 8,
+        "required_nodes_after": 0,
+        "required_nodes_before": 0,
+        "required_nodes_total": 2,
+        "unnecessary_after": 7,
+        "unnecessary_before": 7,
+        "valid_edges_after": 8
+      }
+    ],
+    "metrics": {
+      "affected_count": 3,
+      "boundary_canary_exposures": 0,
+      "controls_unchanged": true,
+      "improved_cases": 2,
+      "invalid_edges_after": 0,
+      "lost_required_nodes": 0,
+      "maximum_related": 10,
+      "required_edge_precision": "13/13",
+      "required_edge_recall": "13/13",
+      "required_node_recall_after": "3/5",
+      "required_node_recall_before": "1/5",
+      "unnecessary_after": 9,
+      "unnecessary_before": 9
+    },
+    "oracle_sha256": "39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1",
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    }
+  },
+  "current": {
+    "canary": {
+      "adjacent_edges": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ],
+      "boundary_canary_exposures": 0,
+      "cap_ok": true,
+      "deterministic": true,
+      "edges": 38,
+      "nodes": 10,
+      "primary": {
+        "path": "src/parcel_lab/retry.py",
+        "qualified_name": "retry_request"
+      },
+      "raw_canary_exposures": 0,
+      "related": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ]
+    },
+    "cases": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "99b7cc62e0c2cb8d24e5f546b7e34e17496c265e",
+        "deterministic": true,
+        "edges": 14456,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1793,
+        "primary": {
+          "path": "starlette/middleware/cors.py",
+          "qualified_name": "CORSMiddleware.allow_explicit_origin"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "encode/starlette",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "134869b74b6cba214284faa9f13d54b7247362c0",
+        "deterministic": true,
+        "edges": 12694,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 2057,
+        "primary": {
+          "path": "ninja/operation.py",
+          "qualified_name": "Operation._result_to_response"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "vitalik/django-ninja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "ec6f9c95443d323a8cee4d9ff5dd1bd9862f5fc8",
+        "deterministic": true,
+        "edges": 70352,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 8584,
+        "primary": {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_response_headers"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "litestar-org/litestar",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "5ef70112a1ff19c05324ff889dd30405b1002044",
+        "deterministic": true,
+        "edges": 12579,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 1866,
+        "primary": {
+          "path": "src/jinja2/environment.py",
+          "qualified_name": "Environment.get_or_select_template"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "pallets/jinja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        "deterministic": true,
+        "edges": 52229,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 7214,
+        "primary": {
+          "path": "src/_pytest/config/__init__.py",
+          "qualified_name": "Config.getoption"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "repository": "pytest-dev/pytest",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "92b74dcfe348d0e01e14d40d6c1fa47a4ee04a54",
+        "deterministic": true,
+        "edges": 41746,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 4066,
+        "primary": {
+          "path": "src/poetry/factory.py",
+          "qualified_name": "Factory.create_poetry"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "python-poetry/poetry",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "06ea505ce2b2042af26e96d35ebf159af7c0869d",
+        "deterministic": true,
+        "edges": 9457,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1661,
+        "primary": {
+          "path": "src/flask/sansio/app.py",
+          "qualified_name": "App.select_jinja_autoescape"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pallets/flask",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "0ed510d8dc9f6397878fe775ac7e2fbd0b13641f",
+        "deterministic": true,
+        "edges": 65077,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 7070,
+        "primary": {
+          "path": "aiohttp/web_response.py",
+          "qualified_name": "StreamResponse.last_modified"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "aio-libs/aiohttp",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin.serve",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a64dc641a8e4ad777a4602d2bdec53d736901472",
+        "deterministic": true,
+        "edges": 31450,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 4379,
+        "primary": {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin._get_process_states"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin.serve",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "sanic-org/sanic",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "9cb198944f8184df92217efc8b20d3fffa4b4fa0",
+        "deterministic": true,
+        "edges": 20372,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 2276,
+        "primary": {
+          "path": "rich/ansi.py",
+          "qualified_name": "AnsiDecoder.decode"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "Textualize/rich",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "calls",
+              "contains"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "fa72105efac5c15c3a3c83c21ec6e6097c525325",
+        "deterministic": true,
+        "edges": 14181,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 1153,
+        "primary": {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "calls",
+              "contains"
+            ]
+          }
+        ],
+        "repository": "psf/black",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a54529f06204ecb8f940d2506ff66dd1521917c8",
+        "deterministic": true,
+        "edges": 91399,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 13909,
+        "primary": {
+          "path": "pydantic/types.py",
+          "qualified_name": "SecretStr.__eq__"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pydantic/pydantic",
+        "suite": "edge-idf"
+      }
+    ],
+    "commit": "ab98e39910d9dc70eacdad3fcb4df4d5e7b579de",
+    "controls": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_write_json",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "create_project",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "project_in",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "tests.test_stored_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "create_index",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 10432,
+        "name": "setup_project",
+        "nodes": 831,
+        "primary": {
+          "path": "src/silobrief/state.py",
+          "qualified_name": "setup_project"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_validated_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_walk_sources",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "CurrentIndexTests.test_loads_current_index_and_returns_source_warnings_read_only",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "ApprovedOutputTests.test_source_change_after_write_approval_blocks_output",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 10432,
+        "name": "snapshot_sources",
+        "nodes": 831,
+        "primary": {
+          "path": "src/silobrief/sources.py",
+          "qualified_name": "snapshot_sources"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      }
+    ],
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    },
+    "version": "current"
+  },
+  "evaluator_sha256": "124d0e7e68c5a3352a47611ab0ea165a0373b3b832646f956d48035093238d78",
+  "manifest_sha256": {
+    "edge-idf": "1b45b645362a26a24e3d89805282b4dfd14c583b527ebe326698fbce4f0b5eaf",
+    "ranking": "6fe09278638ccede6e4be981fcc8b2fd5fedcd9288dbcc780210032bce616736"
+  },
+  "schema_version": 1
+}


### PR DESCRIPTION
### 무엇을 검증했나

#182에서 바로잡은 Python 범위 edge가 사용자가 primary symbol을 고른 뒤 표시되는 one-hop 관련 코드에 실제로 도움이 되는지 확인했습니다.

- 기준 commit `e5329b2`와 수정 commit `ab98e39`를 같은 evaluator로 비교했습니다.
- ranking은 사용하지 않고 기존 외부 holdout 12개의 primary symbol을 직접 선택했습니다.
- 필수·허용 이웃은 제품의 before/after 출력을 보지 않은 별도 검토자가 prompt와 reference patch로 정했습니다.
- 화면의 10개 제한 목록과 원본 one-hop edge 정확도를 따로 측정했습니다.
- 각 고정 commit의 Git blob만 canonical 입력으로 사용했고, 외부 저장소와 기존 `.silobrief` 상태가 바뀌지 않았는지 전후로 확인했습니다.

Refs #185

### 결과

판정은 `proceed`이며 사전에 정한 gate 14개를 모두 통과했습니다.

- 영향 과제 3개: Litestar, Sanic, Black
- 실질 개선 2개: Litestar의 nested `send_wrapper`, Sanic의 `StartupMixin.serve`
- 정적으로 해석 가능한 edge precision/recall: 13/13
- 필수 관련 노드 Recall@10: 1/5 → 3/5
- 필수 이웃 손실과 잘못된 현재 edge: 0
- 불필요한 제안: 9 → 9
- 최대 관련 제안: 10
- boundary canary 노출: 0
- control, 입력 순서, hash seed 결정성: 통과

Canonical result SHA-256은 `0c65bd3a7d64bc5218583b08c332029e384bda63bcd42337999c92ffd0171923`입니다.

### 해석

결과는 scope-correct one-hop 구현을 유지할 근거입니다. graph DB, multi-hop, LLM reranker를 추가할 근거는 아닙니다. Black에서 필요한 `Line.append`와 `Leaf.clone`은 receiver type을 정적으로 찾지 못해 전후 모두 빠졌습니다. 이 한계는 별도 자료가 쌓이기 전까지 확장 구현으로 이어가지 않습니다.

### 확인한 내용

- evaluator 최초 실행과 `--check` 재계산의 canonical SHA 일치
- 집중 회귀 테스트 64개 통과
- 전체 unittest 234개 통과, 7개 환경상 skip
- Ruff lint와 format 통과
- mypy strict 통과
- 최종 보안 검토에서 중간·높음 잔여 문제 없음
- 제품 코드 변경 0줄