### PR TITLE
fix(index): honor local assignment shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   conditional implementations (#197).
 - Reserve test-file candidates when Korean requests use forms such as `테스트를` or `테스트용` (#198).
 - Aggregate approved public imports and boundary descriptions from selected source context (#199).
+- Keep local assignment targets unresolved instead of linking them to shadowed global or boundary
+  symbols (#200).
 
 ## [1.0.4] - 2026-08-19
 

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -11,7 +11,13 @@ from silobrief.boundary_placeholders import (
     BoundaryPlaceholder,
     import_target,
 )
-from silobrief.python_structure import Definition, ImportEntry, ModuleStructure, SymbolUse
+from silobrief.python_structure import (
+    Definition,
+    ImportEntry,
+    ModuleStructure,
+    StoreBinding,
+    SymbolUse,
+)
 from silobrief.search_tokens import extract_scoped_source_text_tokens, normalize_search_tokens
 from silobrief.sources import SourceFile, SourceSnapshot
 from silobrief.state import BoundaryData, ConfigData
@@ -73,6 +79,17 @@ class _ImportBinding:
 
 
 @dataclass(frozen=True, slots=True)
+class _StoreBinding:
+    context: str | None
+    name: str
+    line: int
+    column: int
+    conditional: bool
+    runtime: bool
+    deferred: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class _ScopeBinding:
     target_id: str | None = None
     imported_target: str | None = None
@@ -88,6 +105,7 @@ class _ModuleContext:
     definition_nodes: tuple[IndexNode, ...]
     context_ids: dict[str, str]
     import_bindings: tuple[_ImportBinding, ...]
+    store_bindings: tuple[_StoreBinding, ...]
     path_tokens: tuple[str, ...]
     import_tokens: tuple[str, ...]
     comment_tokens: tuple[str, ...]
@@ -208,6 +226,7 @@ def _build_module_context(
         definition_nodes=tuple(definition_nodes),
         context_ids=context_ids,
         import_bindings=_import_bindings(module_name, source.path, structure.imports),
+        store_bindings=_store_bindings(structure.store_bindings),
         path_tokens=path_tokens,
         import_tokens=import_tokens,
         comment_tokens=text_tokens.module.comments,
@@ -302,7 +321,7 @@ def _resolve_use_target(
 ) -> tuple[str | BoundaryPlaceholder, str | None]:
     if synthetic_local:
         return target, None
-    use_position = (*lookup_limit, -1) if lookup_limit is not None else (line, column, 2)
+    use_position = (line, column, 3)
     possible: list[_ScopeBinding] = []
     saw_binding = False
     for scope in _lexical_scopes(context, source_context, target, line, skip_class_scope):
@@ -313,6 +332,7 @@ def _resolve_use_target(
             target,
             line,
             use_position,
+            lookup_limit,
         )
         if bindings is None:
             continue
@@ -374,6 +394,7 @@ def _resolve_scope_bindings(
     target: str,
     line: int,
     use_position: tuple[int, int, int],
+    definition_under_construction: tuple[int, int] | None,
 ) -> tuple[_ScopeBinding, ...] | None:
     root = target.split(".", 1)[0]
     scope_definition = _definition_at(context, scope, line) if scope is not None else None
@@ -384,6 +405,8 @@ def _resolve_scope_bindings(
             _structural_parent(candidate_definition.qualified_name) != scope
             or candidate_definition.name != root
             or not _inside_definition(scope_definition, candidate_definition.line)
+            or definition_under_construction
+            == (candidate_definition.line, candidate_definition.column)
         ):
             continue
         suffix = target[len(root) :]
@@ -421,12 +444,40 @@ def _resolve_scope_bindings(
             deferred_bindings.append(candidate[1])
         else:
             candidates.append(candidate)
+    for store_binding in context.store_bindings:
+        if (
+            not store_binding.runtime
+            or store_binding.context != scope
+            or store_binding.name != root
+            or not _inside_definition(scope_definition, store_binding.line)
+        ):
+            continue
+        candidate = (
+            (store_binding.line, store_binding.column, 2),
+            _ScopeBinding(unknown=True),
+            store_binding.conditional,
+        )
+        if store_binding.deferred:
+            deferred_bindings.append(candidate[1])
+        else:
+            candidates.append(candidate)
     if (parameter := _parameter_binding(context, scope, target, line)) is not None:
         candidates.append(((0, 0, 0), parameter, False))
 
     direct_scope = scope == source_context
     declared = _has_declaration(context, scope, line, root, "global") or _has_declaration(
         context, scope, line, root, "nonlocal"
+    )
+    static_local = (
+        not declared
+        and scope_definition is not None
+        and scope_definition.kind == "function"
+        and any(
+            item.context == scope
+            and item.name == root
+            and _inside_definition(scope_definition, item.line)
+            for item in context.store_bindings
+        )
     )
     falls_through = declared or (
         direct_scope and scope_definition is not None and scope_definition.kind == "class"
@@ -451,11 +502,13 @@ def _resolve_scope_bindings(
 
     if (
         direct_scope
-        and candidates
+        and (candidates or static_local)
         and not declared
         and (scope is None or scope_definition is not None and scope_definition.kind == "function")
     ):
         return tuple(dict.fromkeys([_ScopeBinding(), *deferred_bindings]))
+    if static_local:
+        return tuple(dict.fromkeys([_ScopeBinding(unknown=True), *deferred_bindings]))
     if deferred_bindings:
         return tuple(dict.fromkeys([_ScopeBinding(falls_through=True), *deferred_bindings]))
     return None
@@ -606,6 +659,31 @@ def _import_bindings(
                     imported.line,
                     imported.column,
                     conditional,
+                    deferred,
+                )
+            )
+    return tuple(result)
+
+
+def _store_bindings(bindings: tuple[StoreBinding, ...]) -> tuple[_StoreBinding, ...]:
+    result: list[_StoreBinding] = []
+    for binding in bindings:
+        scopes = (
+            (binding.context, binding.conditional, False),
+            *(
+                (item.context, item.conditional, item.deferred)
+                for item in binding.projected_binding_scopes
+            ),
+        )
+        for scope, conditional, deferred in scopes:
+            result.append(
+                _StoreBinding(
+                    scope,
+                    binding.name,
+                    binding.line,
+                    binding.column,
+                    conditional,
+                    binding.runtime,
                     deferred,
                 )
             )

--- a/src/silobrief/python_structure.py
+++ b/src/silobrief/python_structure.py
@@ -75,6 +75,17 @@ class ImportEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class StoreBinding:
+    name: str
+    context: str | None
+    line: int
+    column: int
+    conditional: bool = False
+    runtime: bool = True
+    projected_binding_scopes: tuple[ImportBindingScope, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class SymbolUse:
     context: str | None
     target: str
@@ -102,6 +113,7 @@ class ModuleStructure:
     calls: tuple[SymbolUse, ...]
     references: tuple[SymbolUse, ...]
     declarations: tuple[ScopeDeclaration, ...]
+    store_bindings: tuple[StoreBinding, ...] = ()
 
 
 def extract_structures(snapshot: SourceSnapshot) -> tuple[ModuleStructure, ...]:
@@ -133,6 +145,7 @@ def extract_module_structure(source: SourceFile) -> ModuleStructure:
         calls=tuple(visitor.calls),
         references=tuple(visitor.references),
         declarations=tuple(visitor.declarations),
+        store_bindings=tuple(visitor.store_bindings),
     )
 
 
@@ -200,6 +213,7 @@ class _StructureVisitor(ast.NodeVisitor):
         self.calls: list[SymbolUse] = []
         self.references: list[SymbolUse] = []
         self.declarations: list[ScopeDeclaration] = []
+        self.store_bindings: list[StoreBinding] = []
         self._contexts: list[str] = []
         self._context_kinds: list[DefinitionKind] = []
         self._context_conditionals: list[bool] = []
@@ -207,6 +221,8 @@ class _StructureVisitor(ast.NodeVisitor):
         self._symbol_tables = [symbols]
         self._conditional_depth = 0
         self._synthetic_scopes: list[set[str]] = []
+        self._suppress_store_bindings = 0
+        self._store_position_overrides: list[tuple[int, int]] = []
         self._lookup_limit: tuple[int, int] | None = None
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
@@ -231,7 +247,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
-                    projected_binding_scopes=self._projected_import_scopes(
+                    projected_binding_scopes=self._projected_binding_scopes(
                         imported.asname or imported.name.split(".", 1)[0]
                     ),
                 )
@@ -250,7 +266,7 @@ class _StructureVisitor(ast.NodeVisitor):
                     line=line,
                     column=column,
                     conditional=self._conditional_depth > 0,
-                    projected_binding_scopes=self._projected_import_scopes(
+                    projected_binding_scopes=self._projected_binding_scopes(
                         imported.asname or imported.name
                     ),
                 )
@@ -283,11 +299,86 @@ class _StructureVisitor(ast.NodeVisitor):
             line, column = _location(node)
             self.references.append(self._symbol_use(node.id, line, column))
 
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self._visit_store_target(target, _end_location(node))
+        self._record_store_bindings(
+            set().union(*(_bound_names(target) for target in node.targets)),
+            _end_location(node),
+        )
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+        self._visit_store_target(node.target, _end_location(node))
+        self.visit(node.annotation)
+        self._record_store_bindings(
+            _bound_names(node.target),
+            _end_location(node),
+            runtime=node.value is not None,
+        )
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.target)
+        self.visit(node.value)
+        self._record_store_bindings(_bound_names(node.target), _end_location(node))
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self.visit(node.target)
+        self._record_store_bindings(
+            _bound_names(node.target),
+            _end_location(node),
+            conditional=bool(self._synthetic_scopes),
+        )
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        first, *remaining = node.values
+        self.visit(first)
+        self._conditional_depth += 1
+        try:
+            for value in remaining:
+                self.visit(value)
+        finally:
+            self._conditional_depth -= 1
+
+    def visit_IfExp(self, node: ast.IfExp) -> None:
+        self.visit(node.test)
+        self._conditional_depth += 1
+        try:
+            self.visit(node.body)
+            self.visit(node.orelse)
+        finally:
+            self._conditional_depth -= 1
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        self.visit(node.left)
+        first, *remaining = node.comparators
+        self.visit(first)
+        self._conditional_depth += 1
+        try:
+            for comparator in remaining:
+                self.visit(comparator)
+        finally:
+            self._conditional_depth -= 1
+
+    def visit_Assert(self, node: ast.Assert) -> None:
+        self._conditional_depth += 1
+        try:
+            self.visit(node.test)
+            if node.msg is not None:
+                self.visit(node.msg)
+        finally:
+            self._conditional_depth -= 1
+
     def visit_Lambda(self, node: ast.Lambda) -> None:
         for default in (*node.args.defaults, *node.args.kw_defaults):
             if default is not None:
                 self.visit(default)
-        self._visit_synthetic(node.body, set(_argument_names(node.args)))
+        names = set(_argument_names(node.args))
+        names.update(_walrus_bound_names(node.body))
+        self._visit_synthetic(node.body, names, suppress_store_bindings=True)
 
     def visit_ListComp(self, node: ast.ListComp) -> None:
         self._visit_comprehension(node.generators, (node.elt,))
@@ -305,10 +396,10 @@ class _StructureVisitor(ast.NodeVisitor):
         self._visit_conditional(node)
 
     def visit_For(self, node: ast.For) -> None:
-        self._visit_conditional(node)
+        self._visit_for(node)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
-        self._visit_conditional(node)
+        self._visit_for(node)
 
     def visit_While(self, node: ast.While) -> None:
         self._visit_conditional(node)
@@ -320,13 +411,36 @@ class _StructureVisitor(ast.NodeVisitor):
         self._visit_conditional(node)
 
     def visit_Match(self, node: ast.Match) -> None:
-        self._visit_conditional(node)
+        self._conditional_depth += 1
+        try:
+            self.visit(node.subject)
+            for case in node.cases:
+                self.visit(case.pattern)
+                self._record_store_bindings(
+                    _match_bound_names(case.pattern),
+                    _end_location(case.pattern),
+                )
+                if case.guard is not None:
+                    self.visit(case.guard)
+                for statement in case.body:
+                    self.visit(statement)
+        finally:
+            self._conditional_depth -= 1
 
     def visit_With(self, node: ast.With) -> None:
-        self._visit_conditional(node)
+        self._visit_with(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
-        self._visit_conditional(node)
+        self._visit_with(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None:
+            position = _end_location(node.type) if node.type is not None else _location(node)
+            self._record_store_bindings({node.name}, position)
+        for statement in node.body:
+            self.visit(statement)
 
     def visit_Global(self, node: ast.Global) -> None:
         self._record_declarations("global", node)
@@ -408,7 +522,7 @@ class _StructureVisitor(ast.NodeVisitor):
         if self._scope_declarations:
             self._scope_declarations[-1].update(dict.fromkeys(node.names, kind))
 
-    def _projected_import_scopes(self, name: str) -> tuple[ImportBindingScope, ...]:
+    def _projected_binding_scopes(self, name: str) -> tuple[ImportBindingScope, ...]:
         if not self._context_kinds:
             return ()
         declaration = self._scope_declarations[-1].get(name)
@@ -456,11 +570,19 @@ class _StructureVisitor(ast.NodeVisitor):
             lookup_limit=self._lookup_limit,
         )
 
-    def _visit_synthetic(self, node: ast.AST, names: set[str]) -> None:
+    def _visit_synthetic(
+        self,
+        node: ast.AST,
+        names: set[str],
+        *,
+        suppress_store_bindings: bool = False,
+    ) -> None:
         self._synthetic_scopes.append(names)
+        self._suppress_store_bindings += suppress_store_bindings
         try:
             self.visit(node)
         finally:
+            self._suppress_store_bindings -= suppress_store_bindings
             self._synthetic_scopes.pop()
 
     def _visit_comprehension(
@@ -470,7 +592,7 @@ class _StructureVisitor(ast.NodeVisitor):
     ) -> None:
         first, *remaining = generators
         self.visit(first.iter)
-        names = _bound_names(first.target)
+        names = set().union(*(_bound_names(generator.target) for generator in generators))
         self._synthetic_scopes.append(names)
         try:
             self.visit(first.target)
@@ -478,7 +600,6 @@ class _StructureVisitor(ast.NodeVisitor):
                 self.visit(condition)
             for generator in remaining:
                 self.visit(generator.iter)
-                names.update(_bound_names(generator.target))
                 self.visit(generator.target)
                 for condition in generator.ifs:
                     self.visit(condition)
@@ -486,6 +607,66 @@ class _StructureVisitor(ast.NodeVisitor):
                 self.visit(result)
         finally:
             self._synthetic_scopes.pop()
+
+    def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
+        self._conditional_depth += 1
+        try:
+            self.visit(node.iter)
+            self._visit_store_target(node.target, _end_location(node.iter))
+            self._record_store_bindings(_bound_names(node.target), _end_location(node.iter))
+            for statement in (*node.body, *node.orelse):
+                self.visit(statement)
+        finally:
+            self._conditional_depth -= 1
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        self._conditional_depth += 1
+        try:
+            for item in node.items:
+                self.visit(item.context_expr)
+                if item.optional_vars is not None:
+                    self._visit_store_target(item.optional_vars, _end_location(item.optional_vars))
+                    self._record_store_bindings(
+                        _bound_names(item.optional_vars),
+                        _end_location(item.optional_vars),
+                    )
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self._conditional_depth -= 1
+
+    def _record_store_bindings(
+        self,
+        names: set[str],
+        position: tuple[int, int],
+        *,
+        conditional: bool = False,
+        runtime: bool = True,
+    ) -> None:
+        if self._suppress_store_bindings:
+            return
+        if self._store_position_overrides:
+            position = self._store_position_overrides[-1]
+        line, column = position
+        for name in sorted(names):
+            self.store_bindings.append(
+                StoreBinding(
+                    name,
+                    self._context,
+                    line,
+                    column,
+                    conditional=self._conditional_depth > 0 or conditional,
+                    runtime=runtime,
+                    projected_binding_scopes=self._projected_binding_scopes(name),
+                )
+            )
+
+    def _visit_store_target(self, node: ast.expr, position: tuple[int, int]) -> None:
+        self._store_position_overrides.append(position)
+        try:
+            self.visit(node)
+        finally:
+            self._store_position_overrides.pop()
 
     def _visit_conditional(self, node: ast.AST) -> None:
         self._conditional_depth += 1
@@ -554,5 +735,53 @@ def _bound_names(node: ast.expr) -> set[str]:
     return set()
 
 
-def _location(node: ast.stmt | ast.expr) -> tuple[int, int]:
+def _match_bound_names(node: ast.pattern) -> set[str]:
+    if isinstance(node, ast.MatchAs):
+        names = _match_bound_names(node.pattern) if node.pattern is not None else set()
+        if node.name is not None:
+            names.add(node.name)
+        return names
+    if isinstance(node, ast.MatchStar):
+        return {node.name} if node.name is not None else set()
+    if isinstance(node, ast.MatchSequence):
+        return set().union(*(_match_bound_names(item) for item in node.patterns))
+    if isinstance(node, ast.MatchMapping):
+        names = set().union(*(_match_bound_names(item) for item in node.patterns))
+        if node.rest is not None:
+            names.add(node.rest)
+        return names
+    if isinstance(node, ast.MatchClass):
+        return set().union(
+            *(_match_bound_names(item) for item in (*node.patterns, *node.kwd_patterns))
+        )
+    if isinstance(node, ast.MatchOr):
+        return set().union(*(_match_bound_names(item) for item in node.patterns))
+    return set()
+
+
+def _walrus_bound_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+
+    def collect(current: ast.AST) -> None:
+        if isinstance(current, ast.Lambda):
+            for default in (*current.args.defaults, *current.args.kw_defaults):
+                if default is not None:
+                    collect(default)
+            return
+        if isinstance(current, ast.NamedExpr):
+            names.update(_bound_names(current.target))
+        for child in ast.iter_child_nodes(current):
+            collect(child)
+
+    collect(node)
+    return names
+
+
+def _location(node: ast.stmt | ast.expr | ast.pattern | ast.ExceptHandler) -> tuple[int, int]:
     return node.lineno, node.col_offset + 1
+
+
+def _end_location(node: ast.stmt | ast.expr | ast.pattern) -> tuple[int, int]:
+    line = node.end_lineno if node.end_lineno is not None else node.lineno
+    column = node.end_col_offset if node.end_col_offset is not None else node.col_offset
+    return line, column + 1

--- a/tests/test_boundary_placeholders.py
+++ b/tests/test_boundary_placeholders.py
@@ -4,7 +4,7 @@ import hashlib
 import unittest
 
 from silobrief.boundary_placeholders import BoundaryPlaceholder
-from silobrief.index import build_index, render_index_json
+from silobrief.index import IndexEdge, build_index, render_index_json
 from silobrief.python_structure import extract_structures
 from silobrief.sources import SourceFile, SourceSnapshot
 from silobrief.state import DEFAULT_EXCLUDES, BoundaryData, ConfigData
@@ -371,6 +371,232 @@ class BoundaryPlaceholderTests(unittest.TestCase):
         self.assertIsNone(calls["use_public_import"].target_id)
         self.assertNotIn(b'"alias": "private-code"', render_index_json(index))
 
+    def test_local_store_forms_shadow_global_and_raw_boundary_targets(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def private():\n"
+                b"    return 'global'\n"
+                b"def assigned():\n"
+                b"    private = object()\n"
+                b"    return private()\n"
+                b"def annotated():\n"
+                b"    private: object\n"
+                b"    return private()\n"
+                b"def augmented():\n"
+                b"    private += object()\n"
+                b"    return private()\n"
+                b"def looped(values):\n"
+                b"    for private in values:\n"
+                b"        pass\n"
+                b"    return private()\n"
+                b"def managed(manager):\n"
+                b"    with manager() as private:\n"
+                b"        pass\n"
+                b"    return private()\n"
+                b"def caught(error):\n"
+                b"    try:\n"
+                b"        raise error\n"
+                b"    except Exception as private:\n"
+                b"        pass\n"
+                b"    return private()\n"
+                b"def matched(value):\n"
+                b"    match value:\n"
+                b"        case {'private': private}:\n"
+                b"            pass\n"
+                b"    return private()\n"
+                b"def named(factory):\n"
+                b"    (private := factory)\n"
+                b"    return private()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-code",
+            description="Approved private code",
+            path="private.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in (
+            "annotated",
+            "assigned",
+            "augmented",
+            "caught",
+            "looped",
+            "managed",
+            "matched",
+            "named",
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(nodes[qualified_name].id, "call", "private", None),
+                    index.edges,
+                )
+        self.assertNotIn(b'"alias": "private-code"', render_index_json(index))
+
+    def test_conditional_store_does_not_hide_a_possible_boundary_import(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose(use_public):\n"
+                b"    from private_zone import HiddenClient as service\n"
+                b"    if use_public:\n"
+                b"        service = object()\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
+        self.assertNotIn(b"private_zone", render_index_json(index))
+
+    def test_expression_control_flow_keeps_possible_boundaries(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as service\n"
+                b"flag = False\n"
+                b"flag and (service := object())\n"
+                b"(service := object()) if flag else None\n"
+                b"0 > flag > (service := object())\n"
+                b"assert True, (service := object())\n"
+                b"service.HiddenClient()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        module = next(node for node in index.nodes if node.kind == "module")
+
+        self.assertIn(
+            IndexEdge(
+                module.id,
+                "call",
+                BoundaryPlaceholder("private-service", "Approved private service"),
+                None,
+            ),
+            index.edges,
+        )
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_assignment_target_walrus_does_not_hide_a_boundary_from_the_rhs(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as service\n"
+                b"target[(service := object()) and 0] = service.HiddenClient()\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        module = next(node for node in index.nodes if node.kind == "module")
+
+        self.assertIn(
+            IndexEdge(
+                module.id,
+                "call",
+                BoundaryPlaceholder("private-service", "Approved private service"),
+                None,
+            ),
+            index.edges,
+        )
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_global_and_nonlocal_stores_keep_deferred_boundaries_conservative(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"import private_zone as module_service\n"
+                b"def update_global():\n"
+                b"    global module_service\n"
+                b"    module_service = object()\n"
+                b"    return module_service.run()\n"
+                b"def use_global():\n"
+                b"    return module_service.run()\n"
+                b"def outer():\n"
+                b"    from private_zone import HiddenClient as local_service\n"
+                b"    def update_nonlocal():\n"
+                b"        nonlocal local_service\n"
+                b"        local_service = object()\n"
+                b"        return local_service()\n"
+                b"    def use_nonlocal():\n"
+                b"        return local_service()\n"
+                b"    return update_nonlocal, use_nonlocal\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name, target in (
+            ("update_global", "module_service.run"),
+            ("outer.update_nonlocal", "local_service"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(nodes[qualified_name].id, "call", target, None), index.edges
+                )
+        for qualified_name, target in (
+            ("use_global", "module_service.run"),
+            ("outer.use_nonlocal", "local_service"),
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[qualified_name].id,
+                        "call",
+                        BoundaryPlaceholder("private-service", "Approved private service"),
+                        None,
+                    ),
+                    index.edges,
+                )
+                self.assertNotIn(
+                    IndexEdge(nodes[qualified_name].id, "call", target, None),
+                    index.edges,
+                )
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
     def test_conditional_boundary_import_is_redacted_conservatively(self) -> None:
         source = source_snapshot(
             "service.py",
@@ -517,6 +743,41 @@ class BoundaryPlaceholderTests(unittest.TestCase):
                     BoundaryPlaceholder("private-service", "Approved private service"),
                 )
                 self.assertIsNone(call.target_id)
+        rendered = render_index_json(index)
+        for forbidden in (b"private_zone", b"HiddenClient"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+    def test_later_store_does_not_hide_a_boundary_possible_for_a_closure(self) -> None:
+        source = source_snapshot(
+            "service.py",
+            (
+                b"def choose():\n"
+                b"    from private_zone import HiddenClient as service\n"
+                b"    def run():\n"
+                b"        return service()\n"
+                b"    run()\n"
+                b"    service = object()\n"
+                b"    return run\n"
+            ),
+        )
+        boundary = BoundaryData(
+            alias="private-service",
+            description="Approved private service",
+            path="private_zone.py",
+        )
+
+        index = build_index(source, extract_structures(source), config(boundary))
+        run = next(node for node in index.nodes if node.qualified_name == "choose.run")
+        call = next(
+            edge for edge in index.edges if edge.source_id == run.id and edge.kind == "call"
+        )
+
+        self.assertEqual(
+            call.target,
+            BoundaryPlaceholder("private-service", "Approved private service"),
+        )
+        self.assertIsNone(call.target_id)
         rendered = render_index_json(index)
         for forbidden in (b"private_zone", b"HiddenClient"):
             with self.subTest(forbidden=forbidden):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -437,6 +437,226 @@ class DeterministicIndexTests(unittest.TestCase):
                     index.edges,
                 )
 
+    def test_local_store_bindings_keep_calls_and_references_unresolved(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def assigned():\n"
+                b"    helper = lambda: None\n"
+                b"    return helper(), helper.attribute\n"
+                b"def annotated():\n"
+                b"    helper: object\n"
+                b"    return helper(), helper.attribute\n"
+                b"def augmented():\n"
+                b"    helper += 1\n"
+                b"    return helper(), helper.attribute\n"
+                b"def looped(values):\n"
+                b"    for helper in values:\n"
+                b"        pass\n"
+                b"    return helper(), helper.attribute\n"
+                b"def managed(manager):\n"
+                b"    with manager() as helper:\n"
+                b"        pass\n"
+                b"    return helper(), helper.attribute\n"
+                b"def caught(error):\n"
+                b"    try:\n"
+                b"        raise error\n"
+                b"    except Exception as helper:\n"
+                b"        pass\n"
+                b"    return helper(), helper.attribute\n"
+                b"def matched(value):\n"
+                b"    match value:\n"
+                b"        case {'helper': helper}:\n"
+                b"            pass\n"
+                b"    return helper(), helper.attribute\n"
+                b"def named(factory):\n"
+                b"    (helper := factory)\n"
+                b"    return helper(), helper.attribute\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        for qualified_name in (
+            "annotated",
+            "assigned",
+            "augmented",
+            "caught",
+            "looped",
+            "managed",
+            "matched",
+            "named",
+        ):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(nodes[qualified_name].id, "call", "helper", None),
+                    index.edges,
+                )
+                self.assertIn(
+                    IndexEdge(nodes[qualified_name].id, "reference", "helper.attribute", None),
+                    index.edges,
+                )
+
+    def test_store_binding_preserves_rhs_order_without_alias_inference(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from dependency import helper\n"
+                b"helper = helper()\n"
+                b"def public_helper():\n"
+                b"    return 2\n"
+                b"def later():\n"
+                b"    return helper()\n"
+                b"def use_alias():\n"
+                b"    callback = public_helper\n"
+                b"    return callback()\n"
+            ),
+        )
+        dependency = source_file("dependency.py", b"def helper():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        caller_module = nodes[("caller.py", "caller")]
+        dependency_helper = nodes[("dependency.py", "helper")]
+
+        self.assertIn(
+            IndexEdge(caller_module.id, "call", "helper", dependency_helper.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(nodes[("caller.py", "later")].id, "call", "helper", None), index.edges
+        )
+        self.assertIn(
+            IndexEdge(nodes[("caller.py", "use_alias")].id, "call", "callback", None),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "use_alias")].id,
+                "reference",
+                "public_helper",
+                nodes[("caller.py", "public_helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_annotation_only_keeps_existing_runtime_bindings(self) -> None:
+        caller = source_file(
+            "caller.py",
+            (
+                b"from dependency import helper\n"
+                b"helper: object\n"
+                b"def use_module():\n"
+                b"    return helper()\n"
+                b"def use_import():\n"
+                b"    from dependency import helper\n"
+                b"    helper: object\n"
+                b"    return helper()\n"
+                b"class Worker:\n"
+                b"    def helper(self):\n"
+                b"        return 1\n"
+                b"    def run(self):\n"
+                b"        self: object\n"
+                b"        return self.helper()\n"
+            ),
+        )
+        dependency = source_file("dependency.py", b"def helper():\n    return 1\n")
+        snapshot = source_snapshot(caller, dependency)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.qualified_name): node for node in index.nodes}
+        dependency_helper = nodes[("dependency.py", "helper")]
+
+        for qualified_name in ("use_module", "use_import"):
+            with self.subTest(qualified_name=qualified_name):
+                self.assertIn(
+                    IndexEdge(
+                        nodes[("caller.py", qualified_name)].id,
+                        "call",
+                        "helper",
+                        dependency_helper.id,
+                    ),
+                    index.edges,
+                )
+        self.assertIn(
+            IndexEdge(
+                nodes[("caller.py", "Worker.run")].id,
+                "call",
+                "self.helper",
+                nodes[("caller.py", "Worker.helper")].id,
+            ),
+            index.edges,
+        )
+
+    def test_lambda_walrus_binding_does_not_shadow_its_enclosing_scope(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    callback = lambda: ((helper := lambda: 'local'), helper())[1]\n"
+                b"    return helper(), callback\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        self.assertIn(IndexEdge(nodes["outer"].id, "call", "helper", None), index.edges)
+        self.assertIn(
+            IndexEdge(nodes["outer"].id, "call", "helper", nodes["helper"].id),
+            index.edges,
+        )
+
+    def test_enclosing_store_binding_shadows_a_global_for_closures(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def outer():\n"
+                b"    def inner():\n"
+                b"        return helper()\n"
+                b"    helper = lambda: 'local'\n"
+                b"    return inner\n"
+                b"def annotation_outer():\n"
+                b"    helper: object\n"
+                b"    def inner():\n"
+                b"        return helper()\n"
+                b"    return inner\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+
+        self.assertIn(IndexEdge(nodes["outer.inner"].id, "call", "helper", None), index.edges)
+        self.assertNotIn(
+            IndexEdge(nodes["outer.inner"].id, "call", "helper", nodes["helper"].id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(nodes["annotation_outer.inner"].id, "call", "helper", None),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(
+                nodes["annotation_outer.inner"].id,
+                "call",
+                "helper",
+                nodes["helper"].id,
+            ),
+            index.edges,
+        )
+
     def test_calls_follow_repeated_import_rebindings(self) -> None:
         caller = source_file(
             "caller.py",
@@ -793,6 +1013,8 @@ class DeterministicIndexTests(unittest.TestCase):
                 b"    return 'module'\n"
                 b"def comprehension_local():\n"
                 b"    return 'module'\n"
+                b"def later():\n"
+                b"    return ()\n"
                 b"class Worker:\n"
                 b"    def helper():\n"
                 b"        return 'class'\n"
@@ -801,6 +1023,7 @@ class DeterministicIndexTests(unittest.TestCase):
                 b"    lambda_shadow = (lambda lambda_local: lambda_local())(None)\n"
                 b"    comprehension_shadow = "
                 b"[comprehension_local() for comprehension_local in ()]\n"
+                b"    chained = [item for item in () for later in later()]\n"
             ),
         )
         snapshot = source_snapshot(source)
@@ -817,7 +1040,7 @@ class DeterministicIndexTests(unittest.TestCase):
             IndexEdge(worker.id, "call", "helper", nodes["Worker.helper"].id),
             index.edges,
         )
-        for name in ("lambda_local", "comprehension_local"):
+        for name in ("lambda_local", "comprehension_local", "later"):
             with self.subTest(name=name):
                 self.assertIn(IndexEdge(worker.id, "call", name, None), index.edges)
                 self.assertNotIn(
@@ -844,6 +1067,35 @@ class DeterministicIndexTests(unittest.TestCase):
                 "Base",
                 nodes[("pkg.py", "class", "Base")].id,
             ),
+            index.edges,
+        )
+
+    def test_definition_headers_see_earlier_walrus_bindings(self) -> None:
+        source = source_file(
+            "caller.py",
+            (
+                b"def helper():\n"
+                b"    return 'global'\n"
+                b"def run(value=((helper := lambda: 'local'), helper())):\n"
+                b"    return value\n"
+                b"class Child((helper := object), helper):\n"
+                b"    pass\n"
+            ),
+        )
+        snapshot = source_snapshot(source)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {node.qualified_name: node for node in index.nodes}
+        module = nodes["caller"]
+
+        self.assertIn(IndexEdge(module.id, "call", "helper", None), index.edges)
+        self.assertIn(IndexEdge(module.id, "reference", "helper", None), index.edges)
+        self.assertNotIn(
+            IndexEdge(module.id, "call", "helper", nodes["helper"].id),
+            index.edges,
+        )
+        self.assertNotIn(
+            IndexEdge(module.id, "reference", "helper", nodes["helper"].id),
             index.edges,
         )
 

--- a/tests/test_python_structure.py
+++ b/tests/test_python_structure.py
@@ -249,6 +249,85 @@ class PythonStructureTests(unittest.TestCase):
             ),
         )
 
+    def test_extracts_local_store_bindings_without_inferring_values(self) -> None:
+        source = source_file(
+            "bindings.py",
+            (
+                b"def bind(items, manager, error, value):\n"
+                b"    assigned = 1\n"
+                b"    augmented += 1\n"
+                b"    annotated: int\n"
+                b"    valued: int = 2\n"
+                b"    for looped in items:\n"
+                b"        pass\n"
+                b"    with manager() as managed:\n"
+                b"        pass\n"
+                b"    try:\n"
+                b"        raise error\n"
+                b"    except error as caught:\n"
+                b"        pass\n"
+                b"    match value:\n"
+                b"        case {'item': captured, **rest}:\n"
+                b"            pass\n"
+                b"    if named := value:\n"
+                b"        pass\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        bindings = {
+            item.name: (item.context, item.conditional, item.runtime)
+            for item in module.store_bindings
+        }
+
+        self.assertEqual(
+            bindings,
+            {
+                "annotated": ("bind", False, False),
+                "assigned": ("bind", False, True),
+                "augmented": ("bind", False, True),
+                "caught": ("bind", True, True),
+                "captured": ("bind", True, True),
+                "looped": ("bind", True, True),
+                "managed": ("bind", True, True),
+                "named": ("bind", True, True),
+                "rest": ("bind", True, True),
+                "valued": ("bind", False, True),
+            },
+        )
+        self.assertTrue(all(not item.projected_binding_scopes for item in module.store_bindings))
+
+    def test_projects_global_and_nonlocal_store_bindings_to_their_owners(self) -> None:
+        source = source_file(
+            "projected_stores.py",
+            (
+                b"module_value = 0\n"
+                b"def outer():\n"
+                b"    local_value = 0\n"
+                b"    def mutate():\n"
+                b"        global module_value\n"
+                b"        nonlocal local_value\n"
+                b"        module_value = 1\n"
+                b"        local_value = 2\n"
+                b"    return mutate\n"
+            ),
+        )
+
+        (module,) = extract_structures(source_snapshot(source))
+        projected = {
+            item.name: item.projected_binding_scopes
+            for item in module.store_bindings
+            if item.context == "outer.mutate"
+        }
+
+        self.assertEqual(
+            projected,
+            {
+                "local_value": (ImportBindingScope("outer", conditional=True, deferred=True),),
+                "module_value": (ImportBindingScope(None, conditional=True, deferred=True),),
+            },
+        )
+
     def test_projects_class_imports_to_declared_binding_scopes(self) -> None:
         source = source_file(
             "class_bindings.py",
@@ -413,6 +492,7 @@ class PythonStructureTests(unittest.TestCase):
                 b"class Worker:\n"
                 b"    lambda_value = (lambda local: local())(None)\n"
                 b"    values = [item() for item in items()]\n"
+                b"    chained = [value for value in sources() for later in later()]\n"
             ),
         )
 
@@ -425,6 +505,9 @@ class PythonStructureTests(unittest.TestCase):
         self.assertFalse(calls["items"].synthetic_local)
         self.assertTrue(calls["item"].skip_class_scope)
         self.assertTrue(calls["item"].synthetic_local)
+        self.assertFalse(calls["sources"].synthetic_local)
+        self.assertTrue(calls["later"].skip_class_scope)
+        self.assertTrue(calls["later"].synthetic_local)
 
     def test_attributes_definition_header_calls_to_the_enclosing_context(self) -> None:
         source = source_file(


### PR DESCRIPTION
## 왜 수정했나요?

함수 안에서 전역 함수나 경계 모듈과 같은 이름에 값을 대입하면 Python은 그 이름을 지역 변수로 처리합니다. 기존 색인은 일반 대입을 기록하지 않아, 실제로는 지역 변수인 호출을 전역 함수나 경계 코드에 잘못 연결했습니다.

## 무엇을 바꿨나요?

- 일반 대입과 타입 주석 대입의 지역 binding을 기록합니다.
- `for`, `with as`, `except as`, 패턴 매칭, walrus로 생기는 이름도 같은 규칙으로 처리합니다.
- 함수의 지역 이름은 대입문보다 앞에서 사용해도 바깥 정의로 연결하지 않습니다.
- `global`과 `nonlocal`로 바깥 범위를 갱신하는 경우는 기존 어휘 범위 규칙을 유지합니다.
- 조건부·지연 실행 경로에 경계 대상이 남아 있으면 placeholder를 보수적으로 유지합니다.
- 대입값의 타입이나 별칭은 추측하지 않습니다.

## 어떻게 확인했나요?

- 독립 반례 검토와 경계 placeholder 회귀 71개 통과
- `python -m ruff check . --no-cache`
- `python -m ruff format --check . --no-cache`
- `python -m mypy --strict src tests --no-incremental`
- `python -m unittest discover -s tests -q` — 통합 상태 253개 통과, 7개 skip

모든 검증은 이 브랜치의 `src`를 `PYTHONPATH`로 지정해 실행했습니다. 제품 코드 변경량은 400줄 분할 기준 안입니다.

## 이번 수정에서 제외한 내용

대입값의 실제 타입 추론, receiver type inference, 전체 데이터 흐름 분석은 추가하지 않았습니다.

Refs #200