### PR TITLE
fix(ranking): recognize Korean test particles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Preserve every source span for repeated definitions such as property accessors, overloads, and
   conditional implementations (#197).
+- Reserve test-file candidates when Korean requests use forms such as `테스트를` or `테스트용` (#198).
 
 ## [1.0.4] - 2026-08-19
 

--- a/src/silobrief/ranking.py
+++ b/src/silobrief/ranking.py
@@ -20,7 +20,19 @@ _MAX_IMPLEMENTATION_CANDIDATES = 7
 _MAX_TEST_CANDIDATES = _MAX_CANDIDATES - _MAX_IMPLEMENTATION_CANDIDATES
 _LEADING_ACTION_BONUS = 8
 _EXACT_MODULE_BONUS = 4
-_TEST_QUERY_TOKENS = frozenset({"test", "tests", "pytest", "unittest", "테스트"})
+_TEST_QUERY_TOKENS = frozenset(
+    {
+        "test",
+        "tests",
+        "pytest",
+        "unittest",
+        "테스트",
+        "테스트가",
+        "테스트도",
+        "테스트를",
+        "테스트용",
+    }
+)
 _WORD_PATTERN = re.compile(r"[^\W_]+", re.UNICODE)
 
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -211,16 +211,28 @@ class LexicalRankingTests(unittest.TestCase):
         source_index = index(*implementation, *tests)
 
         without_tests = rank_candidates("match behavior", source_index, notes())
-        with_tests = rank_candidates("match behavior tests", source_index, notes())
-        with_korean_tests = rank_candidates("match behavior 테스트", source_index, notes())
-
         self.assertEqual(len(without_tests), 7)
         self.assertTrue(all(not item.node.path.startswith("tests/") for item in without_tests))
-        self.assertEqual(len(with_tests), 10)
-        self.assertTrue(all(not item.node.path.startswith("tests/") for item in with_tests[:7]))
-        self.assertTrue(all(item.node.path.startswith("tests/") for item in with_tests[7:]))
-        self.assertEqual(len(with_korean_tests), 10)
-        self.assertTrue(all(item.node.path.startswith("tests/") for item in with_korean_tests[7:]))
+        for prompt in (
+            "match behavior tests",
+            "match behavior 테스트",
+            "match behavior 테스트를 추가해 주세요",
+            "match behavior 테스트가 필요해",
+            "match behavior 테스트도 확인해 주세요",
+            "match behavior 테스트용 코드를 찾아줘",
+        ):
+            with self.subTest(prompt=prompt):
+                ranked = rank_candidates(prompt, source_index, notes())
+                self.assertEqual(len(ranked), 10)
+                self.assertTrue(all(not item.node.path.startswith("tests/") for item in ranked[:7]))
+                self.assertTrue(all(item.node.path.startswith("tests/") for item in ranked[7:]))
+        contest_request = rank_candidates(
+            "match behavior 콘테스트를 준비해 주세요",
+            source_index,
+            notes(),
+        )
+        self.assertEqual(len(contest_request), 7)
+        self.assertTrue(all(not item.node.path.startswith("tests/") for item in contest_request))
 
     def test_ignores_module_and_import_only_matches(self) -> None:
         module = node(


### PR DESCRIPTION
## 왜 필요한가

#171에서 한국어 `테스트`를 지원했지만 조사나 용도 표현이 붙으면 테스트 요청으로 인식하지 못했습니다. 실제 사용자가 입력할 법한 `테스트를 추가해 주세요`에서는 테스트 파일 후보가 모두 빠졌습니다.

## 무엇을 바꿨나

- `테스트가`, `테스트도`, `테스트를`, `테스트용`을 테스트 의도 토큰에 추가했습니다.
- 기존 영어 토큰과 단독 `테스트` 동작을 유지했습니다.
- `콘테스트를`처럼 글자 일부만 우연히 겹치는 단어를 오인하지 않는 대조 테스트를 추가했습니다.
- Unreleased changelog에 #198을 기록했습니다.

## 확인한 내용

- `python -m ruff check . --no-cache`
- `python -m ruff format --check . --no-cache`
- `python -m mypy --strict src tests --no-incremental`
- `python -m unittest discover -s tests -q`
- 결과: 237 tests passed, 7 skipped

모든 Python 검사는 이 브랜치의 `src`를 가리키도록 `PYTHONPATH=src`에서 실행했습니다.

## 이번 PR에서 제외한 내용

- 외부 형태소 분석기
- 문장 전체 번역
- 검색 점수와 후보 수 변경

Closes #198