### PR TITLE
fix(index): preserve real src package names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Aggregate approved public imports and boundary descriptions from selected source context (#199).
 - Keep local assignment targets unresolved instead of linking them to shadowed global or boundary
   symbols (#200).
+- Preserve absolute and relative imports when a project's real top-level package is named `src`
+  (#201).
 
 ## [1.0.4] - 2026-08-19
 

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -134,11 +134,13 @@ def build_index(
     contexts: dict[str, _ModuleContext] = {}
     all_nodes: list[IndexNode] = []
     global_targets: dict[str, str] = {}
+    src_is_package = "src/__init__.py" in sources
     for path in sorted(sources):
         context = _build_module_context(
             sources[path],
             modules[path],
             tuple(config["boundaries"]),
+            src_is_package=src_is_package,
         )
         contexts[path] = context
         module_node = _module_node(context)
@@ -182,8 +184,10 @@ def _build_module_context(
     source: SourceFile,
     structure: ModuleStructure,
     boundaries: tuple[BoundaryData, ...],
+    *,
+    src_is_package: bool,
 ) -> _ModuleContext:
-    module_name = _module_name(source.path)
+    module_name = _module_name(source.path, src_is_package=src_is_package)
     module_id = stable_node_id(source.path, "module", module_name)
     text_tokens = extract_scoped_source_text_tokens(source, structure.definitions)
     definition_tokens = dict(text_tokens.definitions)
@@ -618,10 +622,10 @@ def _context_id(context: _ModuleContext, qualified_name: str | None) -> str:
         raise IndexBuildError(f"unknown source context: {qualified_name}") from error
 
 
-def _module_name(path: str) -> str:
+def _module_name(path: str, *, src_is_package: bool) -> str:
     _validate_relative_path(path)
     parts = list(PurePosixPath(path).parts)
-    if len(parts) > 1 and parts[0] == "src" and parts[1] != "__init__.py":
+    if not src_is_package and len(parts) > 1 and parts[0] == "src" and parts[1] != "__init__.py":
         parts.pop(0)
     filename = parts[-1]
     if filename == "__init__.py" and len(parts) > 1:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -170,6 +170,44 @@ class DeterministicIndexTests(unittest.TestCase):
             index.edges,
         )
 
+    def test_preserves_src_when_it_is_the_actual_package_name(self) -> None:
+        package = source_file(
+            "src/__init__.py",
+            b"from .worker import helper\n",
+        )
+        dependency = source_file(
+            "src/worker.py",
+            b"def helper():\n    return 42\n",
+        )
+        caller = source_file(
+            "app.py",
+            b"from src.worker import helper as absolute_helper\n"
+            b"def run():\n    return absolute_helper()\n",
+        )
+        snapshot = source_snapshot(package, dependency, caller)
+
+        index = build_index(snapshot, extract_structures(snapshot), config())
+        nodes = {(node.path, node.kind, node.qualified_name): node for node in index.nodes}
+        package_module = nodes[("src/__init__.py", "module", "src")]
+        dependency_module = nodes[("src/worker.py", "module", "src.worker")]
+        dependency_function = nodes[("src/worker.py", "function", "helper")]
+        caller_module = nodes[("app.py", "module", "app")]
+        run = nodes[("app.py", "function", "run")]
+
+        self.assertIn(
+            IndexEdge(package_module.id, "import", "src.worker.helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(caller_module.id, "import", "src.worker.helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertIn(
+            IndexEdge(run.id, "call", "absolute_helper", dependency_function.id),
+            index.edges,
+        )
+        self.assertNotEqual(package_module.id, dependency_module.id)
+
     def test_resolves_relative_and_aliased_import_calls(self) -> None:
         caller = source_file(
             "src/pkg/feature.py",


### PR DESCRIPTION
## 왜 수정했나요?

siloBrief는 일반적인 `src/package` 구조에서 바깥 `src/`를 검색 경로로 보고 모듈명에서 제거합니다. 하지만 프로젝트의 실제 최상위 패키지 이름이 `src`이고 `src/__init__.py`가 있는 경우에도 같은 처리를 해 `src.worker`를 `worker`로 저장했습니다. 이 때문에 절대 import와 상대 import가 같은 코드에 연결되지 않았습니다.

## 무엇을 바꿨나요?

- 수집된 파일에 `src/__init__.py`가 있으면 `src`를 실제 패키지명으로 유지합니다.
- 이 경우 `src`, `src.worker`처럼 정식 모듈명을 만듭니다.
- 일반적인 `src/package` 구조는 기존처럼 바깥 `src/`를 제거합니다.
- 실제 `src` 패키지의 상대 import와 외부의 절대 import가 같은 함수 node로 연결되는 회귀 테스트를 추가했습니다.

## 어떻게 확인했나요?

- 실제 `src` 패키지, 일반적인 src-layout, namespace package, 중첩 경로, Windows 경로를 독립 검토
- `src` 아래 경계 모듈의 placeholder와 JSON 비노출 재현 확인
- `python -m ruff check . --no-cache`
- `python -m ruff format --check . --no-cache`
- `python -m mypy --strict src tests --no-incremental`
- `python -m unittest discover -s tests -q` — 통합 상태 254개 통과, 7개 skip

## 이번 수정에서 제외한 내용

`src/__init__.py`가 없는 namespace package를 실제 패키지 `src`로 추측하지 않습니다. 프로젝트 설정 파일을 읽어 패키지 배치 방식을 추론하는 기능도 추가하지 않았습니다.

Refs #201