### PR TITLE
fix(security): document private reporting channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Point vulnerability and conduct reports to working private GitHub channels (#196).
 - Preserve every source span for repeated definitions such as property accessors, overloads, and
   conditional implementations (#197).
 - Reserve test-file candidates when Korean requests use forms such as `테스트를` or `테스트용` (#198).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,9 +46,12 @@ represents the community in public spaces.
 
 ## Enforcement
 
-Report abusive, harassing, or otherwise unacceptable behavior to the repository owner using
-the contact information on their public GitHub profile. All complaints will be reviewed and
-investigated promptly and fairly.
+For behavior on GitHub, use the relevant Issue, pull request, discussion, or comment's
+**Report content** action. Choose **Report to repository admins** when GitHub offers it. If that
+option is unavailable, follow GitHub's [abuse reporting instructions](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam)
+to contact GitHub Support privately. Do not open a public Issue for a private conduct report.
+
+Reports delivered to community leaders will be reviewed and investigated promptly and fairly.
 
 Community leaders must respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,9 +18,9 @@ The latest 1.0.x release is the currently supported line.
 
 Do not open a public Issue for a suspected vulnerability or accidental disclosure.
 
-Use GitHub private vulnerability reporting when it is available. If it is unavailable, contact
-the repository owner using the contact information on their public GitHub profile. Include the
-affected version or commit, reproduction steps, impact, and a minimal synthetic example.
+Use the repository's [private vulnerability reporting form](https://github.com/d3vksy/silobrief/security/advisories/new).
+GitHub requires you to sign in before opening the form. Include the affected version or commit,
+reproduction steps, impact, and a minimal synthetic example.
 
 Do not include real credentials, private source code, organization names, or restricted data in
 the report.

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -188,6 +188,17 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertIn("| 0.5.x | :x: |", security)
         self.assertNotIn("has not released a supported version yet", security)
 
+        self.assertIn(
+            "https://github.com/d3vksy/silobrief/security/advisories/new",
+            security,
+        )
+        self.assertNotIn("public GitHub profile", security)
+
+        conduct = (REPOSITORY_ROOT / "CODE_OF_CONDUCT.md").read_text(encoding="utf-8")
+        self.assertIn("Report content", conduct)
+        self.assertIn("reporting-abuse-or-spam", conduct)
+        self.assertNotIn("public GitHub profile", conduct)
+
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
         self.assertEqual(pyproject.count('version = "1.0.4"'), 1)
         self.assertEqual(version("silobrief"), "1.0.4")


### PR DESCRIPTION
## 왜 수정했나요?

문서는 보안 문제와 행동 강령 위반을 공개 이슈가 아닌 비공개 경로로 신고하라고 안내했지만, 실제로 사용할 수 있는 연락처가 없었습니다. 저장소의 Private Vulnerability Reporting은 이제 활성화했으며, 문서도 실제로 열리는 경로와 맞췄습니다.

## 무엇을 바꿨나요?

- `SECURITY.md`에서 저장소의 비공개 취약점 신고 양식으로 바로 연결합니다.
- 신고 양식을 사용하려면 GitHub 로그인이 필요하다는 점을 적었습니다.
- `CODE_OF_CONDUCT.md`는 관련 콘텐츠의 **Report content** 기능과 GitHub Support의 비공개 신고 절차를 안내합니다.
- 존재하지 않는 공개 프로필 연락처 안내를 제거했습니다.
- 문서 경로가 다시 끊기지 않도록 회귀 테스트를 추가했습니다.

## 어떻게 확인했나요?

- GitHub API에서 Private Vulnerability Reporting `enabled: true` 확인
- 비로그인 요청이 로그인 후 비공개 신고 양식으로 연결되는지 확인
- `python -m ruff check . --no-cache`
- `python -m ruff format --check . --no-cache`
- `python -m mypy --strict src tests --no-incremental`
- `python -m unittest tests.test_documentation -q` — 10개 통과
- `python -m unittest discover -s tests -q` — 239개 통과, 7개 skip

## 이번 수정에서 제외한 내용

별도 메일 서버나 외부 신고 서비스를 추가하지 않았습니다. 비공개 보안 권고의 공개·CVE 발급 정책도 바꾸지 않았습니다.

Refs #196