### PR TITLE
release: siloBrief v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep indexing Pyodide and notebook-style Python files that use top-level asynchronous syntax
+  while preserving scope metadata (#188).
+
 ## [1.0.3] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-08-19
+
+### Added
+
+- Record a frozen 12-task comparison of scope-correct one-hop related context. Two of the three
+  affected tasks gained required context without adding unnecessary proposals (#185).
+
 ### Fixed
 
 - Keep indexing Pyodide and notebook-style Python files that use top-level asynchronous syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Keep indexing Pyodide and notebook-style Python files that use top-level asynchronous syntax
   while preserving scope metadata (#188).
+- Resolve definitions, imports, method receivers, and boundary placeholders using Python lexical
+  scopes and source-order rebinding rules (#182). Existing projects should run `sb init` after
+  upgrading to rebuild the derived index with corrected graph edges.
 
 ## [1.0.3] - 2026-08-18
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="릴리스 v1.0.3"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.4"><img src="https://img.shields.io/badge/release-v1.0.4-4f46e5" alt="릴리스 v1.0.4"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.0.3
+siloBrief 1.0.4
 ```
 
 ### 실습 예제
@@ -191,7 +191,7 @@ siloBrief는 등록된 제외 경로를 읽지 않고, 색인을 만들 때 심�
 
 ## 검증 현황
 
-최신 공개 버전은 v1.0.3이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.0.4이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.
@@ -207,6 +207,7 @@ Django Ninja, pytest, Jinja 저장소에서 Python 소스를 바꾸지 않고 �
 - [v0.8 연관 맥락 결과](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [1인 현장 시험 절차](validation/v0.9/FIELD_TRIAL.md)
 - [v1.0.1 릴리스 검증](validation/v1.0.1/RELEASE_VERIFICATION.md)
+- [v1.0 범위 기반 연관 코드 검증](validation/v1.0-scope-related-context/REPORT.md)
 
 ## 종료 코드
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.3"><img src="https://img.shields.io/badge/release-v1.0.3-4f46e5" alt="Release v1.0.3"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.0.4"><img src="https://img.shields.io/badge/release-v1.0.4-4f46e5" alt="Release v1.0.4"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -48,7 +48,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.0.3
+siloBrief 1.0.4
 ```
 
 ### Practice project
@@ -192,7 +192,7 @@ organization's disclosure rules before sharing it.
 
 ## Validation status
 
-The latest public release is v1.0.3 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.0.4 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.
@@ -208,6 +208,7 @@ across other AI models or private projects.
 - [v0.8 related-context result](validation/v0.8/RELATED_CONTEXT_RESULT.md)
 - [Solo field-trial procedure](validation/v0.9/FIELD_TRIAL.md)
 - [v1.0.1 release verification](validation/v1.0.1/RELEASE_VERIFICATION.md)
+- [v1.0 scope-related context study](validation/v1.0-scope-related-context/REPORT.md)
 
 ## Exit codes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.0.3"
+version = "1.0.4"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/silobrief/boundary_placeholders.py
+++ b/src/silobrief/boundary_placeholders.py
@@ -71,6 +71,9 @@ class BoundaryMatcher:
                 return self._match_module(f"{origin}{suffix}")
         return None
 
+    def match_resolved(self, target: str) -> BoundaryPlaceholder | None:
+        return self._match_module(target)
+
     def _visible_origins(self, context: str | None) -> tuple[tuple[str, str], ...]:
         contexts: list[str | None] = []
         current = context

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -11,7 +11,7 @@ from silobrief.boundary_placeholders import (
     BoundaryPlaceholder,
     import_target,
 )
-from silobrief.python_structure import ImportEntry, ModuleStructure, SymbolUse
+from silobrief.python_structure import Definition, ImportEntry, ModuleStructure, SymbolUse
 from silobrief.search_tokens import extract_scoped_source_text_tokens, normalize_search_tokens
 from silobrief.sources import SourceFile, SourceSnapshot
 from silobrief.state import BoundaryData, ConfigData
@@ -66,6 +66,18 @@ class _ImportBinding:
     context: str | None
     visible: str
     target: str
+    line: int
+    column: int
+    conditional: bool
+    deferred: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ScopeBinding:
+    target_id: str | None = None
+    imported_target: str | None = None
+    falls_through: bool = False
+    unknown: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -263,42 +275,283 @@ def _add_use_edges(
 ) -> None:
     for use in uses:
         source_id = _context_id(context, use.context)
-        placeholder = context.boundary_matcher.match_use(use.target, use.context)
-        target: str | BoundaryPlaceholder = placeholder or use.target
-        target_id = (
-            None
-            if placeholder is not None
-            else _resolve_target(context, use.context, use.target, global_targets)
+        target, target_id = _resolve_use_target(
+            context,
+            use.context,
+            use.target,
+            use.line,
+            use.column,
+            use.skip_class_scope,
+            use.synthetic_local,
+            use.lookup_limit,
+            global_targets,
         )
         edges.add(IndexEdge(source_id, kind, target, target_id))
 
 
-def _resolve_target(
+def _resolve_use_target(
     context: _ModuleContext,
     source_context: str | None,
     target: str,
+    line: int,
+    column: int,
+    skip_class_scope: bool,
+    synthetic_local: bool,
+    lookup_limit: tuple[int, int] | None,
     global_targets: dict[str, str],
-) -> str | None:
-    if source_context is not None and target.startswith("self."):
-        owner, separator, _ = source_context.rpartition(".")
-        if separator:
-            candidate = f"{owner}.{target.removeprefix('self.')}"
-            if candidate in context.context_ids:
-                return context.context_ids[candidate]
+) -> tuple[str | BoundaryPlaceholder, str | None]:
+    if synthetic_local:
+        return target, None
+    use_position = (*lookup_limit, -1) if lookup_limit is not None else (line, column, 2)
+    possible: list[_ScopeBinding] = []
+    saw_binding = False
+    for scope in _lexical_scopes(context, source_context, target, line, skip_class_scope):
+        bindings = _resolve_scope_bindings(
+            context,
+            scope,
+            source_context,
+            target,
+            line,
+            use_position,
+        )
+        if bindings is None:
+            continue
+        saw_binding = True
+        for binding in bindings:
+            if binding.imported_target is None:
+                continue
+            placeholder = context.boundary_matcher.match_resolved(binding.imported_target)
+            if placeholder is not None:
+                return placeholder, None
+        possible.extend(binding for binding in bindings if not binding.falls_through)
+        if not any(binding.falls_through for binding in bindings):
+            return _binding_result(target, possible, global_targets)
+    direct_placeholder = context.boundary_matcher.match_resolved(target)
+    if direct_placeholder is not None:
+        return direct_placeholder, None
+    if saw_binding:
+        possible.append(_ScopeBinding())
+        return _binding_result(target, possible, global_targets)
+    return target, None
 
-    if source_context is not None:
-        parts = source_context.split(".")
-        for length in range(len(parts) - 1, -1, -1):
-            prefix = ".".join(parts[:length])
-            candidate = f"{prefix}.{target}" if prefix else target
-            if candidate in context.context_ids:
-                return context.context_ids[candidate]
-    if target in context.context_ids:
-        return context.context_ids[target]
-    imported_target = _resolve_import_binding(context, source_context, target)
-    if imported_target is not None:
-        return global_targets.get(imported_target)
-    return global_targets.get(target)
+
+def _lexical_scopes(
+    context: _ModuleContext,
+    source_context: str | None,
+    target: str,
+    line: int,
+    skip_class_scope: bool,
+) -> tuple[str | None, ...]:
+    if source_context is None:
+        return (None,)
+    root = target.split(".", 1)[0]
+    result: list[str | None] = []
+    current: str | None = source_context
+    nonlocal_lookup = False
+    while current is not None:
+        definition = _definition_at(context, current, line)
+        kind = definition.kind if definition is not None else None
+        hidden_class = skip_class_scope and kind == "class"
+        visible = kind == "function" or current == source_context and not hidden_class
+        if visible:
+            result.append(current)
+            if _has_declaration(context, current, line, root, "global"):
+                if not nonlocal_lookup:
+                    result.append(None)
+                return tuple(result)
+            if _has_declaration(context, current, line, root, "nonlocal"):
+                nonlocal_lookup = True
+        current = _structural_parent(current)
+    if not nonlocal_lookup:
+        result.append(None)
+    return tuple(result)
+
+
+def _resolve_scope_bindings(
+    context: _ModuleContext,
+    scope: str | None,
+    source_context: str | None,
+    target: str,
+    line: int,
+    use_position: tuple[int, int, int],
+) -> tuple[_ScopeBinding, ...] | None:
+    root = target.split(".", 1)[0]
+    scope_definition = _definition_at(context, scope, line) if scope is not None else None
+    candidates: list[tuple[tuple[int, int, int], _ScopeBinding, bool]] = []
+    deferred_bindings: list[_ScopeBinding] = []
+    for candidate_definition in context.structure.definitions:
+        if (
+            _structural_parent(candidate_definition.qualified_name) != scope
+            or candidate_definition.name != root
+            or not _inside_definition(scope_definition, candidate_definition.line)
+        ):
+            continue
+        suffix = target[len(root) :]
+        if suffix and candidate_definition.kind == "class":
+            target_id = context.context_ids.get(f"{candidate_definition.qualified_name}{suffix}")
+        elif suffix:
+            target_id = None
+        else:
+            target_id = stable_node_id(
+                context.structure.path,
+                candidate_definition.kind,
+                candidate_definition.qualified_name,
+            )
+        candidates.append(
+            (
+                (candidate_definition.line, candidate_definition.column, 0),
+                _ScopeBinding(target_id=target_id, unknown=target_id is None),
+                candidate_definition.conditional,
+            )
+        )
+    for import_binding in context.import_bindings:
+        if import_binding.context != scope or not _inside_definition(
+            scope_definition, import_binding.line
+        ):
+            continue
+        imported_target = _imported_target(import_binding, target)
+        if imported_target is None:
+            continue
+        candidate = (
+            (import_binding.line, import_binding.column, 1),
+            _ScopeBinding(imported_target=imported_target),
+            import_binding.conditional,
+        )
+        if import_binding.deferred:
+            deferred_bindings.append(candidate[1])
+        else:
+            candidates.append(candidate)
+    if (parameter := _parameter_binding(context, scope, target, line)) is not None:
+        candidates.append(((0, 0, 0), parameter, False))
+
+    direct_scope = scope == source_context
+    declared = _has_declaration(context, scope, line, root, "global") or _has_declaration(
+        context, scope, line, root, "nonlocal"
+    )
+    falls_through = declared or (
+        direct_scope and scope_definition is not None and scope_definition.kind == "class"
+    )
+    visible_candidates = candidates
+    if direct_scope:
+        visible_candidates = [candidate for candidate in candidates if candidate[0] <= use_position]
+    if visible_candidates:
+        if direct_scope:
+            possible = list(_possible_bindings(visible_candidates, falls_through))
+        else:
+            entry_position = _scope_entry_position(context, scope, source_context, line)
+            missing = _ScopeBinding(falls_through=falls_through)
+            if entry_position is None:
+                possible = [missing, *(item[1] for item in candidates)]
+            else:
+                before = [item for item in visible_candidates if item[0] < entry_position]
+                possible = list(_possible_bindings(before, falls_through)) if before else [missing]
+                possible.extend(item[1] for item in visible_candidates if item[0] >= entry_position)
+        possible.extend(deferred_bindings)
+        return tuple(dict.fromkeys(possible))
+
+    if (
+        direct_scope
+        and candidates
+        and not declared
+        and (scope is None or scope_definition is not None and scope_definition.kind == "function")
+    ):
+        return tuple(dict.fromkeys([_ScopeBinding(), *deferred_bindings]))
+    if deferred_bindings:
+        return tuple(dict.fromkeys([_ScopeBinding(falls_through=True), *deferred_bindings]))
+    return None
+
+
+def _possible_bindings(
+    candidates: list[tuple[tuple[int, int, int], _ScopeBinding, bool]],
+    missing_falls_through: bool = False,
+) -> tuple[_ScopeBinding, ...]:
+    possible: list[_ScopeBinding] = []
+    for _, binding, conditional in sorted(candidates, key=lambda candidate: candidate[0]):
+        if conditional:
+            if not possible:
+                possible.append(_ScopeBinding(falls_through=missing_falls_through))
+            possible.append(binding)
+        else:
+            possible = [binding]
+    return tuple(dict.fromkeys(possible))
+
+
+def _binding_result(
+    target: str,
+    bindings: list[_ScopeBinding],
+    global_targets: dict[str, str],
+) -> tuple[str, str | None]:
+    concrete = tuple(
+        binding
+        for binding in dict.fromkeys(bindings)
+        if binding.target_id is not None or binding.imported_target is not None or binding.unknown
+    )
+    if len(concrete) != 1 or concrete[0].unknown:
+        return target, None
+    if concrete[0].imported_target is not None:
+        return target, global_targets.get(concrete[0].imported_target)
+    return target, concrete[0].target_id
+
+
+def _scope_entry_position(
+    context: _ModuleContext,
+    scope: str | None,
+    source_context: str | None,
+    line: int,
+) -> tuple[int, int, int] | None:
+    if source_context is None:
+        return None
+    prefix = f"{scope}." if scope is not None else ""
+    if not source_context.startswith(prefix):
+        return None
+    child = source_context[len(prefix) :].split(".", 1)[0]
+    definition = _definition_at(context, f"{prefix}{child}", line)
+    if definition is None:
+        return None
+    if definition.kind == "class" and source_context != definition.qualified_name:
+        return (definition.end_line + 1, definition.column, 2)
+    return (definition.line, definition.column, 2)
+
+
+def _parameter_binding(
+    context: _ModuleContext,
+    scope: str | None,
+    target: str,
+    line: int,
+) -> _ScopeBinding | None:
+    if scope is None:
+        return None
+    receiver, separator, member = target.partition(".")
+    definition = _definition_at(context, scope, line)
+    if definition is None or receiver not in definition.parameters:
+        return None
+    if not separator or receiver not in {"self", "cls"}:
+        return _ScopeBinding(unknown=True)
+    owner = _structural_parent(scope)
+    owner_definition = _definition_at(context, owner, line) if owner is not None else None
+    if owner_definition is None or owner_definition.kind != "class":
+        return _ScopeBinding(unknown=True)
+    target_id = context.context_ids.get(f"{owner}.{member}")
+    return _ScopeBinding(target_id=target_id, unknown=target_id is None)
+
+
+def _structural_parent(context: str) -> str | None:
+    return context.rpartition(".")[0] or None
+
+
+def _definition_at(
+    context: _ModuleContext,
+    qualified_name: str,
+    line: int,
+) -> Definition | None:
+    for definition in context.structure.definitions:
+        if definition.qualified_name == qualified_name and _inside_definition(definition, line):
+            return definition
+    return None
+
+
+def _inside_definition(definition: Definition | None, line: int) -> bool:
+    return definition is None or definition.start_line <= line <= definition.end_line
 
 
 def _context_id(context: _ModuleContext, qualified_name: str | None) -> str:
@@ -328,21 +581,32 @@ def _import_bindings(
     source_path: str,
     imports: tuple[ImportEntry, ...],
 ) -> tuple[_ImportBinding, ...]:
-    bindings: dict[str | None, dict[str, str]] = {}
-    for imported in imports:
-        target = _resolved_import_target(module_name, source_path, imported)
-        visible = _visible_import_binding(imported)
-        if target is None or visible is None:
-            continue
-        bindings.setdefault(imported.context, {})[visible] = target
-
     result: list[_ImportBinding] = []
-    for context in sorted(bindings, key=lambda value: value or ""):
-        for visible, target in sorted(
-            bindings[context].items(),
-            key=lambda item: (-len(item[0].split(".")), item[0], item[1]),
-        ):
-            result.append(_ImportBinding(context, visible, target))
+    for imported in imports:
+        resolved_target = _resolved_import_target(module_name, source_path, imported)
+        visible = _visible_import_binding(imported)
+        if resolved_target is None or visible is None:
+            continue
+        target = _import_binding_target(imported, resolved_target)
+        scopes = (
+            (imported.context, imported.conditional, False),
+            *(
+                (item.context, item.conditional, item.deferred)
+                for item in imported.projected_binding_scopes
+            ),
+        )
+        for scope, conditional, deferred in scopes:
+            result.append(
+                _ImportBinding(
+                    scope,
+                    visible,
+                    target,
+                    imported.line,
+                    imported.column,
+                    conditional,
+                    deferred,
+                )
+            )
     return tuple(result)
 
 
@@ -378,28 +642,39 @@ def _visible_import_binding(imported: ImportEntry) -> str | None:
         return None if imported.name == "*" else imported.name
     if imported.module is None:
         return None
-    return imported.module
+    return imported.module.split(".", 1)[0]
 
 
-def _resolve_import_binding(
+def _import_binding_target(imported: ImportEntry, resolved_target: str) -> str:
+    if imported.alias is None and imported.name is None:
+        return resolved_target.split(".", 1)[0]
+    return resolved_target
+
+
+def _imported_target(binding: _ImportBinding, target: str) -> str | None:
+    if target == binding.visible:
+        return binding.target
+    if target.startswith(f"{binding.visible}."):
+        return f"{binding.target}{target[len(binding.visible) :]}"
+    return None
+
+
+def _has_declaration(
     context: _ModuleContext,
-    source_context: str | None,
-    target: str,
-) -> str | None:
-    current = source_context
-    while True:
-        for binding in context.import_bindings:
-            if binding.context != current:
-                continue
-            if target == binding.visible:
-                return binding.target
-            if target.startswith(f"{binding.visible}."):
-                return f"{binding.target}{target[len(binding.visible) :]}"
-        if current is None:
-            return None
-        current, separator, _ = current.rpartition(".")
-        if not separator:
-            current = None
+    scope: str | None,
+    line: int,
+    name: str,
+    kind: Literal["global", "nonlocal"],
+) -> bool:
+    definition = _definition_at(context, scope, line) if scope is not None else None
+    return any(
+        declaration.kind == kind
+        and declaration.context == scope
+        and declaration.name == name
+        and definition is not None
+        and definition.start_line <= declaration.line <= definition.end_line
+        for declaration in context.structure.declarations
+    )
 
 
 def _import_search_values(

--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -7,6 +7,7 @@ from typing import Literal, TypeAlias
 from silobrief.sources import SourceFile, SourceSnapshot
 
 DefinitionKind: TypeAlias = Literal["class", "function"]
+DeclarationKind: TypeAlias = Literal["global", "nonlocal"]
 
 
 class PythonParseError(Exception):
@@ -46,6 +47,8 @@ class Definition:
     column: int
     start_line: int
     end_line: int
+    parameters: tuple[str, ...] = ()
+    conditional: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,12 +60,25 @@ class ImportEntry:
     context: str | None
     line: int
     column: int
+    conditional: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class SymbolUse:
     context: str | None
     target: str
+    line: int
+    column: int
+    skip_class_scope: bool = False
+    synthetic_local: bool = False
+    lookup_limit: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeDeclaration:
+    kind: DeclarationKind
+    name: str
+    context: str | None
     line: int
     column: int
 
@@ -74,6 +90,7 @@ class ModuleStructure:
     imports: tuple[ImportEntry, ...]
     calls: tuple[SymbolUse, ...]
     references: tuple[SymbolUse, ...]
+    declarations: tuple[ScopeDeclaration, ...]
 
 
 def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
@@ -102,6 +119,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
         imports=tuple(visitor.imports),
         calls=tuple(visitor.calls),
         references=tuple(visitor.references),
+        declarations=tuple(visitor.declarations),
     )
 
 
@@ -111,7 +129,11 @@ class _StructureVisitor(ast.NodeVisitor):
         self.imports: list[ImportEntry] = []
         self.calls: list[SymbolUse] = []
         self.references: list[SymbolUse] = []
+        self.declarations: list[ScopeDeclaration] = []
         self._contexts: list[str] = []
+        self._conditional_depth = 0
+        self._synthetic_scopes: list[set[str]] = []
+        self._lookup_limit: tuple[int, int] | None = None
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self._visit_definition(node, "class", is_async=False)
@@ -134,6 +156,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     context=self._context,
                     line=line,
                     column=column,
+                    conditional=self._conditional_depth > 0,
                 )
             )
 
@@ -149,6 +172,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     context=self._context,
                     line=line,
                     column=column,
+                    conditional=self._conditional_depth > 0,
                 )
             )
 
@@ -158,7 +182,7 @@ class _StructureVisitor(ast.NodeVisitor):
             self.visit(node.func)
         else:
             line, column = _location(node)
-            self.calls.append(SymbolUse(self._context, target, line, column))
+            self.calls.append(self._symbol_use(target, line, column))
 
         for argument in node.args:
             self.visit(argument)
@@ -170,14 +194,65 @@ class _StructureVisitor(ast.NodeVisitor):
             target = _dotted_name(node)
             if target is not None:
                 line, column = _location(node)
-                self.references.append(SymbolUse(self._context, target, line, column))
+                self.references.append(self._symbol_use(target, line, column))
                 return
         self.generic_visit(node)
 
     def visit_Name(self, node: ast.Name) -> None:
         if isinstance(node.ctx, ast.Load):
             line, column = _location(node)
-            self.references.append(SymbolUse(self._context, node.id, line, column))
+            self.references.append(self._symbol_use(node.id, line, column))
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self._visit_synthetic(node.body, set(_argument_names(node.args)))
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, (node.elt,))
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, (node.key, node.value))
+
+    def visit_If(self, node: ast.If) -> None:
+        self._visit_conditional(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_conditional(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_conditional(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self._visit_conditional(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._visit_conditional(node)
+
+    def visit_TryStar(self, node: ast.AST) -> None:
+        self._visit_conditional(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self._visit_conditional(node)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_conditional(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_conditional(node)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self._record_declarations("global", node)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self._record_declarations("nonlocal", node)
 
     def _visit_definition(
         self,
@@ -200,14 +275,24 @@ class _StructureVisitor(ast.NodeVisitor):
                 column,
                 start_line,
                 end_line,
+                _function_parameters(node),
+                self._conditional_depth > 0,
             )
         )
-        self._visit_definition_header(node)
+        previous_limit = self._lookup_limit
+        self._lookup_limit = (line, column)
+        try:
+            self._visit_definition_header(node)
+        finally:
+            self._lookup_limit = previous_limit
         self._contexts.append(qualified_name)
+        previous_conditional_depth = self._conditional_depth
+        self._conditional_depth = 0
         try:
             for statement in node.body:
                 self.visit(statement)
         finally:
+            self._conditional_depth = previous_conditional_depth
             self._contexts.pop()
 
     def _visit_definition_header(
@@ -222,6 +307,66 @@ class _StructureVisitor(ast.NodeVisitor):
                 for item in value:
                     if isinstance(item, ast.AST):
                         self.visit(item)
+
+    def _record_declarations(
+        self,
+        kind: DeclarationKind,
+        node: ast.Global | ast.Nonlocal,
+    ) -> None:
+        line, column = _location(node)
+        self.declarations.extend(
+            ScopeDeclaration(kind, name, self._context, line, column) for name in node.names
+        )
+
+    def _symbol_use(self, target: str, line: int, column: int) -> SymbolUse:
+        root = target.split(".", 1)[0]
+        return SymbolUse(
+            self._context,
+            target,
+            line,
+            column,
+            skip_class_scope=bool(self._synthetic_scopes),
+            synthetic_local=any(root in scope for scope in reversed(self._synthetic_scopes)),
+            lookup_limit=self._lookup_limit,
+        )
+
+    def _visit_synthetic(self, node: ast.AST, names: set[str]) -> None:
+        self._synthetic_scopes.append(names)
+        try:
+            self.visit(node)
+        finally:
+            self._synthetic_scopes.pop()
+
+    def _visit_comprehension(
+        self,
+        generators: list[ast.comprehension],
+        results: tuple[ast.expr, ...],
+    ) -> None:
+        first, *remaining = generators
+        self.visit(first.iter)
+        names = _bound_names(first.target)
+        self._synthetic_scopes.append(names)
+        try:
+            self.visit(first.target)
+            for condition in first.ifs:
+                self.visit(condition)
+            for generator in remaining:
+                self.visit(generator.iter)
+                names.update(_bound_names(generator.target))
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result in results:
+                self.visit(result)
+        finally:
+            self._synthetic_scopes.pop()
+
+    def _visit_conditional(self, node: ast.AST) -> None:
+        self._conditional_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._conditional_depth -= 1
 
     @property
     def _context(self) -> str | None:
@@ -239,6 +384,32 @@ def _dotted_name(node: ast.expr) -> str | None:
     parts.append(current.id)
     parts.reverse()
     return ".".join(parts)
+
+
+def _function_parameters(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[str, ...]:
+    return () if isinstance(node, ast.ClassDef) else _argument_names(node.args)
+
+
+def _argument_names(arguments: ast.arguments) -> tuple[str, ...]:
+    names = [argument.arg for argument in (*arguments.posonlyargs, *arguments.args)]
+    if arguments.vararg is not None:
+        names.append(arguments.vararg.arg)
+    names.extend(argument.arg for argument in arguments.kwonlyargs)
+    if arguments.kwarg is not None:
+        names.append(arguments.kwarg.arg)
+    return tuple(names)
+
+
+def _bound_names(node: ast.expr) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return set().union(*(_bound_names(item) for item in node.elts))
+    if isinstance(node, ast.Starred):
+        return _bound_names(node.value)
+    return set()
 
 
 def _location(node: ast.stmt | ast.expr) -> tuple[int, int]:

--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -115,7 +115,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
     try:
         tree = ast.parse(source.content, filename=source.path, mode="exec")
         encoding, _ = tokenize.detect_encoding(io.BytesIO(source.content).readline)
-        symbols = symtable.symtable(source.content.decode(encoding), source.path, "exec")
+        symbols = _scope_symbol_table(source.content.decode(encoding), source.path)
     except SyntaxError as error:
         raise PythonParseError(
             path=source.path,
@@ -134,6 +134,63 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
         references=tuple(visitor.references),
         declarations=tuple(visitor.declarations),
     )
+
+
+def _scope_symbol_table(source: str, path: str) -> symtable.SymbolTable:
+    try:
+        return symtable.symtable(source, path, "exec")
+    except SyntaxError as original_error:
+        try:
+            compile(
+                source,
+                path,
+                "exec",
+                flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+                dont_inherit=True,
+            )
+        except SyntaxError:
+            raise original_error from None
+        try:
+            return symtable.symtable(_without_async_keywords(source), path, "exec")
+        except (RuntimeError, SyntaxError):
+            raise original_error from None
+
+
+def _without_async_keywords(source: str) -> str:
+    lines = list(io.StringIO(source))
+    edits: dict[int, list[tuple[int, int, str]]] = {}
+    tokens = tuple(tokenize.generate_tokens(io.StringIO(source).readline))
+    for index, token in enumerate(tokens):
+        if token.type != tokenize.NAME or token.string not in {"async", "await"}:
+            continue
+        replacement = "+    "
+        if token.string == "async":
+            following = next(
+                candidate
+                for candidate in tokens[index + 1 :]
+                if candidate.type
+                not in {
+                    tokenize.COMMENT,
+                    tokenize.DEDENT,
+                    tokenize.INDENT,
+                    tokenize.NEWLINE,
+                    tokenize.NL,
+                }
+            )
+            if following.string not in {"def", "for", "with"}:
+                raise RuntimeError("unexpected async syntax while building symbol table")
+            replacement = following.string.ljust(len(token.string))
+            edits.setdefault(following.start[0] - 1, []).append(
+                (following.start[1], following.end[1], " " * len(following.string))
+            )
+        edits.setdefault(token.start[0] - 1, []).append((token.start[1], token.end[1], replacement))
+    for line, ranges in edits.items():
+        for start, end, replacement in sorted(ranges, reverse=True):
+            lines[line] = f"{lines[line][:start]}{replacement}{lines[line][end:]}"
+    rewritten = "".join(lines)
+    if len(rewritten) != len(source):
+        raise RuntimeError("symbol-table rewrite changed source positions")
+    return rewritten
 
 
 class _StructureVisitor(ast.NodeVisitor):

--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import ast
+import io
+import symtable
+import tokenize
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
@@ -52,6 +55,13 @@ class Definition:
 
 
 @dataclass(frozen=True, slots=True)
+class ImportBindingScope:
+    context: str | None
+    conditional: bool = False
+    deferred: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class ImportEntry:
     module: str | None
     name: str | None
@@ -61,6 +71,7 @@ class ImportEntry:
     line: int
     column: int
     conditional: bool = False
+    projected_binding_scopes: tuple[ImportBindingScope, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,6 +114,8 @@ def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
 def extract_module_structure(source: SourceFile) -> ModuleStructure:
     try:
         tree = ast.parse(source.content, filename=source.path, mode="exec")
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(source.content).readline)
+        symbols = symtable.symtable(source.content.decode(encoding), source.path, "exec")
     except SyntaxError as error:
         raise PythonParseError(
             path=source.path,
@@ -111,7 +124,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
             reason=error.msg,
         ) from error
 
-    visitor = _StructureVisitor()
+    visitor = _StructureVisitor(symbols)
     visitor.visit(tree)
     return ModuleStructure(
         path=source.path,
@@ -124,13 +137,17 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
 
 
 class _StructureVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
+    def __init__(self, symbols: symtable.SymbolTable) -> None:
         self.definitions: list[Definition] = []
         self.imports: list[ImportEntry] = []
         self.calls: list[SymbolUse] = []
         self.references: list[SymbolUse] = []
         self.declarations: list[ScopeDeclaration] = []
         self._contexts: list[str] = []
+        self._context_kinds: list[DefinitionKind] = []
+        self._context_conditionals: list[bool] = []
+        self._scope_declarations: list[dict[str, DeclarationKind]] = []
+        self._symbol_tables = [symbols]
         self._conditional_depth = 0
         self._synthetic_scopes: list[set[str]] = []
         self._lookup_limit: tuple[int, int] | None = None
@@ -157,6 +174,9 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
+                    projected_binding_scopes=self._projected_import_scopes(
+                        imported.asname or imported.name.split(".", 1)[0]
+                    ),
                 )
             )
 
@@ -173,6 +193,9 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
+                    projected_binding_scopes=self._projected_import_scopes(
+                        imported.asname or imported.name
+                    ),
                 )
             )
 
@@ -286,6 +309,10 @@ class _StructureVisitor(ast.NodeVisitor):
         finally:
             self._lookup_limit = previous_limit
         self._contexts.append(qualified_name)
+        self._context_kinds.append(kind)
+        self._context_conditionals.append(self._conditional_depth > 0)
+        self._scope_declarations.append({})
+        self._symbol_tables.append(_child_symbol_table(self._symbol_tables[-1], node, kind))
         previous_conditional_depth = self._conditional_depth
         self._conditional_depth = 0
         try:
@@ -293,7 +320,11 @@ class _StructureVisitor(ast.NodeVisitor):
                 self.visit(statement)
         finally:
             self._conditional_depth = previous_conditional_depth
+            self._scope_declarations.pop()
+            self._context_conditionals.pop()
+            self._context_kinds.pop()
             self._contexts.pop()
+            self._symbol_tables.pop()
 
     def _visit_definition_header(
         self, node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
@@ -317,6 +348,44 @@ class _StructureVisitor(ast.NodeVisitor):
         self.declarations.extend(
             ScopeDeclaration(kind, name, self._context, line, column) for name in node.names
         )
+        if self._scope_declarations:
+            self._scope_declarations[-1].update(dict.fromkeys(node.names, kind))
+
+    def _projected_import_scopes(self, name: str) -> tuple[ImportBindingScope, ...]:
+        if not self._context_kinds:
+            return ()
+        declaration = self._scope_declarations[-1].get(name)
+        if declaration is None:
+            return ()
+
+        source_kind = self._context_kinds[-1]
+        deferred = source_kind == "function"
+        conditional = self._conditional_depth > 0
+        conditional = conditional or (
+            self._context_conditionals[-1] if source_kind == "class" else True
+        )
+        if declaration == "global":
+            for kind, definition_conditional in zip(
+                self._context_kinds[:-1], self._context_conditionals[:-1], strict=True
+            ):
+                if kind == "function":
+                    conditional = deferred = True
+                conditional = conditional or definition_conditional
+            return (ImportBindingScope(None, conditional, deferred),)
+
+        for index in range(len(self._contexts) - 2, -1, -1):
+            kind = self._context_kinds[index]
+            if kind == "function":
+                try:
+                    owns_name = self._symbol_tables[index + 1].lookup(name).is_local()
+                except KeyError:
+                    owns_name = False
+                if owns_name:
+                    return (ImportBindingScope(self._contexts[index], conditional, deferred),)
+                conditional = deferred = True
+            else:
+                conditional = conditional or self._context_conditionals[index]
+        return ()
 
     def _symbol_use(self, target: str, line: int, column: int) -> SymbolUse:
         root = target.split(".", 1)[0]
@@ -371,6 +440,22 @@ class _StructureVisitor(ast.NodeVisitor):
     @property
     def _context(self) -> str | None:
         return self._contexts[-1] if self._contexts else None
+
+
+def _child_symbol_table(
+    parent: symtable.SymbolTable,
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+    kind: DefinitionKind,
+) -> symtable.SymbolTable:
+    for child in parent.get_children():
+        if child.get_name() == node.name and child.get_lineno() == node.lineno:
+            if child.get_type() == kind:
+                return child
+            try:
+                return _child_symbol_table(child, node, kind)
+            except RuntimeError:
+                pass
+    raise RuntimeError(f"missing symbol table for {kind} {node.name} at line {node.lineno}")
 
 
 def _dotted_name(node: ast.expr) -> str | None:

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import unittest
 
+from silobrief.boundary_placeholders import BoundaryPlaceholder
 from silobrief.index import build_index, render_index_json
 from silobrief.python_structure import extract_structures
 from silobrief.sources import SourceFile, SourceSnapshot
@@ -134,6 +135,553 @@ class BoundaryPlaceholderTests(unittest.TestCase):
         for forbidden in (b"private_zone", b"HiddenThing", b"local_hidden"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, first)
+
+    def test_method_boundary_lookup_skips_the_class_namespace(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"from private_zone import send\n"
+                b"class Service:\n"
+                b"    from public_api import send\n"
+                b"    def run(self):\n"
+                b"        return send()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "Service.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_class_global_does_not_hide_an_enclosing_function_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def outer():\n"
+                b"    import private_zone as selected\n"
+                b"    class Service:\n"
+                b"        global selected\n"
+                b"        import public_zone as selected\n"
+                b"        def run(self):\n"
+                b"            return selected.HiddenClient()\n"
+                b"    return Service\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "outer.Service.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_parameter_shadows_a_module_boundary_import(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            b"from private_zone import send\ndef run(send):\n    return send()\n",
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "send")
+        self.assertIsNone(call.target_id)
+
+    def test_receiver_import_shadows_the_enclosing_method_parameter(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"class Service:\n"
+                b"    def helper(self):\n"
+                b"        return 'public'\n"
+                b"    def run(self):\n"
+                b"        from private_zone import client as self\n"
+                b"        def inner():\n"
+                b"            return self.helper()\n"
+                b"        return inner\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        inner = next(node for node in index.nodes if node.qualified_name == "Service.run.inner")
+        call = next(
+            edge for edge in index.edges if edge.source_id == inner.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_global_declaration_skips_an_enclosing_function_import(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as service\n"
+                b"def outer():\n"
+                b"    import public_api as service\n"
+                b"    def inner():\n"
+                b"        global service\n"
+                b"        return service.send()\n"
+                b"    return inner\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        inner = next(node for node in index.nodes if node.qualified_name == "outer.inner")
+        call = next(
+            edge for edge in index.edges if edge.source_id == inner.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+
+    def test_source_order_resolves_boundary_import_and_local_definition(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def imported_last():\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    from private_zone import client as service\n"
+                b"    return service()\n"
+                b"def defined_last():\n"
+                b"    from private_zone import client as service\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    return service()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+        imported_call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes["imported_last"].id and edge.kind == "call"
+        )
+        defined_call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes["defined_last"].id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            imported_call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(imported_call.target_id)
+        self.assertEqual(defined_call.target, "service")
+        self.assertEqual(defined_call.target_id, nodes["defined_last.service"].id)
+        self.assertNotIn(b"private_zone", render_index_json(index))
+
+    def test_lexical_bindings_shadow_a_raw_boundary_name(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def use_local():\n"
+                b"    def private():\n"
+                b"        return 'local'\n"
+                b"    return private()\n"
+                b"def use_parameter(private):\n"
+                b"    return private()\n"
+                b"def use_public_import():\n"
+                b"    from public_api import helper as private\n"
+                b"    return private()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-code",
+            description="Approved private code",
+            path="private.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+        calls = {
+            node_name: next(
+                edge
+                for edge in index.edges
+                if edge.source_id == nodes[node_name].id and edge.kind == "call"
+            )
+            for node_name in ("use_local", "use_parameter", "use_public_import")
+        }
+
+        self.assertEqual(calls["use_local"].target, "private")
+        self.assertEqual(
+            calls["use_local"].target_id,
+            nodes["use_local.private"].id,
+        )
+        for node_name in ("use_parameter", "use_public_import"):
+            with self.subTest(node_name=node_name):
+                self.assertEqual(calls[node_name].target, "private")
+                self.assertIsNone(calls[node_name].target_id)
+        self.assertNotIn(b'"alias": "private-code"', render_index_json(index))
+
+    def test_conditional_boundary_import_is_redacted_conservatively(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose(use_private):\n"
+                b"    if use_private:\n"
+                b"        from private_zone import HiddenClient as service\n"
+                b"    else:\n"
+                b"        def service():\n"
+                b"            return 'public'\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+        rendered = render_index_json(index)
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_try_boundary_import_is_redacted_conservatively(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose():\n"
+                b"    try:\n"
+                b"        from private_zone import HiddenClient as service\n"
+                b"    except ImportError:\n"
+                b"        def service():\n"
+                b"            return 'public'\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+        rendered = render_index_json(index)
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_later_rebinding_does_not_hide_a_boundary_possible_for_a_closure(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose():\n"
+                b"    from private_zone import HiddenClient as service\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    run()\n"
+                b"    def service():\n"
+                b"        return 'public'\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        self.assertNotIn(b"private_zone", render_index_json(index))
+
+    def test_conditional_class_and_global_bindings_fall_back_to_a_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as backend\n"
+                b"def choose(flag):\n"
+                b"    global backend\n"
+                b"    if flag:\n"
+                b"        import public_zone as backend\n"
+                b"    def run():\n"
+                b"        return backend.HiddenClient()\n"
+                b"    return run\n"
+                b"class Service:\n"
+                b"    if ENABLE_PUBLIC:\n"
+                b"        import public_zone as backend\n"
+                b"    backend.HiddenClient()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in ("choose.run", "Service"):
+            with self.subTest(qualified_name=qualified_name):
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == nodes[qualified_name].id and edge.kind == "call"
+                )
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_class_declarations_change_the_binding_seen_by_methods(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import public_zone as module_backend\n"
+                b"class GlobalService:\n"
+                b"    global module_backend\n"
+                b"    import private_zone as module_backend\n"
+                b"    def run(self):\n"
+                b"        return module_backend.HiddenClient()\n"
+                b"def make_service():\n"
+                b"    import public_zone as closure_backend\n"
+                b"    class NonlocalService:\n"
+                b"        nonlocal closure_backend\n"
+                b"        import private_zone as closure_backend\n"
+                b"        def run(self):\n"
+                b"            return closure_backend.HiddenClient()\n"
+                b"    return NonlocalService\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in ("GlobalService.run", "make_service.NonlocalService.run"):
+            with self.subTest(qualified_name=qualified_name):
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == nodes[qualified_name].id and edge.kind == "call"
+                )
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_deferred_declaration_imports_remain_possible_boundaries(self) -> None:
+        cases = (
+            (
+                b"import public_zone as backend\n"
+                b"def configure():\n"
+                b"    global backend\n"
+                b"    import private_zone as backend\n"
+                b"import public_zone as backend\n"
+                b"configure()\n"
+                b"def run():\n"
+                b"    return backend.HiddenClient()\n",
+                "run",
+            ),
+            (
+                b"def outer():\n"
+                b"    import public_zone as backend\n"
+                b"    def configure():\n"
+                b"        nonlocal backend\n"
+                b"        import private_zone as backend\n"
+                b"    import public_zone as backend\n"
+                b"    configure()\n"
+                b"    def run():\n"
+                b"        return backend.HiddenClient()\n"
+                b"    return run\n",
+                "outer.run",
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        for content, qualified_name in cases:
+            with self.subTest(qualified_name=qualified_name):
+                source = source_snapshot("service.py", content)
+                index = build_index(source, extract_structures(source), config(boundary))
+                node = next(node for node in index.nodes if node.qualified_name == qualified_name)
+                call = next(
+                    edge
+                    for edge in index.edges
+                    if edge.source_id == node.id and edge.kind == "call"
+                )
+
+                self.assertEqual(
+                    call.target,
+                    BoundaryPlaceholder("private-service", "Approved private service"),
+                )
+                self.assertIsNone(call.target_id)
+                rendered = render_index_json(index)
+                for forbidden in (b"private_zone", b"HiddenClient"):
+                    self.assertNotIn(forbidden, rendered)
+
+    def test_deferred_import_without_an_outer_binding_falls_back_to_boundary(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def configure():\n"
+                b"    global secret\n"
+                b"    import public_api as secret\n"
+                b"def run():\n"
+                b"    return secret.Hidden()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="secret.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        self.assertNotIn(b'"target": "secret.Hidden"', render_index_json(index))
+
+    def test_projected_import_does_not_cross_duplicate_scope_occurrences(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class Configure:\n"
+                b"        nonlocal selected\n"
+                b"        import private_zone as selected\n"
+                b"    return Configure\n"
+                b"def outer():\n"
+                b"    import public_zone as selected\n"
+                b"    def run():\n"
+                b"        return selected.send()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "outer.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "selected.send")
+        self.assertIsNone(call.target_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,4 +48,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.3\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.0.4\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -72,8 +72,8 @@ SAFETY_EXPECTATIONS = {
     "README.ko.md": ("제외 경로", "심볼릭 링크", "보안 검사기"),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.0.3", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.0.3", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.0.4", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.0.4", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -84,6 +84,7 @@ VALIDATION_LINKS = (
     "validation/v0.8/RELATED_CONTEXT_RESULT.md",
     "validation/v0.9/FIELD_TRIAL.md",
     "validation/v1.0.1/RELEASE_VERIFICATION.md",
+    "validation/v1.0-scope-related-context/REPORT.md",
 )
 PRACTICE_FLOW_EXPECTATIONS = (
     "sb example ./silobrief-practice",
@@ -161,6 +162,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.0.4] - 2026-08-19", changelog)
         self.assertIn("## [1.0.3] - 2026-08-18", changelog)
         self.assertIn("## [1.0.2] - 2026-08-17", changelog)
         self.assertIn("## [1.0.1] - 2026-08-12", changelog)
@@ -187,8 +189,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("has not released a supported version yet", security)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.0.3"'), 1)
-        self.assertEqual(version("silobrief"), "1.0.3")
+        self.assertEqual(pyproject.count('version = "1.0.4"'), 1)
+        self.assertEqual(version("silobrief"), "1.0.4")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -214,6 +214,639 @@ class DeterministicIndexTests(unittest.TestCase):
             index.edges,
         )
 
+    def test_resolves_definitions_in_python_lexical_scopes(self) -> None:
+        source = source_file(
+            "scope_demo.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    return helper()\n"
+                b"class Worker:\n"
+                b"    def helper(self):\n"
+                b"        return 'method'\n"
+                b"    def run(self):\n"
+                b"        helper()\n"
+                b"        def inner():\n"
+                b"            return self.helper()\n"
+                b"        return inner()\n"
+                b"    @classmethod\n"
+                b"    def create(cls):\n"
+                b"        return cls.helper()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes["outer"].id,
+                "call",
+                "helper",
+                nodes["outer.helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run"].id,
+                "call",
+                "helper",
+                nodes["helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run"].id,
+                "call",
+                "inner",
+                nodes["Worker.run.inner"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.run.inner"].id,
+                "call",
+                "self.helper",
+                nodes["Worker.helper"].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes["Worker.create"].id,
+                "call",
+                "cls.helper",
+                nodes["Worker.helper"].id,
+            ),
+            index.edges,
+        )
+
+    def test_resolves_imports_in_python_lexical_scopes(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from pkg import global_target as alias\n"
+                b"def outer():\n"
+                b"    from pkg import local_target as alias\n"
+                b"    def inner():\n"
+                b"        return alias()\n"
+                b"    class NestedWorker:\n"
+                b"        from pkg import class_target as alias\n"
+                b"        def run(self):\n"
+                b"            return alias()\n"
+                b"    return inner()\n"
+                b"class Worker:\n"
+                b"    from pkg import class_target as alias\n"
+                b"    value = alias()\n"
+                b"    def run(self):\n"
+                b"        return alias()\n"
+            ),
+        )
+        dependency = source_file(
+            "pkg.py",
+            (
+                b"def global_target():\n"
+                b"    return 'global'\n"
+                b"def local_target():\n"
+                b"    return 'local'\n"
+                b"def class_target():\n"
+                b"    return 'class'\n"
+            ),
+        )
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer.inner")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "local_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "Worker")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "class_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "Worker.run")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "global_target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer.NestedWorker.run")].id,
+                "call",
+                "alias",
+                nodes[("pkg.py", "local_target")].id,
+            ),
+            index.edges,
+        )
+
+    def test_local_import_takes_priority_over_outer_definition(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    from pkg import helper\n"
+                b"    return helper()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 'imported'\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "outer")].id,
+                "call",
+                "helper",
+                nodes[("pkg.py", "helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_uses_the_latest_definition_or_import_in_the_same_scope(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def imported_last():\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    from pkg import helper\n"
+                b"    callback = helper\n"
+                b"    return helper()\n"
+                b"def defined_last():\n"
+                b"    from pkg import helper\n"
+                b"    def helper():\n"
+                b"        return 'local'\n"
+                b"    callback = helper\n"
+                b"    return helper()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 'imported'\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        imported = nodes[("pkg.py", "helper")]
+        local = nodes[("caller.py", "defined_last.helper")]
+
+        for kind in ("call", "reference"):
+            with self.subTest(scope="imported_last", kind=kind):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", "imported_last")].id,
+                        kind,
+                        "helper",
+                        imported.id,
+                    ),
+                    index.edges,
+                )
+            with self.subTest(scope="defined_last", kind=kind):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", "defined_last")].id,
+                        kind,
+                        "helper",
+                        local.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_calls_follow_repeated_import_rebindings(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def choose():\n"
+                b"    from first import target as selected\n"
+                b"    selected()\n"
+                b"    from second import target as selected\n"
+                b"    selected()\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        choose = nodes[("caller.py", "choose")]
+
+        self.assertIn(
+            IndexEdge(choose.id, "call", "selected", nodes[("first.py", "target")].id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(choose.id, "call", "selected", nodes[("second.py", "target")].id),
+            index.edges,
+        )
+
+    def test_nested_uses_take_the_latest_binding_before_their_definition(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as module_selected\n"
+                b"from second import target as module_selected\n"
+                b"def module_user():\n"
+                b"    return module_selected()\n"
+                b"def outer():\n"
+                b"    from first import target as local_selected\n"
+                b"    from second import target as local_selected\n"
+                b"    def inner():\n"
+                b"        return local_selected()\n"
+                b"    return inner\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name, target in (
+            ("module_user", "module_selected"),
+            ("outer.inner", "local_selected"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        target,
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_function_bodies_resolve_module_bindings_defined_later(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def run():\n"
+                b"    Later()\n"
+                b"    return selected()\n"
+                b"class Later:\n"
+                b"    pass\n"
+                b"from dependency import target as selected\n"
+            ),
+        )
+        dependency = source_file("dependency.py", b"def target():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        run = nodes[("caller.py", "run")]
+
+        self.assertIn(
+            IndexEdge(run.id, "call", "Later", nodes[("caller.py", "Later")].id), index.edges
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "selected", nodes[("dependency.py", "target")].id),
+            index.edges,
+        )
+
+    def test_declarations_are_scoped_to_each_duplicate_definition_body(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from module_api import target as selected\n"
+                b"def outer():\n"
+                b"    from local_api import target as selected\n"
+                b"    def duplicate():\n"
+                b"        global selected\n"
+                b"        return selected()\n"
+                b"    def duplicate():\n"
+                b"        return selected()\n"
+                b"    return duplicate()\n"
+            ),
+        )
+        module_api = source_file("module_api.py", b"def target():\n    return 1\n")
+        local_api = source_file("local_api.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, module_api, local_api)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        duplicate = nodes[("caller.py", "outer.duplicate")]
+
+        self.assertIn(
+            IndexEdge(duplicate.id, "call", "selected", nodes[("module_api.py", "target")].id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(duplicate.id, "call", "selected", nodes[("local_api.py", "target")].id),
+            index.edges,
+        )
+
+    def test_class_only_import_is_not_visible_to_a_method(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"class Worker:\n"
+                b"    from pkg import helper as alias\n"
+                b"    def run(self):\n"
+                b"        return alias()\n"
+            ),
+        )
+        dependency = source_file("pkg.py", b"def helper():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        call = next(
+            edge
+            for edge in index.edges
+            if edge.source_id == nodes[("caller.py", "Worker.run")].id and edge.kind == "call"
+        )
+
+        self.assertEqual(call.target, "alias")
+        self.assertIsNone(call.target_id)
+
+    def test_dotted_import_binds_the_top_level_package_name(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"def pkg():\n"
+                b"    return 'function'\n"
+                b"def run():\n"
+                b"    import pkg.sub\n"
+                b"    return pkg\n"
+            ),
+        )
+        package = source_file("pkg/__init__.py", b"VALUE = 1\n")
+        dependency = source_file("pkg/sub.py", b"VALUE = 2\n")
+        snapshot = source_snapshot(caller, package, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "run")].id,
+                "reference",
+                "pkg",
+                nodes[("pkg/__init__.py", "pkg")].id,
+            ),
+            index.edges,
+        )
+
+    def test_declaration_scope_imports_override_existing_outer_bindings(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as selected\n"
+                b"def use_global():\n"
+                b"    global selected\n"
+                b"    from second import target as selected\n"
+                b"    return selected()\n"
+                b"def outer():\n"
+                b"    from first import target as selected\n"
+                b"    def use_nonlocal():\n"
+                b"        nonlocal selected\n"
+                b"        from second import target as selected\n"
+                b"        return selected()\n"
+                b"    return use_nonlocal()\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name in ("use_global", "outer.use_nonlocal"):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        "selected",
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_class_declaration_imports_update_their_actual_outer_scopes(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from first import target as module_selected\n"
+                b"class ModuleWriter:\n"
+                b"    global module_selected\n"
+                b"    from second import target as module_selected\n"
+                b"    def use_module(self):\n"
+                b"        return module_selected()\n"
+                b"def after_module_class():\n"
+                b"    return module_selected()\n"
+                b"def outer():\n"
+                b"    from first import target as closure_selected\n"
+                b"    class ClosureWriter:\n"
+                b"        nonlocal closure_selected\n"
+                b"        from second import target as closure_selected\n"
+                b"        def use_closure(self):\n"
+                b"            return closure_selected()\n"
+                b"    def after_closure_class():\n"
+                b"        return closure_selected()\n"
+                b"    return ClosureWriter, after_closure_class\n"
+            ),
+        )
+        first = source_file("first.py", b"def target():\n    return 1\n")
+        second = source_file("second.py", b"def target():\n    return 2\n")
+        snapshot = source_snapshot(caller, first, second)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        second_target = nodes[("second.py", "target")]
+
+        for qualified_name, target in (
+            ("ModuleWriter.use_module", "module_selected"),
+            ("after_module_class", "module_selected"),
+            ("outer.ClosureWriter.use_closure", "closure_selected"),
+            ("outer.after_closure_class", "closure_selected"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        target,
+                        second_target.id,
+                    ),
+                    index.edges,
+                )
+
+    def test_redefinition_uses_the_latest_definition_node_kind(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def Target():\n"
+                b"    return 'function'\n"
+                b"class Target:\n"
+                b"    def helper(self):\n"
+                b"        return 'method'\n"
+                b"    def run(self):\n"
+                b"        helper()\n"
+                b"        return self.helper()\n"
+                b"Target()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.kind, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("module", "caller")].id,
+                "call",
+                "Target",
+                nodes[("class", "Target")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "self.helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(nodes[("function", "Target.run")].id, "call", "helper", None),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_function_redefinition_keeps_its_nested_function_scope(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"class Target:\n"
+                b"    pass\n"
+                b"def Target():\n"
+                b"    def helper():\n"
+                b"        return 'nested'\n"
+                b"    def run():\n"
+                b"        return helper()\n"
+                b"    return run()\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.kind, node.qualified_name): node for node in index.nodes}
+
+        self.assertIn(
+            IndexEdge(
+                nodes[("function", "Target.run")].id,
+                "call",
+                "helper",
+                nodes[("function", "Target.helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_synthetic_scopes_skip_class_bindings_and_keep_local_names_unresolved(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'module'\n"
+                b"def lambda_local():\n"
+                b"    return 'module'\n"
+                b"def comprehension_local():\n"
+                b"    return 'module'\n"
+                b"class Worker:\n"
+                b"    def helper():\n"
+                b"        return 'class'\n"
+                b"    lambda_value = (lambda: helper())()\n"
+                b"    comprehension_value = [helper() for _ in ()]\n"
+                b"    lambda_shadow = (lambda lambda_local: lambda_local())(None)\n"
+                b"    comprehension_shadow = "
+                b"[comprehension_local() for comprehension_local in ()]\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+        worker = nodes["Worker"]
+
+        self.assertIn(
+            IndexEdge(worker.id, "call", "helper", nodes["helper"].id),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(worker.id, "call", "helper", nodes["Worker.helper"].id),
+            index.edges,
+        )
+        for name in ("lambda_local", "comprehension_local"):
+            with self.subTest(name=name):
+                self.assertIn(IndexEdge(worker.id, "call", name, None), index.edges)
+                self.assertNotIn(
+                    IndexEdge(worker.id, "call", name, nodes[name].id),
+                    index.edges,
+                )
+
+    def test_definition_header_resolves_the_previous_import_binding(self) -> None:
+        caller = source_file(
+            "caller.py",
+            b"from pkg import Base\nclass Base(Base):\n    pass\n",
+        )
+        dependency = source_file("pkg.py", b"class Base:\n    pass\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.kind, node.qualified_name): node for node in index.nodes}
+        caller_module = nodes[("caller.py", "module", "caller")]
+
+        self.assertIn(
+            IndexEdge(
+                caller_module.id,
+                "reference",
+                "Base",
+                nodes[("pkg.py", "class", "Base")].id,
+            ),
+            index.edges,
+        )
+
     def test_json_is_identical_for_equivalent_input_order(self) -> None:
         first_source = source_file(
             "a.py",

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -8,6 +8,7 @@ from silobrief.python_structure import (
     Definition,
     ImportEntry,
     PythonParseError,
+    ScopeDeclaration,
     SymbolUse,
     extract_structures,
 )
@@ -52,8 +53,28 @@ class PythonStructureTests(unittest.TestCase):
             (
                 Definition("class", "Outer", "Outer", False, 1, 1, 1, 7),
                 Definition("class", "Inner", "Outer.Inner", False, 2, 5, 2, 3),
-                Definition("function", "method", "Outer.method", False, 4, 5, 4, 5),
-                Definition("function", "fetch", "Outer.fetch", True, 6, 5, 6, 7),
+                Definition(
+                    "function",
+                    "method",
+                    "Outer.method",
+                    False,
+                    4,
+                    5,
+                    4,
+                    5,
+                    ("self",),
+                ),
+                Definition(
+                    "function",
+                    "fetch",
+                    "Outer.fetch",
+                    True,
+                    6,
+                    5,
+                    6,
+                    7,
+                    ("self",),
+                ),
                 Definition("function", "top", "top", False, 8, 1, 8, 10),
                 Definition("function", "nested", "top.nested", False, 9, 5, 9, 10),
             ),
@@ -118,6 +139,75 @@ class PythonStructureTests(unittest.TestCase):
             ),
         )
 
+    def test_extracts_global_and_nonlocal_declarations_by_context(self) -> None:
+        source = source_file(
+            "scopes.py",
+            (
+                b"value = 1\n"
+                b"def outer():\n"
+                b"    value = 2\n"
+                b"    def use_nonlocal():\n"
+                b"        nonlocal value\n"
+                b"        return value\n"
+                b"    def use_global():\n"
+                b"        global value\n"
+                b"        return value\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.declarations,
+            (
+                ScopeDeclaration("nonlocal", "value", "outer.use_nonlocal", 5, 9),
+                ScopeDeclaration("global", "value", "outer.use_global", 8, 9),
+            ),
+        )
+
+    def test_marks_conditional_bindings_without_leaking_into_definition_bodies(self) -> None:
+        source = source_file(
+            "branches.py",
+            (
+                b"def choose(flag):\n"
+                b"    if flag:\n"
+                b"        import private_api as service\n"
+                b"    else:\n"
+                b"        def service():\n"
+                b"            import body_dependency\n"
+                b"    import direct_dependency\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        imports = {(item.module, item.context): item.conditional for item in module.imports}
+        service = next(item for item in module.definitions if item.name == "service")
+
+        self.assertTrue(imports[("private_api", "choose")])
+        self.assertFalse(imports[("body_dependency", "choose.service")])
+        self.assertFalse(imports[("direct_dependency", "choose")])
+        self.assertTrue(service.conditional)
+
+    def test_marks_lambda_and_comprehension_lookup_scopes(self) -> None:
+        source = source_file(
+            "synthetic.py",
+            (
+                b"class Worker:\n"
+                b"    lambda_value = (lambda local: local())(None)\n"
+                b"    values = [item() for item in items()]\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        calls = {call.target: call for call in module.calls}
+
+        self.assertTrue(calls["local"].skip_class_scope)
+        self.assertTrue(calls["local"].synthetic_local)
+        self.assertFalse(calls["items"].skip_class_scope)
+        self.assertFalse(calls["items"].synthetic_local)
+        self.assertTrue(calls["item"].skip_class_scope)
+        self.assertTrue(calls["item"].synthetic_local)
+
     def test_attributes_definition_header_calls_to_the_enclosing_context(self) -> None:
         source = source_file(
             "definitions.py",
@@ -155,7 +245,10 @@ class PythonStructureTests(unittest.TestCase):
             },
         )
         self.assertEqual(len(module.calls), len(contexts))
-        self.assertIn(SymbolUse("outer", "Value", 3, 22), module.references)
+        self.assertIn(
+            SymbolUse("outer", "Value", 3, 22, lookup_limit=(3, 5)),
+            module.references,
+        )
 
     def test_omits_source_text_comments_docstrings_and_string_literals(self) -> None:
         source = source_file(

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -111,6 +111,62 @@ class PythonStructureTests(unittest.TestCase):
             ("Box", "Box.transform"),
         )
 
+    def test_accepts_top_level_async_syntax_without_losing_scope_owners(self) -> None:
+        source = source_file(
+            "pyodide_runner.py",
+            (
+                b"async def main():\n"
+                b"    await inside()\n"
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    def middle():\n"
+                b"        class Configure:\n"
+                b"            nonlocal selected\n"
+                b"            import package.client as selected\n"
+                b"        return Configure\n"
+                b"    return middle\n"
+                b"await main()\n"
+                b"async for item in items:\n"
+                b"    consume(item)\n"
+                b"async with manager():\n"
+                b"    consume(resource)\n"
+                b"values = [item async for item in items]\n"
+                b"async \\\n"
+                b"def continued():\n"
+                b"    pass\n"
+                b"await\f continued()\n"
+                b"async\fdef formfeed():\n"
+                b"    pass\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        selected = next(item for item in module.imports if item.alias == "selected")
+
+        self.assertEqual(
+            selected.projected_binding_scopes,
+            (ImportBindingScope("outer", conditional=True, deferred=True),),
+        )
+        self.assertIn(Definition("function", "main", "main", True, 1, 1, 1, 2), module.definitions)
+        self.assertIn(
+            Definition("function", "continued", "continued", True, 17, 1, 17, 19),
+            module.definitions,
+        )
+        self.assertIn(
+            Definition("function", "formfeed", "formfeed", True, 21, 1, 21, 22),
+            module.definitions,
+        )
+        self.assertIn(SymbolUse(None, "main", 11, 7), module.calls)
+
+    def test_top_level_async_fallback_keeps_invalid_scopes_rejected(self) -> None:
+        sources = [b"def inner():\n    nonlocal missing\n"]
+        if sys.version_info >= (3, 14):
+            sources.append(b"class Invalid:\n    await run()\n")
+
+        for content in sources:
+            with self.subTest(content=content), self.assertRaises(PythonParseError):
+                extract_structures(source_snapshot(source_file("invalid.py", content)))
+
     def test_extracts_import_variants_in_source_order(self) -> None:
         source = source_file(
             "imports.py",

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import sys
 import unittest
 from unittest import mock
 
 from silobrief.python_structure import (
     Definition,
+    ImportBindingScope,
     ImportEntry,
     PythonParseError,
     ScopeDeclaration,
@@ -82,6 +84,32 @@ class PythonStructureTests(unittest.TestCase):
         self.assertEqual(module.imports, ())
         self.assertEqual(module.calls, ())
         self.assertEqual(module.references, ())
+
+    @unittest.skipIf(sys.version_info < (3, 12), "PEP 695 requires Python 3.12")
+    def test_follows_type_parameter_symbol_tables_to_generic_definitions(self) -> None:
+        source = source_file(
+            "generics.py",
+            (
+                b"class Box[T]:\n"
+                b"    import package\n"
+                b"    def transform[U](self, value: U) -> T:\n"
+                b"        import helper\n"
+                b"        return value\n"
+                b"def identity[T](value: T) -> T:\n"
+                b"    return value\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            tuple(item.qualified_name for item in module.definitions),
+            ("Box", "Box.transform", "identity"),
+        )
+        self.assertEqual(
+            tuple(item.context for item in module.imports),
+            ("Box", "Box.transform"),
+        )
 
     def test_extracts_import_variants_in_source_order(self) -> None:
         source = source_file(
@@ -163,6 +191,140 @@ class PythonStructureTests(unittest.TestCase):
                 ScopeDeclaration("nonlocal", "value", "outer.use_nonlocal", 5, 9),
                 ScopeDeclaration("global", "value", "outer.use_global", 8, 9),
             ),
+        )
+
+    def test_projects_class_imports_to_declared_binding_scopes(self) -> None:
+        source = source_file(
+            "class_bindings.py",
+            (
+                b"class ModuleBindings:\n"
+                b"    global client, service, package\n"
+                b"    import package.client as client\n"
+                b"    from package import service\n"
+                b"    import package.client\n"
+                b"    import package.local as local\n"
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class ClosureBindings:\n"
+                b"        nonlocal selected\n"
+                b"        from package import selected\n"
+                b"    return ClosureBindings\n"
+                b"def delayed():\n"
+                b"    class ModuleBinding:\n"
+                b"        global delayed_client\n"
+                b"        import package.client as delayed_client\n"
+                b"    return ModuleBinding\n"
+                b"def function_binding():\n"
+                b"    global function_client\n"
+                b"    import package.client as function_client\n"
+                b"def owner():\n"
+                b"    owned = None\n"
+                b"    def middle():\n"
+                b"        class ClosureBinding:\n"
+                b"            nonlocal owned\n"
+                b"            import package.client as owned\n"
+                b"    return middle\n"
+                b"def function_owner():\n"
+                b"    function_owned = None\n"
+                b"    def configure():\n"
+                b"        nonlocal function_owned\n"
+                b"        import package.client as function_owned\n"
+                b"    return configure\n"
+                b"class Mismatch:\n"
+                b"    global another_name\n"
+                b"    import package.client as mismatch\n"
+                b"def chain_owner():\n"
+                b"    chained = None\n"
+                b"    def middle():\n"
+                b"        nonlocal chained\n"
+                b"        class ClosureBinding:\n"
+                b"            nonlocal chained\n"
+                b"            import package.client as chained\n"
+                b"    return middle\n"
+                b"def late_owner():\n"
+                b"    class ClosureBinding:\n"
+                b"        nonlocal late\n"
+                b"        import package.client as late\n"
+                b"    late = None\n"
+                b"    return ClosureBinding\n"
+            ),
+        )
+
+        compile(source.content, source.path, "exec")
+        (module,) = extract_structures(source_snapshot(source))
+        imports = {item.alias or item.name or item.module: item for item in module.imports}
+
+        for name in ("client", "service"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    imports[name].projected_binding_scopes,
+                    (ImportBindingScope(None),),
+                )
+        dotted = next(
+            item for item in module.imports if item.module == "package.client" and not item.alias
+        )
+        self.assertEqual(dotted.projected_binding_scopes, (ImportBindingScope(None),))
+        self.assertEqual(
+            imports["selected"].projected_binding_scopes,
+            (ImportBindingScope("outer"),),
+        )
+        self.assertEqual(
+            imports["delayed_client"].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["function_client"].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["owned"].projected_binding_scopes,
+            (ImportBindingScope("owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["function_owned"].projected_binding_scopes,
+            (ImportBindingScope("function_owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["chained"].projected_binding_scopes,
+            (ImportBindingScope("chain_owner", conditional=True, deferred=True),),
+        )
+        self.assertEqual(
+            imports["late"].projected_binding_scopes,
+            (ImportBindingScope("late_owner"),),
+        )
+        for name in ("local", "mismatch"):
+            with self.subTest(name=name):
+                self.assertEqual(imports[name].projected_binding_scopes, ())
+
+    def test_preserves_conditions_on_nested_class_import_projections(self) -> None:
+        source = source_file(
+            "conditional_bindings.py",
+            (
+                b"if ENABLED:\n"
+                b"    class ModuleBindings:\n"
+                b"        global client\n"
+                b"        import package.client as client\n"
+                b"def outer():\n"
+                b"    selected = None\n"
+                b"    class Container:\n"
+                b"        if ENABLED:\n"
+                b"            class ClosureBindings:\n"
+                b"                nonlocal selected\n"
+                b"                from package import selected\n"
+                b"    return Container\n"
+            ),
+        )
+
+        compile(source.content, source.path, "exec")
+        (module,) = extract_structures(source_snapshot(source))
+
+        self.assertEqual(
+            module.imports[0].projected_binding_scopes,
+            (ImportBindingScope(None, conditional=True),),
+        )
+        self.assertEqual(
+            module.imports[1].projected_binding_scopes,
+            (ImportBindingScope("outer", conditional=True),),
         )
 
     def test_marks_conditional_bindings_without_leaking_into_definition_bodies(self) -> None:

--- a/tests/test_source_review.py
+++ b/tests/test_source_review.py
@@ -5,10 +5,12 @@ import io
 import unittest
 
 from silobrief.boundary_placeholders import BoundaryPlaceholder
-from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens
+from silobrief.index import IndexData, IndexEdge, IndexNode, NodeKind, NodeTokens, build_index
+from silobrief.python_structure import extract_structures
 from silobrief.review import DisclosureChoices, ReviewNode, ReviewSelection
 from silobrief.source_review import SourceReviewError, review_source_disclosure
 from silobrief.sources import SourceFile, SourceSnapshot
+from silobrief.state import DEFAULT_EXCLUDES, BoundaryData, ConfigData
 
 
 class TtyBuffer(io.StringIO):
@@ -147,6 +149,59 @@ class SourceReviewTests(unittest.TestCase):
         self.assertEqual(len(approved), 1)
         self.assertEqual(approved[0].qualified_name, "Service")
         self.assertEqual(approved[0].boundary_aliases, ("delivery-boundary",))
+
+    def test_deferred_boundary_binding_requires_expose(self) -> None:
+        source = snapshot(
+            source_file(
+                "service.py",
+                (
+                    b"import public_zone as backend\n"
+                    b"def configure():\n"
+                    b"    global backend\n"
+                    b"    import private_zone as backend\n"
+                    b"import public_zone as backend\n"
+                    b"configure()\n"
+                    b"def run():\n"
+                    b"    return backend.HiddenClient()\n"
+                ),
+            )
+        )
+        source_index = build_index(
+            source,
+            extract_structures(source),
+            ConfigData(
+                boundaries=[
+                    BoundaryData(
+                        alias="private-service",
+                        description="Approved private service",
+                        path="private_zone.py",
+                    )
+                ],
+                default_excludes=list(DEFAULT_EXCLUDES),
+                schema_version=1,
+            ),
+        )
+        run = next(node for node in source_index.nodes if node.qualified_name == "run")
+        selection = ReviewSelection((review_node(run),), (), FIELDS)
+
+        declined = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nnot-expose\n"),
+            output_stream=TtyBuffer(),
+        )
+        approved = review_source_disclosure(
+            source_index,
+            source,
+            selection,
+            input_stream=TtyBuffer("y\nEXPOSE\n"),
+            output_stream=TtyBuffer(),
+        )
+
+        self.assertEqual(declined, ())
+        self.assertEqual(len(approved), 1)
+        self.assertEqual(approved[0].boundary_aliases, ("private-service",))
 
     def test_parse_failure_does_not_remove_valid_candidate(self) -> None:
         broken = node("broken", "bad.py", "function", "broken")

--- a/validation/v1.0-scope-related-context/REPORT.md
+++ b/validation/v1.0-scope-related-context/REPORT.md
@@ -1,0 +1,85 @@
+# Scope-related one-hop context validation
+
+## Decision
+
+Proceed with the lexical-scope correction. The fixed-primary comparison affected three of the 12
+holdout tasks, met every gate in Issue #185, and improved the required related context in two cases.
+This result supports the scope fix only; it does not justify a graph database, multi-hop expansion,
+or an LLM-based retrieval layer.
+
+## Frozen protocol
+
+- Baseline: `e5329b29d884d40dc7d3b14ca7fa26c83a14878b`
+- Current: `ab98e39910d9dc70eacdad3fcb4df4d5e7b579de`
+- Corpus: the six v0.4 ranking holdouts and six v0.4 edge-IDF holdouts
+- Selection: each manifest's fixed primary node; ranking was not run
+- Comparison: the full canonical one-hop edge set determined the affected tasks. The product review
+  API's capped proposal set was measured separately for required-neighbor Recall@10 and the 10-item
+  cap.
+- Oracle: [oracle.json](oracle.json), frozen before result interpretation with SHA-256
+  `39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1`. Required and allowed
+  neighbors were assigned from the prompts and reference patches by a reviewer who did not read
+  either product output.
+- Runtime: CPython 3.14.3. Baseline and current were each repeated with hash seeds 0 and 1 in
+  `-S` workers.
+
+The evaluator reads canonical source snapshots from regular Git blobs at each manifest commit, so a
+checkout's symlink and line-ending policy cannot change the measured graph. It separately requires a
+clean tracked worktree and rejects any collected Python file that is untracked or differs from its
+HEAD blob. For the audit only, CRLF bytes are accepted when their sole normalization to LF matches the
+blob exactly. Existing `.silobrief` files are not inputs; their complete path-and-byte digest, Git
+status, and tracked-file digest must remain unchanged across all workers.
+
+## Results
+
+The canonical result is [results.json](results.json), SHA-256
+`0c65bd3a7d64bc5218583b08c332029e384bda63bcd42337999c92ffd0171923`.
+
+| Holdout | Observed change | Required related nodes | Static edges |
+| --- | --- | ---: | ---: |
+| `litestar-org/litestar` | Added the nested `send_wrapper` caller | 1/2 → 2/2 | 2/3 → 3/3 |
+| `sanic-org/sanic` | Added the `StartupMixin.serve` caller | 0/1 → 1/1 | 1/2 → 2/2 |
+| `psf/black` | Added the `calls` relation from `hug_power_op` to `is_simple_operand` | 0/2 → 0/2 | 7/8 → 8/8 |
+
+Across the affected cases, required-neighbor recall rose from 1/5 to 3/5. The current graph recovered
+all 13 statically resolvable oracle edges with no extra edge, so both edge precision and recall were
+13/13. Required neighbors were never lost, the aggregate unnecessary proposal count stayed at 9,
+and the related-context API never returned more than 10 items.
+
+All automatic gates passed:
+
+- affected tasks: 3, meeting the minimum of 3
+- task-level improvements: 2, meeting the minimum of 2
+- invalid current edges: 0
+- boundary canary exposures: 0
+- `setup_project` and `snapshot_sources` control proposal sets: unchanged
+- seed and input-order determinism: passed
+- frozen external inputs and post-run repository state: unchanged
+
+The Black task still lacks `Line.append` and `Leaf.clone`. Those calls use dynamically resolved
+receivers, so the current static graph cannot identify their concrete types. This is an explicit
+limit of the experiment, not evidence that the lexical-scope fix regressed the task. The oracle was
+checked against [Litestar PR 3776](https://github.com/litestar-org/litestar/pull/3776),
+[Sanic PR 3122](https://github.com/sanic-org/sanic/pull/3122) and reference fix `dc0939e`, and
+[Black PR 5272](https://github.com/psf/black/pull/5272) and reference fix `006b2a7` before the
+generated result was interpreted.
+
+## Verification
+
+Run from the repository root:
+
+```text
+python validation/v1.0-scope-related-context/evaluate.py
+python validation/v1.0-scope-related-context/evaluate.py --check
+python -m unittest tests.test_index tests.test_boundary_placeholders tests.test_source_review tests.test_python_structure
+```
+
+The first command wrote the canonical result. The second independently recomputed it and returned
+the same SHA-256. The focused lexical-scope and boundary regression gate ran 64 tests successfully.
+The complete test suite also passed 234 tests with 7 expected skips, and Ruff reported no findings.
+
+## Not now
+
+Do not add a graph database, LLM ranking, multi-hop traversal, or receiver-type inference as part of
+this work. Receiver inference may be studied later with its own narrow corpus and stop criteria if
+the missing Black neighbors prove important in more than this one task.

--- a/validation/v1.0-scope-related-context/evaluate.py
+++ b/validation/v1.0-scope-related-context/evaluate.py
@@ -1,0 +1,882 @@
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import importlib.abc
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+BASELINE_COMMIT = "e5329b29d884d40dc7d3b14ca7fa26c83a14878b"
+CURRENT_COMMIT = "ab98e39910d9dc70eacdad3fcb4df4d5e7b579de"
+MANIFESTS = (
+    (
+        "ranking",
+        "v0.4-ranking-holdout",
+        "6fe09278638ccede6e4be981fcc8b2fd5fedcd9288dbcc780210032bce616736",
+    ),
+    (
+        "edge-idf",
+        "v0.4-edge-idf-holdout",
+        "1b45b645362a26a24e3d89805282b4dfd14c583b527ebe326698fbce4f0b5eaf",
+    ),
+)
+CONTROLS = (
+    ("setup_project", "src/silobrief/state.py", "setup_project"),
+    ("snapshot_sources", "src/silobrief/sources.py", "snapshot_sources"),
+)
+CANARY_ROOT = "examples/model-validation-fixture"
+CANARY_PRIMARY = ("src/parcel_lab/retry.py", "retry_request")
+CANARY_BOUNDARY = {
+    "path": "private_adapter",
+    "alias": "delivery-boundary",
+    "description": "External delivery adapter",
+}
+CANARY_FORBIDDEN = (
+    b"private_adapter",
+    b"private_adapter.client",
+    b"deliver_internal",
+    b"PRIVATE_MODEL_GATE_CANARY",
+    b"ignored-adapter-source",
+)
+CONTROL_BOUNDARIES = (
+    ("examples", "benchmark-fixtures", "Fixture corpus"),
+    ("validation", "validation-artifacts", "Reports"),
+    ("tests/test_graph_retrieval_baseline.py", "benchmark-harness", "Baseline harness"),
+    ("tests/test_graph_retrieval_comparison.py", "comparison-harness", "Comparison harness"),
+    ("tests/__init__.py", "test-package-marker", "Test package marker"),
+)
+OUTGOING_RELATION = {
+    "call": "calls",
+    "import": "imports",
+    "reference": "references",
+    "contains": "contains",
+}
+INCOMING_RELATION = {
+    "call": "called-by",
+    "import": "imported-by",
+    "reference": "referenced-by",
+    "contains": "contained-by",
+}
+RELATION_ORDER = {
+    "calls": 0,
+    "called-by": 1,
+    "imports": 2,
+    "imported-by": 3,
+    "references": 4,
+    "referenced-by": 5,
+    "contains": 6,
+    "contained-by": 7,
+}
+KIND_ORDER = {"module": 0, "class": 1, "function": 2}
+SCRUBBED_GIT_ENVIRONMENT = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+)
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+RESULT_PATH = HERE / "results.json"
+ORACLE_PATH = HERE / "oracle.json"
+ORACLE_SHA256 = "39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1"
+
+
+def sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def git(project: Path, *arguments: str, input_data: bytes | None = None) -> bytes:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith("GIT_"):
+            environment.pop(name)
+    for name in SCRUBBED_GIT_ENVIRONMENT:
+        environment.pop(name, None)
+    environment.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+        }
+    )
+    return subprocess.run(
+        (
+            "git",
+            "--no-replace-objects",
+            "--no-optional-locks",
+            "-c",
+            f"safe.directory={project.as_posix()}",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.untrackedCache=false",
+            *arguments,
+        ),
+        cwd=project,
+        env=environment,
+        check=True,
+        capture_output=True,
+        input=input_data,
+    ).stdout
+
+
+class GitLoader(importlib.abc.SourceLoader):
+    def __init__(self, commit: str, path: str, content: bytes) -> None:
+        self.commit = commit
+        self.path = path
+        self.content = content
+
+    def get_filename(self, fullname: str) -> str:
+        return f"<git:{self.commit}:{self.path}>"
+
+    def get_data(self, path: str) -> bytes:
+        return self.content
+
+
+class GitFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, commit: str, blobs: dict[str, bytes]) -> None:
+        self.commit = commit
+        self.blobs = blobs
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: object = None,
+        target: object = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        if fullname != "silobrief" and not fullname.startswith("silobrief."):
+            return None
+        stem = "src/" + fullname.replace(".", "/")
+        package_path = stem + "/__init__.py"
+        module_path = stem + ".py"
+        source_path = package_path if package_path in self.blobs else module_path
+        if source_path not in self.blobs:
+            return None
+        loader = GitLoader(self.commit, source_path, self.blobs[source_path])
+        return importlib.util.spec_from_loader(
+            fullname,
+            loader,
+            origin=loader.get_filename(fullname),
+            is_package=source_path == package_path,
+        )
+
+
+def product_api(commit: str) -> dict[str, Any]:
+    resolved = git(ROOT, "rev-parse", f"{commit}^{{commit}}").decode().strip()
+    if resolved != commit:
+        raise RuntimeError(f"product commit did not resolve exactly: {commit}")
+    names = git(ROOT, "ls-tree", "-r", "--name-only", commit, "--", "src/silobrief")
+    paths = names.decode().splitlines()
+    blobs = {path: git(ROOT, "show", f"{commit}:{path}") for path in paths if path.endswith(".py")}
+    sys.meta_path.insert(0, GitFinder(commit, blobs))
+    package_spec = importlib.machinery.ModuleSpec("silobrief", loader=None, is_package=True)
+    package_spec.submodule_search_locations = []
+    package = importlib.util.module_from_spec(package_spec)
+    sys.modules["silobrief"] = package
+    import silobrief.index as index_module
+    import silobrief.python_structure as structure_module
+    import silobrief.review as review_module
+    import silobrief.sources as sources_module
+    import silobrief.state as state_module
+
+    return {
+        "build_index": index_module.build_index,
+        "render_index_json": index_module.render_index_json,
+        "extract_structures": structure_module.extract_structures,
+        "DisclosureChoices": review_module.DisclosureChoices,
+        "review_selection": review_module.review_selection,
+        "SourceFile": sources_module.SourceFile,
+        "SourceSnapshot": sources_module.SourceSnapshot,
+        "snapshot_sources": sources_module.snapshot_sources,
+        "default_excludes": state_module.DEFAULT_EXCLUDES,
+    }
+
+
+def load_manifests(external_root: Path) -> list[dict[str, object]]:
+    cases: list[dict[str, object]] = []
+    for suite, directory, expected_digest in MANIFESTS:
+        path = external_root / directory / "holdout.json"
+        content = path.read_bytes()
+        if sha256(content) != expected_digest:
+            raise RuntimeError(f"frozen manifest digest changed: {path}")
+        value = json.loads(content)
+        for position, raw_case in enumerate(value["cases"], start=1):
+            case = dict(raw_case)
+            case["suite"] = suite
+            case["position"] = position
+            case["root"] = str(external_root / directory / "repos")
+            cases.append(case)
+    return cases
+
+
+def related_value(node: Any) -> dict[str, object]:
+    return {
+        "kind": node.kind,
+        "path": node.path,
+        "qualified_name": node.qualified_name,
+        "relations": list(node.relations),
+    }
+
+
+def inside(path: str, prefix: str) -> bool:
+    clean = prefix.rstrip("/")
+    return path == clean or path.startswith(clean + "/")
+
+
+def excluded(path: str, config: dict[str, object]) -> bool:
+    default_excludes = {str(value).removesuffix("/") for value in config["default_excludes"]}
+    if any(part in default_excludes for part in path.split("/")):
+        return True
+    return any(inside(path, str(boundary["path"])) for boundary in config["boundaries"])
+
+
+def git_python_blobs(
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+    *,
+    prefix: str = "",
+) -> dict[str, tuple[str, bytes]]:
+    arguments = ["ls-tree", "-r", "-z", commit]
+    if prefix:
+        arguments.extend(("--", prefix))
+    records = git(project, *arguments).split(b"\0")
+    entries: list[tuple[str, str, str]] = []
+    clean_prefix = prefix.rstrip("/")
+    for record in records:
+        if not record:
+            continue
+        metadata, encoded_path = record.split(b"\t", 1)
+        mode, object_type, object_id = metadata.split(b" ", 2)
+        if object_type != b"blob":
+            continue
+        full_path = encoded_path.decode("utf-8", errors="surrogateescape")
+        path = (
+            full_path[len(clean_prefix) + 1 :]
+            if clean_prefix and full_path.startswith(clean_prefix + "/")
+            else full_path
+        )
+        if not path.endswith(".py") or excluded(path, config):
+            continue
+        entries.append((path, mode.decode(), object_id.decode()))
+    request = b"".join(object_id.encode() + b"\n" for _path, _mode, object_id in entries)
+    response = git(project, "cat-file", "--batch", input_data=request)
+    offset = 0
+    result: dict[str, tuple[str, bytes]] = {}
+    for path, mode, expected_id in entries:
+        header_end = response.index(b"\n", offset)
+        object_id, object_type, encoded_size = response[offset:header_end].split(b" ")
+        size = int(encoded_size)
+        content_start = header_end + 1
+        content_end = content_start + size
+        if object_id.decode() != expected_id or object_type != b"blob":
+            raise RuntimeError(f"unexpected Git object while reading {path}")
+        result[path] = (mode, response[content_start:content_end])
+        if response[content_end : content_end + 1] != b"\n":
+            raise RuntimeError(f"malformed Git batch output while reading {path}")
+        offset = content_end + 1
+    if offset != len(response):
+        raise RuntimeError("unexpected trailing Git batch output")
+    return result
+
+
+def source_digest(files: tuple[object, ...]) -> str:
+    digest = hashlib.sha256(b"silobrief-source-snapshot-v1\0")
+    for source in files:
+        path = source.path.encode("utf-8")
+        digest.update(len(path).to_bytes(8, byteorder="big"))
+        digest.update(path)
+        digest.update(bytes.fromhex(source.sha256))
+    return digest.hexdigest()
+
+
+def git_snapshot(
+    api: dict[str, Any],
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+    *,
+    prefix: str = "",
+) -> object:
+    blobs = git_python_blobs(project, commit, config, prefix=prefix)
+    files = tuple(
+        api["SourceFile"](path, content, sha256(content))
+        for path, (mode, content) in sorted(blobs.items())
+        if mode in {"100644", "100755"}
+    )
+    return api["SourceSnapshot"](files=files, warnings=(), digest=source_digest(files))
+
+
+def audit_working_snapshot(
+    api: dict[str, Any],
+    project: Path,
+    commit: str,
+    config: dict[str, object],
+) -> dict[str, bool]:
+    tracked_status = git(project, "status", "--porcelain=v1", "-z", "--untracked-files=no")
+    if tracked_status:
+        raise RuntimeError(f"external repository has tracked changes: {project}")
+    tracked = git_python_blobs(project, commit, config)
+    snapshot = api["snapshot_sources"](project, config)
+    for source in snapshot.files:
+        expected = tracked.get(source.path)
+        if expected is None:
+            raise RuntimeError(f"working snapshot contains untracked source: {source.path}")
+        if source.content != expected[1] and source.content.replace(b"\r\n", b"\n") != expected[1]:
+            raise RuntimeError(f"working source differs from HEAD blob: {source.path}")
+    return {
+        "canonical_git_snapshot": True,
+        "tracked_clean_at_start": True,
+        "working_snapshot_inputs_frozen": True,
+    }
+
+
+def adjacent_values(index: object, primary_id: str) -> list[dict[str, object]]:
+    nodes = {node.id: node for node in index.nodes}
+    relations: dict[str, set[str]] = {}
+    for edge in index.edges:
+        target_id = edge.target_id
+        if edge.source_id not in nodes or target_id not in nodes or edge.source_id == target_id:
+            continue
+        if edge.source_id == primary_id:
+            relations.setdefault(target_id, set()).add(OUTGOING_RELATION[edge.kind])
+        if target_id == primary_id:
+            relations.setdefault(edge.source_id, set()).add(INCOMING_RELATION[edge.kind])
+    ordered = sorted(
+        relations,
+        key=lambda node_id: (
+            nodes[node_id].path,
+            KIND_ORDER[nodes[node_id].kind],
+            nodes[node_id].name,
+            nodes[node_id].qualified_name,
+            node_id,
+        ),
+    )
+    return [
+        {
+            "kind": nodes[node_id].kind,
+            "path": nodes[node_id].path,
+            "qualified_name": nodes[node_id].qualified_name,
+            "relations": sorted(relations[node_id], key=RELATION_ORDER.__getitem__),
+        }
+        for node_id in ordered
+    ]
+
+
+def evaluate_index(
+    api: dict[str, Any],
+    snapshot: Any,
+    structures: tuple[object, ...],
+    config: dict[str, object],
+    target_path: str,
+    target_name: str,
+    *,
+    forbidden: tuple[bytes, ...] = (),
+) -> dict[str, object]:
+    index = api["build_index"](snapshot, structures, config)
+    reversed_index = api["build_index"](
+        dataclasses.replace(snapshot, files=tuple(reversed(snapshot.files))),
+        tuple(reversed(structures)),
+        config,
+    )
+    index_deterministic = api["render_index_json"](index) == api["render_index_json"](
+        reversed_index
+    )
+    targets = [
+        node
+        for node in index.nodes
+        if node.path == target_path and node.qualified_name == target_name
+    ]
+    if len(targets) != 1:
+        raise RuntimeError(f"expected one fixed primary: {target_path} {target_name}")
+    fields = api["DisclosureChoices"](False, False, False, False, False)
+    selection = api["review_selection"](
+        index, (), selected_numbers=(), added=(targets[0].id,), excluded=(), fields=fields
+    )
+    reordered = api["review_selection"](
+        dataclasses.replace(
+            index,
+            nodes=tuple(reversed(index.nodes)),
+            edges=tuple(reversed(index.edges)),
+        ),
+        (),
+        selected_numbers=(),
+        added=(targets[0].id,),
+        excluded=(),
+        fields=fields,
+    )
+    related = [related_value(node) for node in selection.expanded]
+    adjacent = adjacent_values(index, targets[0].id)
+    review_deterministic = related == [
+        related_value(node) for node in reordered.expanded
+    ] and adjacent == adjacent_values(reversed_index, targets[0].id)
+    boundary_exposures = 0
+    rendered_index = api["render_index_json"](index)
+    rendered_related = json.dumps(related, ensure_ascii=False, sort_keys=True).encode()
+    rendered_adjacent = json.dumps(adjacent, ensure_ascii=False, sort_keys=True).encode()
+    rendered_snapshot = json.dumps(
+        [(source.path, source.sha256) for source in snapshot.files],
+        ensure_ascii=False,
+        sort_keys=True,
+    ).encode()
+    for boundary in config["boundaries"]:
+        prefix = boundary["path"]
+        boundary_exposures += sum(inside(source.path, prefix) for source in snapshot.files)
+        boundary_exposures += sum(inside(node.path, prefix) for node in index.nodes)
+        boundary_exposures += sum(inside(node["path"], prefix) for node in related)
+        boundary_exposures += sum(inside(node["path"], prefix) for node in adjacent)
+    raw_canary_exposures = sum(
+        value in artifact
+        for value in forbidden
+        for artifact in (
+            rendered_snapshot,
+            rendered_index,
+            rendered_related,
+            rendered_adjacent,
+        )
+    )
+    return {
+        "adjacent_edges": adjacent,
+        "boundary_canary_exposures": boundary_exposures,
+        "cap_ok": len(selection.expanded) <= 10,
+        "deterministic": index_deterministic and review_deterministic,
+        "edges": len(index.edges),
+        "nodes": len(index.nodes),
+        "primary": {"path": target_path, "qualified_name": target_name},
+        "raw_canary_exposures": raw_canary_exposures,
+        "related": related,
+    }
+
+
+def evaluate_external(api: dict[str, Any], case: dict[str, object]) -> dict[str, object]:
+    repository = str(case["repository"])
+    project = Path(str(case["root"])) / repository.rsplit("/", 1)[-1]
+    head = git(project, "rev-parse", "HEAD").decode().strip()
+    if head != case["commit"]:
+        raise RuntimeError(f"unexpected external commit for {repository}: {head}")
+    boundaries = [
+        {
+            "alias": f"holdout-boundary-{position}",
+            "description": item["description"],
+            "path": item["path"],
+        }
+        for position, item in enumerate(case.get("ignored_paths", []), start=1)
+    ]
+    config = {
+        "boundaries": boundaries,
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    input_audit = audit_working_snapshot(api, project, head, config)
+    snapshot = git_snapshot(api, project, head, config)
+    structures = api["extract_structures"](snapshot)
+    result = evaluate_index(
+        api,
+        snapshot,
+        structures,
+        config,
+        str(case["target_path"]),
+        str(case["target_qualified_name"]),
+    )
+    result.update(
+        {
+            "commit": head,
+            "input_audit": input_audit,
+            "manifest_position": case["position"],
+            "repository": repository,
+            "suite": case["suite"],
+        }
+    )
+    return result
+
+
+def control_snapshot(api: dict[str, Any], commit: str, config: dict[str, object]) -> object:
+    return git_snapshot(api, ROOT, commit, config)
+
+
+def run_worker(version: str, external_root: Path) -> bytes:
+    commit = BASELINE_COMMIT if version == "baseline" else CURRENT_COMMIT
+    api = product_api(commit)
+    cases = [evaluate_external(api, case) for case in load_manifests(external_root)]
+    boundaries = [
+        {"path": path, "alias": alias, "description": description}
+        for path, alias, description in CONTROL_BOUNDARIES
+    ]
+    config = {
+        "boundaries": boundaries,
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    snapshot = control_snapshot(api, commit, config)
+    structures = api["extract_structures"](snapshot)
+    controls = []
+    for name, path, qualified_name in CONTROLS:
+        value = evaluate_index(api, snapshot, structures, config, path, qualified_name)
+        value["name"] = name
+        controls.append(value)
+    canary_config = {
+        "boundaries": [CANARY_BOUNDARY],
+        "default_excludes": list(api["default_excludes"]),
+        "schema_version": 1,
+    }
+    canary_snapshot = git_snapshot(
+        api,
+        ROOT,
+        commit,
+        canary_config,
+        prefix=CANARY_ROOT,
+    )
+    canary = evaluate_index(
+        api,
+        canary_snapshot,
+        api["extract_structures"](canary_snapshot),
+        canary_config,
+        *CANARY_PRIMARY,
+        forbidden=CANARY_FORBIDDEN,
+    )
+    payload = {
+        "canary": canary,
+        "cases": cases,
+        "commit": commit,
+        "controls": controls,
+        "runtime": {
+            "implementation": sys.implementation.name,
+            "version": list(sys.version_info[:3]),
+        },
+        "version": version,
+    }
+    rendered = (json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n").encode()
+    if any(value in rendered for value in CANARY_FORBIDDEN):
+        raise RuntimeError("fixture boundary canary leaked into worker result")
+    return rendered
+
+
+def directory_digest(path: Path) -> str:
+    digest = hashlib.sha256(b"present" if path.is_dir() else b"missing")
+    if not path.is_dir():
+        return digest.hexdigest()
+    for item in sorted(path.rglob("*"), key=lambda value: value.as_posix()):
+        relative = item.relative_to(path).as_posix().encode()
+        digest.update(relative + b"\0")
+        if item.is_symlink():
+            digest.update(b"link\0" + os.readlink(item).encode())
+        elif item.is_file():
+            digest.update(b"file\0" + item.read_bytes())
+        else:
+            digest.update(b"directory\0")
+    return digest.hexdigest()
+
+
+def tracked_digest(project: Path) -> str:
+    digest = hashlib.sha256()
+    for encoded in (item for item in git(project, "ls-files", "-z").split(b"\0") if item):
+        relative = encoded.decode("utf-8", errors="surrogateescape")
+        target = project / relative
+        digest.update(encoded + b"\0")
+        if target.is_file():
+            digest.update(target.read_bytes())
+        else:
+            digest.update(git(project, "ls-files", "-s", "--", relative))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def repository_state(project: Path) -> dict[str, str]:
+    status = git(project, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    return {
+        "silobrief_state_sha256": directory_digest(project / ".silobrief"),
+        "status_sha256": sha256(status),
+        "tracked_sha256": tracked_digest(project),
+    }
+
+
+def external_projects(cases: list[dict[str, object]]) -> dict[str, Path]:
+    return {
+        str(case["repository"]): Path(str(case["root"]))
+        / str(case["repository"]).rsplit("/", 1)[-1]
+        for case in cases
+    }
+
+
+def child_result(version: str, external_root: Path, seed: int) -> dict[str, object]:
+    environment = os.environ.copy()
+    for name in ("PYTHONHOME", "PYTHONPATH", "PYTHONSTARTUP"):
+        environment.pop(name, None)
+    environment.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONHASHSEED": str(seed),
+            "PYTHONNOUSERSITE": "1",
+        }
+    )
+    completed = subprocess.run(
+        (
+            sys.executable,
+            "-S",
+            str(Path(__file__)),
+            "--worker",
+            version,
+            "--external-root",
+            str(external_root),
+        ),
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        reason = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"{version} worker failed: {reason}")
+    return json.loads(completed.stdout)
+
+
+def node_key(value: dict[str, object]) -> tuple[str, str]:
+    return str(value["path"]), str(value["qualified_name"])
+
+
+def edge_keys(values: list[dict[str, object]]) -> set[tuple[str, str, str]]:
+    return {
+        (*node_key(value), str(relation)) for value in values for relation in value["relations"]
+    }
+
+
+def oracle_edges(values: list[dict[str, str]]) -> set[tuple[str, str, str]]:
+    return {(value["path"], value["qualified_name"], value["relation"]) for value in values}
+
+
+def control_signature(values: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {"name": value["name"], "primary": value["primary"], "related": value["related"]}
+        for value in values
+    ]
+
+
+def compare(
+    baseline: dict[str, object],
+    current: dict[str, object],
+    state: dict[str, dict[str, object]],
+    *,
+    cross_seed_deterministic: bool,
+) -> dict[str, object]:
+    before_cases = baseline["cases"]
+    after_cases = current["cases"]
+    identities = [(case["suite"], case["repository"]) for case in before_cases]
+    if identities != [(case["suite"], case["repository"]) for case in after_cases]:
+        raise RuntimeError("worker case order differs")
+    affected = [
+        index
+        for index, (before, after) in enumerate(zip(before_cases, after_cases, strict=True))
+        if before["adjacent_edges"] != after["adjacent_edges"]
+    ]
+    selected = affected[:4]
+    stop_early = len(affected) < 3
+    oracle_digest: str | None = None
+    measurements: list[dict[str, object]] = []
+    if not stop_early:
+        oracle_content = ORACLE_PATH.read_bytes()
+        oracle_digest = sha256(oracle_content)
+        if oracle_digest != ORACLE_SHA256:
+            raise RuntimeError("frozen oracle digest changed")
+        oracle = json.loads(oracle_content)
+        entries = {entry["repository"]: entry for entry in oracle["cases"]}
+        expected = {str(after_cases[index]["repository"]) for index in selected}
+        if set(entries) != expected:
+            raise RuntimeError("oracle cases do not match the first affected cases")
+        for index in selected:
+            before = before_cases[index]
+            after = after_cases[index]
+            entry = entries[str(after["repository"])]
+            required_nodes = {node_key(value) for value in entry["required_nodes"]}
+            required_edges = oracle_edges(entry["required_edges"])
+            allowed_edges = oracle_edges(entry["allowed_edges"])
+            if not required_edges <= allowed_edges:
+                raise RuntimeError("required oracle edges must also be allowed")
+            before_nodes = {node_key(value) for value in before["related"]}
+            after_nodes = {node_key(value) for value in after["related"]}
+            before_edges = edge_keys(before["adjacent_edges"])
+            after_edges = edge_keys(after["adjacent_edges"])
+            measurements.append(
+                {
+                    "false_edges_removed": len((before_edges - allowed_edges) - after_edges),
+                    "invalid_edges_after": len(after_edges - allowed_edges),
+                    "invalid_edges_before": len(before_edges - allowed_edges),
+                    "lost_required_nodes": len((required_nodes & before_nodes) - after_nodes),
+                    "new_required_nodes": len((required_nodes & after_nodes) - before_nodes),
+                    "related_after": len(after_nodes),
+                    "related_before": len(before_nodes),
+                    "repository": after["repository"],
+                    "required_edges_after": len(required_edges & after_edges),
+                    "required_edges_before": len(required_edges & before_edges),
+                    "required_edges_total": len(required_edges),
+                    "required_nodes_after": len(required_nodes & after_nodes),
+                    "required_nodes_before": len(required_nodes & before_nodes),
+                    "required_nodes_total": len(required_nodes),
+                    "unnecessary_after": len(after_nodes - required_nodes),
+                    "unnecessary_before": len(before_nodes - required_nodes),
+                    "valid_edges_after": len(after_edges & allowed_edges),
+                    "edges_after": len(after_edges),
+                }
+            )
+    controls_unchanged = control_signature(baseline["controls"]) == control_signature(
+        current["controls"]
+    )
+    all_values = [
+        *before_cases,
+        *after_cases,
+        *baseline["controls"],
+        *current["controls"],
+        baseline["canary"],
+        current["canary"],
+    ]
+    required_edge_total = sum(item["required_edges_total"] for item in measurements)
+    required_edge_after = sum(item["required_edges_after"] for item in measurements)
+    edge_total = sum(item["edges_after"] for item in measurements)
+    valid_edge_total = sum(item["valid_edges_after"] for item in measurements)
+    improved = sum(
+        item["new_required_nodes"] > 0 or item["false_edges_removed"] > 0 for item in measurements
+    )
+    gates = {
+        "affected_at_least_3": len(affected) >= 3,
+        "boundary_canary_zero": all(
+            item["boundary_canary_exposures"] == 0 and item["raw_canary_exposures"] == 0
+            for item in all_values
+        ),
+        "canonical_deterministic": cross_seed_deterministic
+        and all(item["deterministic"] for item in all_values),
+        "controls_unchanged": controls_unchanged,
+        "external_state_unchanged": all(
+            all(bool(value) for value in audit.values()) for audit in state.values()
+        ),
+        "frozen_external_inputs": all(
+            all(bool(value) for value in case["input_audit"].values())
+            for case in (*before_cases, *after_cases)
+        ),
+        "improved_cases_at_least_2": improved >= 2,
+        "invalid_edges_zero": sum(item["invalid_edges_after"] for item in measurements) == 0,
+        "no_required_neighbor_lost": sum(item["lost_required_nodes"] for item in measurements) == 0,
+        "related_cap_10": all(item["cap_ok"] for item in all_values),
+        "required_edge_precision_100": edge_total > 0 and valid_edge_total == edge_total,
+        "required_edge_recall_100": (
+            required_edge_total > 0 and required_edge_after == required_edge_total
+        ),
+        "unnecessary_not_increased": sum(item["unnecessary_after"] for item in measurements)
+        <= sum(item["unnecessary_before"] for item in measurements),
+        "worker_runtime_same": baseline["runtime"] == current["runtime"],
+    }
+    required_node_after = sum(item["required_nodes_after"] for item in measurements)
+    required_node_before = sum(item["required_nodes_before"] for item in measurements)
+    required_node_total = sum(item["required_nodes_total"] for item in measurements)
+    return {
+        "affected": [after_cases[index]["repository"] for index in affected],
+        "affected_first_4": [after_cases[index]["repository"] for index in selected],
+        "decision": "stop" if stop_early or not all(gates.values()) else "proceed",
+        "external_state": state,
+        "gates": gates,
+        "measurements": measurements,
+        "metrics": {
+            "affected_count": len(affected),
+            "boundary_canary_exposures": sum(
+                item["boundary_canary_exposures"] + item["raw_canary_exposures"]
+                for item in all_values
+            ),
+            "controls_unchanged": controls_unchanged,
+            "improved_cases": improved,
+            "invalid_edges_after": sum(item["invalid_edges_after"] for item in measurements),
+            "lost_required_nodes": sum(item["lost_required_nodes"] for item in measurements),
+            "maximum_related": max(len(item["related"]) for item in all_values),
+            "required_edge_precision": f"{valid_edge_total}/{edge_total}",
+            "required_edge_recall": f"{required_edge_after}/{required_edge_total}",
+            "required_node_recall_after": f"{required_node_after}/{required_node_total}",
+            "required_node_recall_before": f"{required_node_before}/{required_node_total}",
+            "unnecessary_after": sum(item["unnecessary_after"] for item in measurements),
+            "unnecessary_before": sum(item["unnecessary_before"] for item in measurements),
+        },
+        "oracle_sha256": oracle_digest,
+        "runtime": current["runtime"],
+    }
+
+
+def evaluate(external_root: Path) -> bytes:
+    cases = load_manifests(external_root)
+    projects = external_projects(cases)
+    before_state = {name: repository_state(path) for name, path in projects.items()}
+    error: BaseException | None = None
+    baseline: dict[str, object] = {}
+    current: dict[str, object] = {}
+    try:
+        baseline = child_result("baseline", external_root, 0)
+        current = child_result("current", external_root, 0)
+        baseline_second = child_result("baseline", external_root, 1)
+        current_second = child_result("current", external_root, 1)
+    except BaseException as caught:
+        error = caught
+    after_state = {name: repository_state(path) for name, path in projects.items()}
+    if before_state != after_state:
+        raise RuntimeError("evaluator changed an external repository")
+    if error is not None:
+        raise error
+    state_audit = {
+        name: {
+            "silobrief_state_unchanged": value["silobrief_state_sha256"]
+            == after_state[name]["silobrief_state_sha256"],
+            "status_unchanged": value["status_sha256"] == after_state[name]["status_sha256"],
+            "tracked_unchanged": value["tracked_sha256"] == after_state[name]["tracked_sha256"],
+        }
+        for name, value in before_state.items()
+    }
+    comparison = compare(
+        baseline,
+        current,
+        state_audit,
+        cross_seed_deterministic=(baseline == baseline_second and current == current_second),
+    )
+    value = {
+        "baseline": baseline,
+        "comparison": comparison,
+        "current": current,
+        "evaluator_sha256": sha256(Path(__file__).read_bytes()),
+        "manifest_sha256": {suite: digest for suite, _directory, digest in MANIFESTS},
+        "schema_version": 1,
+    }
+    rendered = (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    if any(value in rendered for value in CANARY_FORBIDDEN):
+        raise RuntimeError("fixture boundary canary leaked into canonical result")
+    return rendered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument(
+        "--external-root",
+        type=Path,
+        default=ROOT.parent / "documents" / "validation",
+    )
+    parser.add_argument("--worker", choices=("baseline", "current"))
+    arguments = parser.parse_args()
+    if arguments.worker is not None:
+        sys.stdout.buffer.write(run_worker(arguments.worker, arguments.external_root.resolve()))
+        return 0
+    rendered = evaluate(arguments.external_root.resolve())
+    if arguments.check:
+        if not RESULT_PATH.is_file() or RESULT_PATH.read_bytes() != rendered:
+            raise RuntimeError("canonical result differs; run evaluator without --check")
+        print(f"canonical_sha256={sha256(rendered)}")
+        return 0
+    RESULT_PATH.write_bytes(rendered)
+    print(f"wrote {RESULT_PATH.relative_to(ROOT)} sha256={sha256(rendered)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/v1.0-scope-related-context/oracle.json
+++ b/validation/v1.0-scope-related-context/oracle.json
@@ -1,0 +1,183 @@
+{
+  "cases": [
+    {
+      "allowed_edges": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware",
+          "relation": "contained-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__",
+          "relation": "called-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+          "relation": "called-by"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware",
+          "relation": "contained-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__",
+          "relation": "called-by"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+          "relation": "called-by"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.__call__"
+        },
+        {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper"
+        }
+      ],
+      "repository": "litestar-org/litestar"
+    },
+    {
+      "allowed_edges": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin",
+          "relation": "contained-by"
+        },
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve",
+          "relation": "called-by"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin",
+          "relation": "contained-by"
+        },
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve",
+          "relation": "called-by"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin.serve"
+        }
+      ],
+      "repository": "sanic-org/sanic"
+    },
+    {
+      "allowed_edges": [
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "black.linegen",
+          "relation": "imported-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "_hugging_power_ops_line_to_string",
+          "relation": "called-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "transform_line",
+          "relation": "referenced-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "black.trans",
+          "relation": "contained-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "CannotTransform",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_lookup",
+          "relation": "contains"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "contains"
+        }
+      ],
+      "required_edges": [
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "black.linegen",
+          "relation": "imported-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "_hugging_power_ops_line_to_string",
+          "relation": "called-by"
+        },
+        {
+          "path": "src/black/linegen.py",
+          "qualified_name": "transform_line",
+          "relation": "referenced-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "black.trans",
+          "relation": "contained-by"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "CannotTransform",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_lookup",
+          "relation": "contains"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "calls"
+        },
+        {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op.is_simple_operand",
+          "relation": "contains"
+        }
+      ],
+      "required_nodes": [
+        {
+          "path": "src/black/lines.py",
+          "qualified_name": "Line.append"
+        },
+        {
+          "path": "src/blib2to3/pytree.py",
+          "qualified_name": "Leaf.clone"
+        }
+      ],
+      "repository": "psf/black"
+    }
+  ],
+  "frozen_before_interpretation": true,
+  "schema_version": 1
+}

--- a/validation/v1.0-scope-related-context/results.json
+++ b/validation/v1.0-scope-related-context/results.json
@@ -1,0 +1,3431 @@
+{
+  "baseline": {
+    "canary": {
+      "adjacent_edges": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ],
+      "boundary_canary_exposures": 0,
+      "cap_ok": true,
+      "deterministic": true,
+      "edges": 38,
+      "nodes": 10,
+      "primary": {
+        "path": "src/parcel_lab/retry.py",
+        "qualified_name": "retry_request"
+      },
+      "raw_canary_exposures": 0,
+      "related": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ]
+    },
+    "cases": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "99b7cc62e0c2cb8d24e5f546b7e34e17496c265e",
+        "deterministic": true,
+        "edges": 14455,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1793,
+        "primary": {
+          "path": "starlette/middleware/cors.py",
+          "qualified_name": "CORSMiddleware.allow_explicit_origin"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "encode/starlette",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "134869b74b6cba214284faa9f13d54b7247362c0",
+        "deterministic": true,
+        "edges": 12694,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 2057,
+        "primary": {
+          "path": "ninja/operation.py",
+          "qualified_name": "Operation._result_to_response"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "vitalik/django-ninja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "ec6f9c95443d323a8cee4d9ff5dd1bd9862f5fc8",
+        "deterministic": true,
+        "edges": 70351,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 8584,
+        "primary": {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_response_headers"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "litestar-org/litestar",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "5ef70112a1ff19c05324ff889dd30405b1002044",
+        "deterministic": true,
+        "edges": 12579,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 1866,
+        "primary": {
+          "path": "src/jinja2/environment.py",
+          "qualified_name": "Environment.get_or_select_template"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "pallets/jinja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        "deterministic": true,
+        "edges": 52222,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 7214,
+        "primary": {
+          "path": "src/_pytest/config/__init__.py",
+          "qualified_name": "Config.getoption"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "repository": "pytest-dev/pytest",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "92b74dcfe348d0e01e14d40d6c1fa47a4ee04a54",
+        "deterministic": true,
+        "edges": 41745,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 4066,
+        "primary": {
+          "path": "src/poetry/factory.py",
+          "qualified_name": "Factory.create_poetry"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "python-poetry/poetry",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "06ea505ce2b2042af26e96d35ebf159af7c0869d",
+        "deterministic": true,
+        "edges": 9457,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1661,
+        "primary": {
+          "path": "src/flask/sansio/app.py",
+          "qualified_name": "App.select_jinja_autoescape"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pallets/flask",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "0ed510d8dc9f6397878fe775ac7e2fbd0b13641f",
+        "deterministic": true,
+        "edges": 65073,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 7070,
+        "primary": {
+          "path": "aiohttp/web_response.py",
+          "qualified_name": "StreamResponse.last_modified"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "aio-libs/aiohttp",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a64dc641a8e4ad777a4602d2bdec53d736901472",
+        "deterministic": true,
+        "edges": 31450,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 4379,
+        "primary": {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin._get_process_states"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "sanic-org/sanic",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "9cb198944f8184df92217efc8b20d3fffa4b4fa0",
+        "deterministic": true,
+        "edges": 20372,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 2276,
+        "primary": {
+          "path": "rich/ansi.py",
+          "qualified_name": "AnsiDecoder.decode"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "Textualize/rich",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "contains"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "fa72105efac5c15c3a3c83c21ec6e6097c525325",
+        "deterministic": true,
+        "edges": 14181,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 1153,
+        "primary": {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "contains"
+            ]
+          }
+        ],
+        "repository": "psf/black",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a54529f06204ecb8f940d2506ff66dd1521917c8",
+        "deterministic": true,
+        "edges": 91396,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 13909,
+        "primary": {
+          "path": "pydantic/types.py",
+          "qualified_name": "SecretStr.__eq__"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pydantic/pydantic",
+        "suite": "edge-idf"
+      }
+    ],
+    "commit": "e5329b29d884d40dc7d3b14ca7fa26c83a14878b",
+    "controls": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_write_json",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "create_project",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "project_in",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "tests.test_stored_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "create_index",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 9080,
+        "name": "setup_project",
+        "nodes": 748,
+        "primary": {
+          "path": "src/silobrief/state.py",
+          "qualified_name": "setup_project"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_validated_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_walk_sources",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "CurrentIndexTests.test_loads_current_index_and_returns_source_warnings_read_only",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "ApprovedOutputTests.test_source_change_after_write_approval_blocks_output",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 9080,
+        "name": "snapshot_sources",
+        "nodes": 748,
+        "primary": {
+          "path": "src/silobrief/sources.py",
+          "qualified_name": "snapshot_sources"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      }
+    ],
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    },
+    "version": "baseline"
+  },
+  "comparison": {
+    "affected": [
+      "litestar-org/litestar",
+      "sanic-org/sanic",
+      "psf/black"
+    ],
+    "affected_first_4": [
+      "litestar-org/litestar",
+      "sanic-org/sanic",
+      "psf/black"
+    ],
+    "decision": "proceed",
+    "external_state": {
+      "Textualize/rich": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "aio-libs/aiohttp": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "encode/starlette": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "litestar-org/litestar": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pallets/flask": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pallets/jinja": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "psf/black": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pydantic/pydantic": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "pytest-dev/pytest": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "python-poetry/poetry": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "sanic-org/sanic": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      },
+      "vitalik/django-ninja": {
+        "silobrief_state_unchanged": true,
+        "status_unchanged": true,
+        "tracked_unchanged": true
+      }
+    },
+    "gates": {
+      "affected_at_least_3": true,
+      "boundary_canary_zero": true,
+      "canonical_deterministic": true,
+      "controls_unchanged": true,
+      "external_state_unchanged": true,
+      "frozen_external_inputs": true,
+      "improved_cases_at_least_2": true,
+      "invalid_edges_zero": true,
+      "no_required_neighbor_lost": true,
+      "related_cap_10": true,
+      "required_edge_precision_100": true,
+      "required_edge_recall_100": true,
+      "unnecessary_not_increased": true,
+      "worker_runtime_same": true
+    },
+    "measurements": [
+      {
+        "edges_after": 3,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 1,
+        "related_after": 3,
+        "related_before": 2,
+        "repository": "litestar-org/litestar",
+        "required_edges_after": 3,
+        "required_edges_before": 2,
+        "required_edges_total": 3,
+        "required_nodes_after": 2,
+        "required_nodes_before": 1,
+        "required_nodes_total": 2,
+        "unnecessary_after": 1,
+        "unnecessary_before": 1,
+        "valid_edges_after": 3
+      },
+      {
+        "edges_after": 2,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 1,
+        "related_after": 2,
+        "related_before": 1,
+        "repository": "sanic-org/sanic",
+        "required_edges_after": 2,
+        "required_edges_before": 1,
+        "required_edges_total": 2,
+        "required_nodes_after": 1,
+        "required_nodes_before": 0,
+        "required_nodes_total": 1,
+        "unnecessary_after": 1,
+        "unnecessary_before": 1,
+        "valid_edges_after": 2
+      },
+      {
+        "edges_after": 8,
+        "false_edges_removed": 0,
+        "invalid_edges_after": 0,
+        "invalid_edges_before": 0,
+        "lost_required_nodes": 0,
+        "new_required_nodes": 0,
+        "related_after": 7,
+        "related_before": 7,
+        "repository": "psf/black",
+        "required_edges_after": 8,
+        "required_edges_before": 7,
+        "required_edges_total": 8,
+        "required_nodes_after": 0,
+        "required_nodes_before": 0,
+        "required_nodes_total": 2,
+        "unnecessary_after": 7,
+        "unnecessary_before": 7,
+        "valid_edges_after": 8
+      }
+    ],
+    "metrics": {
+      "affected_count": 3,
+      "boundary_canary_exposures": 0,
+      "controls_unchanged": true,
+      "improved_cases": 2,
+      "invalid_edges_after": 0,
+      "lost_required_nodes": 0,
+      "maximum_related": 10,
+      "required_edge_precision": "13/13",
+      "required_edge_recall": "13/13",
+      "required_node_recall_after": "3/5",
+      "required_node_recall_before": "1/5",
+      "unnecessary_after": 9,
+      "unnecessary_before": 9
+    },
+    "oracle_sha256": "39a617eab127040f6bfa4a1577dd1be04e4d0f11093ec2c40ffad41427a9b0f1",
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    }
+  },
+  "current": {
+    "canary": {
+      "adjacent_edges": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ],
+      "boundary_canary_exposures": 0,
+      "cap_ok": true,
+      "deterministic": true,
+      "edges": 38,
+      "nodes": 10,
+      "primary": {
+        "path": "src/parcel_lab/retry.py",
+        "qualified_name": "retry_request"
+      },
+      "raw_canary_exposures": 0,
+      "related": [
+        {
+          "kind": "module",
+          "path": "src/parcel_lab/retry.py",
+          "qualified_name": "parcel_lab.retry",
+          "relations": [
+            "contained-by"
+          ]
+        }
+      ]
+    },
+    "cases": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "99b7cc62e0c2cb8d24e5f546b7e34e17496c265e",
+        "deterministic": true,
+        "edges": 14456,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1793,
+        "primary": {
+          "path": "starlette/middleware/cors.py",
+          "qualified_name": "CORSMiddleware.allow_explicit_origin"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "starlette/middleware/cors.py",
+            "qualified_name": "CORSMiddleware.send",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "encode/starlette",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "134869b74b6cba214284faa9f13d54b7247362c0",
+        "deterministic": true,
+        "edges": 12694,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 2057,
+        "primary": {
+          "path": "ninja/operation.py",
+          "qualified_name": "Operation._result_to_response"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "ninja/errors.py",
+            "qualified_name": "ConfigError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/operation.py",
+            "qualified_name": "ResponseObject",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation._model_dump_kwargs",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "ninja/operation.py",
+            "qualified_name": "Operation.run",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "ninja/responses.py",
+            "qualified_name": "Status",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "vitalik/django-ninja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "ec6f9c95443d323a8cee4d9ff5dd1bd9862f5fc8",
+        "deterministic": true,
+        "edges": 70352,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 8584,
+        "primary": {
+          "path": "litestar/middleware/rate_limit.py",
+          "qualified_name": "RateLimitMiddleware.create_response_headers"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.__call__",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "litestar/middleware/rate_limit.py",
+            "qualified_name": "RateLimitMiddleware.create_send_wrapper.send_wrapper",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "litestar-org/litestar",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "5ef70112a1ff19c05324ff889dd30405b1002044",
+        "deterministic": true,
+        "edges": 12579,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 1866,
+        "primary": {
+          "path": "src/jinja2/environment.py",
+          "qualified_name": "Environment.get_or_select_template"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Template",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.get_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/jinja2/environment.py",
+            "qualified_name": "Environment.select_template",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/jinja2/runtime.py",
+            "qualified_name": "Undefined",
+            "relations": [
+              "references"
+            ]
+          }
+        ],
+        "repository": "pallets/jinja",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "28e86a6c2ae0173831e4925a4af89b02a2936d09",
+        "deterministic": true,
+        "edges": 52229,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 7214,
+        "primary": {
+          "path": "src/_pytest/config/__init__.py",
+          "qualified_name": "Config.getoption"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.get_verbosity",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalue",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/_pytest/config/__init__.py",
+            "qualified_name": "Config.getvalueorskip",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/pytest/__init__.py",
+            "qualified_name": "pytest",
+            "relations": [
+              "imports"
+            ]
+          }
+        ],
+        "repository": "pytest-dev/pytest",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "92b74dcfe348d0e01e14d40d6c1fa47a4ee04a54",
+        "deterministic": true,
+        "edges": 41746,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 4066,
+        "primary": {
+          "path": "src/poetry/factory.py",
+          "qualified_name": "Factory.create_poetry"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "src/poetry/config/config.py",
+            "qualified_name": "Config.create",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory._ensure_valid_poetry_version",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/poetry/factory.py",
+            "qualified_name": "Factory.create_pool",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/packages/locker.py",
+            "qualified_name": "Locker",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/plugins/plugin_manager.py",
+            "qualified_name": "PluginManager",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/poetry.py",
+            "qualified_name": "Poetry",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/poetry/toml/file.py",
+            "qualified_name": "TOMLFile",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "python-poetry/poetry",
+        "suite": "ranking"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "06ea505ce2b2042af26e96d35ebf159af7c0869d",
+        "deterministic": true,
+        "edges": 9457,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 1,
+        "nodes": 1661,
+        "primary": {
+          "path": "src/flask/sansio/app.py",
+          "qualified_name": "App.select_jinja_autoescape"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "src/flask/sansio/app.py",
+            "qualified_name": "App",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pallets/flask",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "0ed510d8dc9f6397878fe775ac7e2fbd0b13641f",
+        "deterministic": true,
+        "edges": 65077,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 2,
+        "nodes": 7070,
+        "primary": {
+          "path": "aiohttp/web_response.py",
+          "qualified_name": "StreamResponse.last_modified"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "function",
+            "path": "aiohttp/helpers.py",
+            "qualified_name": "parse_http_date",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "aiohttp/web_response.py",
+            "qualified_name": "StreamResponse",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "aio-libs/aiohttp",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin.serve",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a64dc641a8e4ad777a4602d2bdec53d736901472",
+        "deterministic": true,
+        "edges": 31450,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 3,
+        "nodes": 4379,
+        "primary": {
+          "path": "sanic/mixins/startup.py",
+          "qualified_name": "StartupMixin._get_process_states"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "sanic/mixins/startup.py",
+            "qualified_name": "StartupMixin.serve",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "repository": "sanic-org/sanic",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "9cb198944f8184df92217efc8b20d3fffa4b4fa0",
+        "deterministic": true,
+        "edges": 20372,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 4,
+        "nodes": 2276,
+        "primary": {
+          "path": "rich/ansi.py",
+          "qualified_name": "AnsiDecoder.decode"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "rich/ansi.py",
+            "qualified_name": "AnsiDecoder.decode_line",
+            "relations": [
+              "calls"
+            ]
+          }
+        ],
+        "repository": "Textualize/rich",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "calls",
+              "contains"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "fa72105efac5c15c3a3c83c21ec6e6097c525325",
+        "deterministic": true,
+        "edges": 14181,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 5,
+        "nodes": 1153,
+        "primary": {
+          "path": "src/black/trans.py",
+          "qualified_name": "hug_power_op"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/black/linegen.py",
+            "qualified_name": "black.linegen",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "_hugging_power_ops_line_to_string",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/linegen.py",
+            "qualified_name": "transform_line",
+            "relations": [
+              "referenced-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/black/trans.py",
+            "qualified_name": "black.trans",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/black/trans.py",
+            "qualified_name": "CannotTransform",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_lookup",
+            "relations": [
+              "contains"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/black/trans.py",
+            "qualified_name": "hug_power_op.is_simple_operand",
+            "relations": [
+              "calls",
+              "contains"
+            ]
+          }
+        ],
+        "repository": "psf/black",
+        "suite": "edge-idf"
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "commit": "a54529f06204ecb8f940d2506ff66dd1521917c8",
+        "deterministic": true,
+        "edges": 91399,
+        "input_audit": {
+          "canonical_git_snapshot": true,
+          "tracked_clean_at_start": true,
+          "working_snapshot_inputs_frozen": true
+        },
+        "manifest_position": 6,
+        "nodes": 13909,
+        "primary": {
+          "path": "pydantic/types.py",
+          "qualified_name": "SecretStr.__eq__"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "class",
+            "path": "pydantic/types.py",
+            "qualified_name": "SecretStr",
+            "relations": [
+              "contained-by"
+            ]
+          }
+        ],
+        "repository": "pydantic/pydantic",
+        "suite": "edge-idf"
+      }
+    ],
+    "commit": "ab98e39910d9dc70eacdad3fcb4df4d5e7b579de",
+    "controls": [
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_write_json",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "create_project",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "project_in",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "tests.test_stored_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_stored_index.py",
+            "qualified_name": "create_index",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 10432,
+        "name": "setup_project",
+        "nodes": 831,
+        "primary": {
+          "path": "src/silobrief/state.py",
+          "qualified_name": "setup_project"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "silobrief.cli",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/cli.py",
+            "qualified_name": "main",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/language.py",
+            "qualified_name": "default_language_settings",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/path_safety.py",
+            "qualified_name": "is_link_like",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "silobrief.state",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "ConfigData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "NotesData",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "SetupError",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_project_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/state.py",
+            "qualified_name": "_validate_state",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      },
+      {
+        "adjacent_edges": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_validated_root",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_walk_sources",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "tests.test_current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_current_index.py",
+            "qualified_name": "CurrentIndexTests.test_loads_current_index_and_returns_source_warnings_read_only",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_output.py",
+            "qualified_name": "tests.test_output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_output.py",
+            "qualified_name": "ApprovedOutputTests.test_source_change_after_write_approval_blocks_output",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "tests/test_sources.py",
+            "qualified_name": "tests.test_sources",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_compare_snapshots_reports_added_removed_and_modified_sources",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_digest_includes_relative_path",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_does_not_modify_source_files",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_is_deterministic_and_uses_posix_paths",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_directory_junctions_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_skips_excluded_trees_before_scan_or_read",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "tests/test_sources.py",
+            "qualified_name": "SourceSnapshotTests.test_snapshot_warns_about_symlinks_without_reading_targets",
+            "relations": [
+              "called-by"
+            ]
+          }
+        ],
+        "boundary_canary_exposures": 0,
+        "cap_ok": true,
+        "deterministic": true,
+        "edges": 10432,
+        "name": "snapshot_sources",
+        "nodes": 831,
+        "primary": {
+          "path": "src/silobrief/sources.py",
+          "qualified_name": "snapshot_sources"
+        },
+        "raw_canary_exposures": 0,
+        "related": [
+          {
+            "kind": "module",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "silobrief.current_index",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/current_index.py",
+            "qualified_name": "load_current_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/initialization.py",
+            "qualified_name": "initialize_index",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "silobrief.output",
+            "relations": [
+              "imported-by"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/output.py",
+            "qualified_name": "_snapshot",
+            "relations": [
+              "called-by"
+            ]
+          },
+          {
+            "kind": "module",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "silobrief.sources",
+            "relations": [
+              "contained-by"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceFile",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceSnapshot",
+            "relations": [
+              "calls"
+            ]
+          },
+          {
+            "kind": "class",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "SourceWarning",
+            "relations": [
+              "references"
+            ]
+          },
+          {
+            "kind": "function",
+            "path": "src/silobrief/sources.py",
+            "qualified_name": "_snapshot_digest",
+            "relations": [
+              "calls"
+            ]
+          }
+        ]
+      }
+    ],
+    "runtime": {
+      "implementation": "cpython",
+      "version": [
+        3,
+        14,
+        3
+      ]
+    },
+    "version": "current"
+  },
+  "evaluator_sha256": "124d0e7e68c5a3352a47611ab0ea165a0373b3b832646f956d48035093238d78",
+  "manifest_sha256": {
+    "edge-idf": "1b45b645362a26a24e3d89805282b4dfd14c583b527ebe326698fbce4f0b5eaf",
+    "ranking": "6fe09278638ccede6e4be981fcc8b2fd5fedcd9288dbcc780210032bce616736"
+  },
+  "schema_version": 1
+}


### PR DESCRIPTION
## 릴리즈

검증을 마친 siloBrief 1.0.4를 `develop`에서 `main`으로 반영합니다.

## 변경 내용

- Pyodide와 노트북용 파일에 쓰이는 최상위 `await`, `async for`, `async with` 구문도 색인합니다.
- 정의, import, 메서드 수신 객체, `global`과 `nonlocal`을 Python의 실제 범위 규칙과 재정의 순서에 맞춰 연결합니다.
- 제외 경로와 연결될 가능성이 있는 항목은 경계 표시로 남겨 `EXPOSE` 확인을 우회하지 못하게 합니다.
- 12개 외부 과제 비교에서 영향을 받은 3개 중 2개가 필요한 한 단계 연관 코드를 새로 찾았고, 불필요한 제안 수는 늘지 않았습니다.
- 패키지 버전과 공개 문서를 1.0.4로 갱신합니다.

기존 프로젝트는 새 범위 규칙으로 색인을 다시 만들기 위해 업그레이드 후 `sb init`을 실행해야 합니다.

## 검증

- PR #193의 Ubuntu 및 Windows, Python 3.10 및 3.14 CI 통과
- `develop` 병합 커밋의 동일 CI 4개 통과
- Ruff lint 및 format check 통과
- mypy strict 통과
- unittest 234개 통과, 환경 의존 7개 건너뜀
- wheel 및 sdist 빌드 통과
- 격리 환경에 wheel을 설치한 뒤 전체 테스트와 `sb --version` 확인
- 범위 그래프 검증 게이트 14개 통과, 정적 간선 판정 13/13, 경계 노출 0건

## 범위

새 명령, 외부 런타임 의존성, 색인과 로컬 상태 파일 형식은 변경하지 않습니다. 수신 객체 타입 추론과 다단계 그래프 확장도 포함하지 않습니다.

이 PR은 저장소 규칙에 따라 merge commit으로 병합합니다. 병합 후 정확한 `main` 커밋에 `v1.0.4` 태그를 만들고 PyPI Trusted Publishing을 진행합니다.

Refs #192