### PR TITLE
fix(excerpts): preserve repeated definition spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve every source span for repeated definitions such as property accessors, overloads, and
+  conditional implementations (#197).
+
 ## [1.0.4] - 2026-08-19
 
 ### Added

--- a/src/silobrief/source_excerpts.py
+++ b/src/silobrief/source_excerpts.py
@@ -71,7 +71,10 @@ def extract_source_excerpts(
         raise ValueError("source excerpt limits cannot be negative")
 
     sources = {source.path: source for source in snapshot.files}
-    definitions: dict[str, dict[tuple[DefinitionKind, str], Definition]] = {}
+    definitions: dict[
+        str,
+        dict[tuple[DefinitionKind, str], tuple[Definition, ...]],
+    ] = {}
     decoded: dict[str, str] = {}
     excerpts: list[SourceExcerpt] = []
 
@@ -87,13 +90,18 @@ def extract_source_excerpts(
         if selection.path not in definitions:
             definitions[selection.path] = _definition_map(source)
             decoded[selection.path] = _decode_source(source)
-        definition = definitions[selection.path].get((selection.kind, selection.qualified_name))
-        if definition is None:
+        matching_definitions = definitions[selection.path].get(
+            (selection.kind, selection.qualified_name)
+        )
+        if matching_definitions is None:
             raise SourceExcerptError(
                 "source definition is not in the current snapshot: "
                 f"{selection.path} {selection.qualified_name}"
             )
-        excerpts.append(_excerpt(selection, definition, decoded[selection.path]))
+        excerpts.extend(
+            _excerpt(selection, definition, decoded[selection.path])
+            for definition in matching_definitions
+        )
 
     return prepare_source_excerpts(
         excerpts,
@@ -106,12 +114,18 @@ def extract_source_excerpt(
     snapshot: SourceSnapshot,
     selection: SourceSelection,
 ) -> SourceExcerpt:
-    return extract_source_excerpts(
+    excerpts = extract_source_excerpts(
         snapshot,
         (selection,),
         max_lines=sys.maxsize,
         max_utf8_bytes=sys.maxsize,
-    )[0]
+    )
+    if len(excerpts) != 1:
+        raise SourceExcerptError(
+            "source selection resolves to multiple definitions: "
+            f"{selection.path} {selection.qualified_name}"
+        )
+    return excerpts[0]
 
 
 def prepare_source_excerpts(
@@ -130,15 +144,17 @@ def prepare_source_excerpts(
     return result
 
 
-def _definition_map(source: SourceFile) -> dict[tuple[DefinitionKind, str], Definition]:
+def _definition_map(
+    source: SourceFile,
+) -> dict[tuple[DefinitionKind, str], tuple[Definition, ...]]:
     try:
         structure = extract_module_structure(source)
     except PythonParseError as error:
         raise SourceExcerptError(str(error)) from error
-    return {
-        (definition.kind, definition.qualified_name): definition
-        for definition in structure.definitions
-    }
+    definitions: dict[tuple[DefinitionKind, str], list[Definition]] = {}
+    for definition in structure.definitions:
+        definitions.setdefault((definition.kind, definition.qualified_name), []).append(definition)
+    return {key: tuple(values) for key, values in definitions.items()}
 
 
 def _decode_source(source: SourceFile) -> str:

--- a/src/silobrief/source_review.py
+++ b/src/silobrief/source_review.py
@@ -14,7 +14,7 @@ from silobrief.source_excerpts import (
     SourceExcerptError,
     SourceExcerptLimitError,
     SourceSelection,
-    extract_source_excerpt,
+    extract_source_excerpts,
     prepare_source_excerpts,
 )
 from silobrief.sources import SourceSnapshot
@@ -69,10 +69,12 @@ def review_source_disclosure(
     candidates: list[SourceExcerpt] = []
     for node in sorted(selected_nodes.values(), key=_node_key):
         try:
-            candidates.append(
-                extract_source_excerpt(
+            candidates.extend(
+                extract_source_excerpts(
                     snapshot,
-                    SourceSelection(node.path, node.kind, node.qualified_name),
+                    (SourceSelection(node.path, node.kind, node.qualified_name),),
+                    max_lines=sys.maxsize,
+                    max_utf8_bytes=sys.maxsize,
                 )
             )
         except SourceExcerptError as error:

--- a/tests/test_source_excerpts.py
+++ b/tests/test_source_excerpts.py
@@ -7,6 +7,7 @@ from silobrief.source_excerpts import (
     SourceExcerptError,
     SourceExcerptLimitError,
     SourceSelection,
+    extract_source_excerpt,
     extract_source_excerpts,
 )
 from silobrief.sources import SourceFile, SourceSnapshot
@@ -116,6 +117,76 @@ class SourceExcerptTests(unittest.TestCase):
         self.assertEqual(
             excerpts[0].content, "class Service:\n    def run(self):\n        return 1\n"
         )
+
+    def test_preserves_every_repeated_definition_span(self) -> None:
+        source = source_file(
+            "models.py",
+            (
+                b"class Item:\n"
+                b"    @property\n"
+                b"    def value(self):\n"
+                b"        return self._value\n"
+                b"\n"
+                b"    @value.setter\n"
+                b"    def value(self, new):\n"
+                b"        self._value = new\n"
+                b"\n"
+                b"@overload\n"
+                b"def render(value: int) -> str: ...\n"
+                b"@overload\n"
+                b"def render(value: str) -> str: ...\n"
+                b"def render(value):\n"
+                b"    return str(value)\n"
+                b"\n"
+                b"if FLAG:\n"
+                b"    def choose():\n"
+                b"        return 'first'\n"
+                b"else:\n"
+                b"    def choose():\n"
+                b"        return 'second'\n"
+            ),
+        )
+
+        excerpts = extract_source_excerpts(
+            snapshot(source),
+            (
+                SourceSelection("models.py", "function", "Item.value"),
+                SourceSelection("models.py", "function", "render"),
+                SourceSelection("models.py", "function", "choose"),
+            ),
+        )
+
+        self.assertEqual(
+            [item.qualified_name for item in excerpts],
+            ["Item.value", "Item.value", "render", "render", "render", "choose", "choose"],
+        )
+        contents = [item.content for item in excerpts]
+        self.assertTrue(any("@property" in content for content in contents))
+        self.assertTrue(any("@value.setter" in content for content in contents))
+        self.assertEqual(sum("@overload" in content for content in contents), 2)
+        self.assertTrue(any("return 'first'" in content for content in contents))
+        self.assertTrue(any("return 'second'" in content for content in contents))
+
+    def test_repeated_definitions_share_limits_and_reject_singular_lookup(self) -> None:
+        source = source_file(
+            "models.py",
+            (
+                b"class Item:\n"
+                b"    @property\n"
+                b"    def value(self):\n"
+                b"        return self._value\n"
+                b"\n"
+                b"    @value.setter\n"
+                b"    def value(self, new):\n"
+                b"        self._value = new\n"
+            ),
+        )
+        selection = SourceSelection("models.py", "function", "Item.value")
+
+        with self.assertRaisesRegex(SourceExcerptLimitError, "6 lines"):
+            extract_source_excerpts(snapshot(source), (selection,), max_lines=5)
+        with self.assertRaisesRegex(SourceExcerptError, "multiple definitions"):
+            extract_source_excerpt(snapshot(source), selection)
 
     def test_sorts_excerpts_by_path_and_source_location(self) -> None:
         first = source_file("a.py", b"def zed():\n    pass\n\ndef alpha():\n    pass\n")

--- a/tests/test_source_review.py
+++ b/tests/test_source_review.py
@@ -150,6 +150,38 @@ class SourceReviewTests(unittest.TestCase):
         self.assertEqual(approved[0].qualified_name, "Service")
         self.assertEqual(approved[0].boundary_aliases, ("delivery-boundary",))
 
+    def test_reviews_every_span_for_a_repeated_definition(self) -> None:
+        value = node("value", "models.py", "function", "Item.value")
+        source = snapshot(
+            source_file(
+                "models.py",
+                (
+                    b"class Item:\n"
+                    b"    @property\n"
+                    b"    def value(self):\n"
+                    b"        return self._value\n"
+                    b"\n"
+                    b"    @value.setter\n"
+                    b"    def value(self, new):\n"
+                    b"        self._value = new\n"
+                ),
+            )
+        )
+        output = TtyBuffer()
+
+        approved = review_source_disclosure(
+            index(value),
+            source,
+            ReviewSelection((review_node(value),), (), FIELDS),
+            input_stream=TtyBuffer("y\ny\n"),
+            output_stream=output,
+        )
+
+        self.assertEqual(len(approved), 2)
+        self.assertIn("@property", approved[0].content)
+        self.assertIn("@value.setter", approved[1].content)
+        self.assertEqual(output.getvalue().count("Source candidate:"), 2)
+
     def test_deferred_boundary_binding_requires_expose(self) -> None:
         source = snapshot(
             source_file(


### PR DESCRIPTION
## 왜 필요한가

같은 qualified name을 가진 정의가 여러 번 나오면 색인은 하나의 항목으로 유지하지만, 소스 발췌는 마지막 범위만 남겼습니다. Property getter와 setter, overload 선언, 조건부 구현을 선택해도 일부 코드가 빠져 외부 검토자가 구현 전체를 이해하기 어려웠습니다.

## 무엇을 바꿨나

- 하나의 선택 항목에 연결된 모든 정의 범위를 소스 순서대로 보존합니다.
- 소스 검토 화면에서 각 범위를 따로 확인하고 승인할 수 있게 했습니다.
- 여러 범위의 줄 수와 byte 수를 기존 공개 한도에 합산합니다.
- 단일 발췌 API가 여러 정의를 만났을 때 임의의 하나를 고르지 않고 오류를 냅니다.
- Unreleased changelog에 #197을 기록했습니다.

## 확인한 내용

- `python -m ruff check . --no-cache`
- `python -m ruff format --check . --no-cache`
- `python -m mypy --strict src tests --no-incremental`
- `python -m unittest discover -s tests -q`
- 결과: 237 tests passed, 7 skipped

모든 Python 검사는 이 브랜치의 `src`를 가리키도록 `PYTHONPATH=src`에서 실행했습니다.

## 이번 PR에서 제외한 내용

- 조건문의 실제 실행 결과 추론
- Python 런타임 실행을 통한 정의 선택
- 색인 schema 변경

Closes #197