### PR TITLE
fix(index): invalidate outdated graph indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   symbols (#200).
 - Preserve absolute and relative imports when a project's real top-level package is named `src`
   (#201).
+- Reject indexes built by older graph algorithms and tell users to run `sb init` (#202).
 
 ## [1.0.4] - 2026-08-19
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ retry after a successful upload.
 - Add complete parameter and return types to every function and method.
 - Keep `mypy --strict` passing without per-module relaxations.
 - Use the standard library at runtime.
+- Increase `INDEX_VERSION` whenever a change alters stored nodes, edges, search tokens, or their
+  meaning. siloBrief will then reject older indexes until the user runs `sb init`.
 - Write a failing acceptance or regression test before the smallest implementation.
 - Avoid speculative abstractions, unused extension points, and comments that repeat the code.
 

--- a/src/silobrief/index.py
+++ b/src/silobrief/index.py
@@ -11,6 +11,7 @@ from silobrief.boundary_placeholders import (
     BoundaryPlaceholder,
     import_target,
 )
+from silobrief.index_version import INDEX_VERSION, is_current_index_version
 from silobrief.python_structure import (
     Definition,
     ImportEntry,
@@ -161,7 +162,7 @@ def build_index(
     return IndexData(
         config_digest=config_digest(config),
         edges=tuple(sorted(edges, key=_edge_key)),
-        index_version=1,
+        index_version=INDEX_VERSION,
         nodes=tuple(sorted(all_nodes, key=_node_key)),
         source_digest=snapshot.digest,
         stale=False,
@@ -169,10 +170,12 @@ def build_index(
 
 
 def render_index_json(index: IndexData) -> bytes:
+    if not is_current_index_version(index.index_version):
+        raise IndexBuildError("index does not use the current version")
     value: dict[str, object] = {
         "config_digest": index.config_digest,
         "edges": [_edge_value(edge) for edge in index.edges],
-        "index_version": index.index_version,
+        "index_version": INDEX_VERSION,
         "nodes": [_node_value(node) for node in index.nodes],
         "source_digest": index.source_digest,
         "stale": index.stale,

--- a/src/silobrief/index_version.py
+++ b/src/silobrief/index_version.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+INDEX_VERSION = 2
+_OLDEST_REBUILDABLE_INDEX_VERSION = 1
+
+
+def is_current_index_version(value: object) -> bool:
+    return type(value) is int and value == INDEX_VERSION
+
+
+def is_rebuildable_index_version(value: object) -> bool:
+    return type(value) is int and _OLDEST_REBUILDABLE_INDEX_VERSION <= value <= INDEX_VERSION

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -8,6 +8,7 @@ import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TypedDict
 
+from silobrief.index_version import INDEX_VERSION, is_rebuildable_index_version
 from silobrief.language import (
     LanguageSettings,
     default_language_settings,
@@ -244,8 +245,10 @@ def _validate_state(state: Path) -> ConfigData:
             index_data = _read_object(index)
         except SetupError as error:
             raise IndexStateError(str(error)) from error
-        if not _is_version_one(index_data.get("index_version")):
-            raise IndexStateError("index.json is not compatible with version 1")
+        if not is_rebuildable_index_version(index_data.get("index_version")):
+            raise IndexStateError(
+                f"index.json is not compatible with index version {INDEX_VERSION}"
+            )
     return config
 
 

--- a/src/silobrief/stored_index.py
+++ b/src/silobrief/stored_index.py
@@ -17,6 +17,11 @@ from silobrief.index import (
     render_index_json,
     stable_node_id,
 )
+from silobrief.index_version import (
+    INDEX_VERSION,
+    is_current_index_version,
+    is_rebuildable_index_version,
+)
 from silobrief.path_safety import is_link_like
 from silobrief.state import STATE_DIRECTORY, is_valid_boundary_alias
 
@@ -50,7 +55,10 @@ def _index(value: object) -> IndexData:
         value,
         {"config_digest", "edges", "index_version", "nodes", "source_digest", "stale"},
     )
-    if type(data["index_version"]) is not int or data["index_version"] != 1:
+    index_version = data["index_version"]
+    if is_rebuildable_index_version(index_version) and not is_current_index_version(index_version):
+        raise StoredIndexError("index.json uses an outdated version; run sb init")
+    if not is_current_index_version(index_version):
         raise StoredIndexError("index.json has an unsupported version")
     if type(data["stale"]) is not bool:
         raise StoredIndexError("index.json stale flag is invalid")
@@ -60,7 +68,7 @@ def _index(value: object) -> IndexData:
     return IndexData(
         config_digest=_digest(data["config_digest"]),
         edges=edges,
-        index_version=1,
+        index_version=INDEX_VERSION,
         nodes=nodes,
         source_digest=_digest(data["source_digest"]),
         stale=data["stale"],

--- a/tests/fixtures/index-v1.0.4-minimal.json
+++ b/tests/fixtures/index-v1.0.4-minimal.json
@@ -1,0 +1,52 @@
+{
+  "config_digest": "1f2cea43ad63fc817972f18ff298ad9e53bf99e2dfd3406dbd27f3db13f8d072",
+  "edges": [
+    {
+      "kind": "contains",
+      "source_id": "node-0a79429d9bc295cd8c473dbf67725be366c8ac8406fdbbf8d72eda56717429d2",
+      "target": "run",
+      "target_id": "node-305953ad8765d5941e4285c77f6a00ae0e67ae175757c3cdca8eb1e46c29c04f"
+    }
+  ],
+  "index_version": 1,
+  "nodes": [
+    {
+      "id": "node-0a79429d9bc295cd8c473dbf67725be366c8ac8406fdbbf8d72eda56717429d2",
+      "kind": "module",
+      "name": "service",
+      "path": "service.py",
+      "qualified_name": "service",
+      "tokens": {
+        "comments": [],
+        "docstrings": [],
+        "imports": [],
+        "path": [
+          "service"
+        ],
+        "symbol": [
+          "service"
+        ]
+      }
+    },
+    {
+      "id": "node-305953ad8765d5941e4285c77f6a00ae0e67ae175757c3cdca8eb1e46c29c04f",
+      "kind": "function",
+      "name": "run",
+      "path": "service.py",
+      "qualified_name": "run",
+      "tokens": {
+        "comments": [],
+        "docstrings": [],
+        "imports": [],
+        "path": [
+          "service"
+        ],
+        "symbol": [
+          "run"
+        ]
+      }
+    }
+  ],
+  "source_digest": "554875b6f8efcea50960fd5c6936b27af8396dd83f43192d696ec082f5d4ac7b",
+  "stale": false
+}

--- a/tests/test_chat_command.py
+++ b/tests/test_chat_command.py
@@ -366,7 +366,7 @@ class ChatCommandTests(unittest.TestCase):
             self.assertEqual(result, 3)
             self.assertIn("cannot read index.json", stderr_text)
 
-            index.write_text('{"index_version": 2}\n', encoding="utf-8", newline="\n")
+            index.write_text('{"index_version": 3}\n', encoding="utf-8", newline="\n")
             result, _, _, stderr_text = run_chat(project, ".silobrief/exports/incompatible.md", "")
             self.assertEqual(result, 3)
             self.assertIn("not compatible", stderr_text)
@@ -379,6 +379,35 @@ class ChatCommandTests(unittest.TestCase):
             self.assertEqual(result, 4)
             self.assertIn("sources changed", stderr_text)
             self.assertFalse((project / ".silobrief/exports/changed.md").exists())
+
+    def test_search_and_brief_reject_v1_index_with_rebuild_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            prepare_project(project)
+            index = project / ".silobrief" / "index.json"
+            current = index.read_bytes()
+            legacy = current.replace(b'"index_version": 2', b'"index_version": 1')
+            self.assertNotEqual(legacy, current)
+            index.write_bytes(legacy)
+
+            search_stderr = io.StringIO()
+            with working_directory(project), contextlib.redirect_stderr(search_stderr):
+                search_result = main(["search", "run"])
+
+            brief_result, _, _, brief_stderr = run_chat(
+                project,
+                ".silobrief/exports/outdated.md",
+                "",
+            )
+
+            self.assertEqual(search_result, 3)
+            self.assertIn("outdated", search_stderr.getvalue())
+            self.assertIn("run sb init", search_stderr.getvalue())
+            self.assertEqual(brief_result, 3)
+            self.assertIn("outdated", brief_stderr)
+            self.assertIn("run sb init", brief_stderr)
+            self.assertFalse((project / ".silobrief/exports/outdated.md").exists())
+            self.assertEqual(index.read_bytes(), legacy)
 
     def test_blocks_non_tty_refusal_and_existing_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_current_index.py
+++ b/tests/test_current_index.py
@@ -11,10 +11,13 @@ from unittest import mock
 from silobrief import current_index
 from silobrief.boundaries import register_boundary
 from silobrief.current_index import CurrentIndexError, load_current_index
+from silobrief.index import config_digest
 from silobrief.initialization import initialize_index
 from silobrief.sources import SourceCollectionError, SourceWarning, snapshot_sources
 from silobrief.state import SetupError, load_config, setup_project
 from silobrief.stored_index import StoredIndexError, load_stored_index
+
+V1_0_4_INDEX = Path(__file__).with_name("fixtures") / "index-v1.0.4-minimal.json"
 
 
 def create_project(project: Path) -> tuple[Path, Path]:
@@ -94,6 +97,55 @@ class CurrentIndexTests(unittest.TestCase):
             self.assertEqual(loaded, expected)
             self.assertEqual(current_snapshot, replace(snapshot, warnings=(warning,)))
             self.assertEqual(file_state(project), before)
+
+    def test_v1_0_4_index_requires_init_before_it_can_be_used(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            source = project / "service.py"
+            source.write_text("def run():\n    return 1\n", encoding="utf-8", newline="\n")
+            setup_project(project)
+            state = project / ".silobrief"
+            index_path = state / "index.json"
+            index_path.write_bytes(V1_0_4_INDEX.read_bytes())
+            legacy_bytes = index_path.read_bytes()
+            config_bytes = (state / "config.json").read_bytes()
+            notes_bytes = (state / "notes.json").read_bytes()
+            source_bytes = source.read_bytes()
+            before_setup = file_state(project)
+            legacy_index = object_file(index_path)
+
+            self.assertEqual(legacy_index["index_version"], 1)
+            self.assertEqual(legacy_index["config_digest"], config_digest(load_config(project)))
+            self.assertEqual(
+                legacy_index["source_digest"],
+                snapshot_sources(project, load_config(project)).digest,
+            )
+
+            self.assertFalse(setup_project(project))
+            self.assertEqual(file_state(project), before_setup)
+
+            with self.assertRaises(StoredIndexError) as caught:
+                load_current_index(project)
+
+            self.assertIn("outdated", str(caught.exception))
+            self.assertIn("run sb init", str(caught.exception))
+            self.assertEqual(index_path.read_bytes(), legacy_bytes)
+
+            initialize_index(project)
+            self.assertEqual(
+                index_path.read_bytes(),
+                legacy_bytes.replace(b'"index_version": 1', b'"index_version": 2'),
+            )
+            loaded, snapshot = load_current_index(project)
+
+            self.assertEqual(loaded.index_version, 2)
+            self.assertEqual(loaded.source_digest, snapshot.digest)
+            self.assertEqual((state / "config.json").read_bytes(), config_bytes)
+            self.assertEqual((state / "notes.json").read_bytes(), notes_bytes)
+            self.assertEqual(source.read_bytes(), source_bytes)
+            current_state = file_state(project)
+            self.assertFalse(setup_project(project))
+            self.assertEqual(file_state(project), current_state)
 
     def test_stale_and_config_mismatch_stop_before_source_collection(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1166,8 +1166,11 @@ class DeterministicIndexTests(unittest.TestCase):
             set(parsed),
             {"config_digest", "edges", "index_version", "nodes", "source_digest", "stale"},
         )
-        self.assertEqual(parsed["index_version"], 1)
+        self.assertEqual(parsed["index_version"], 2)
         self.assertIs(parsed["stale"], False)
+
+        with self.assertRaisesRegex(IndexBuildError, "current version"):
+            render_index_json(replace(first, index_version=1))
 
     def test_config_and_source_digest_changes_are_visible(self) -> None:
         source = source_file("module.py", b"VALUE = 1\n")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -173,7 +173,7 @@ class InitCommandTests(unittest.TestCase):
             self.assertNotIn(b"fixture-private-canary", first_index)
             self.assertIn(b"delivery-boundary", first_index)
             index = index_object(project)
-            self.assertEqual(index["index_version"], 1)
+            self.assertEqual(index["index_version"], 2)
             self.assertIs(index["stale"], False)
 
     def test_init_reports_parse_error_and_preserves_existing_index(self) -> None:

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -21,7 +21,7 @@ from silobrief.cli import main
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "parcel-sync-fixture"
 OUTPUT_PATH = ".silobrief/exports/retry-brief.md"
 REVIEW_INPUT = "y\n1\n\n\ny\ny\ny\ny\ny\ny\nEXPOSE\nWRITE\n"
-INDEX_SHA256 = "ba9d4618aec48471c7f117008fcc467f71259c89cbbc03d7f93107ddc81a1fd1"
+INDEX_SHA256 = "69a477a6abaf7c1b0d60efaa80cf02dfc1e567278c28b2bbfe462a32217517c3"
 BRIEF_SHA256 = "f4403caa6c83ed619bc3783f1d3931d8fc4ff2fd000e28666b6da2152ad4d82c"
 PUBLIC_CANARIES = (
     "PUBLIC_SOURCE_BODY_CANARY",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -316,10 +316,13 @@ class SetupCommandTests(unittest.TestCase):
 
             notes.write_text('{"notes": [], "notes_version": 1}\n', encoding="utf-8")
             index = state / "index.json"
-            index.write_text('{"index_version": 2}\n', encoding="utf-8")
+            for version in (True, 3):
+                with self.subTest(index_version=version):
+                    content = json.dumps({"index_version": version}) + "\n"
+                    index.write_text(content, encoding="utf-8")
 
-            self.assert_setup_error(project)
-            self.assertEqual(index.read_text(encoding="utf-8"), '{"index_version": 2}\n')
+                    self.assert_setup_error(project)
+                    self.assertEqual(index.read_text(encoding="utf-8"), content)
 
     def test_setup_removes_new_state_after_write_failure(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_stored_index.py
+++ b/tests/test_stored_index.py
@@ -78,6 +78,10 @@ def invalidate_version(value: dict[str, object]) -> None:
     value["index_version"] = True
 
 
+def use_future_version(value: dict[str, object]) -> None:
+    value["index_version"] = 3
+
+
 def invalidate_digest(value: dict[str, object]) -> None:
     value["source_digest"] = "not-a-digest"
 
@@ -143,6 +147,7 @@ class StoredIndexTests(unittest.TestCase):
         mutations: tuple[tuple[str, Callable[[dict[str, object]], None]], ...] = (
             ("unknown key", add_unknown_key),
             ("version", invalidate_version),
+            ("future version", use_future_version),
             ("digest", invalidate_digest),
             ("node", invalidate_node_id),
             ("tokens", invalidate_tokens),


### PR DESCRIPTION
## 왜 수정했나요?

v1.0.4에서 Python 이름 해석 방식이 바뀌었지만 저장된 색인 형식은 계속 version 1이었습니다. 소스와 설정이 그대로인 프로젝트에서는 이전 버전이 만든 색인을 최신 상태로 받아들여, 수정된 그래프가 적용되지 않을 수 있었습니다.

## 무엇을 바꿨나요?

- 색인 알고리즘 버전을 한 곳에서 관리하고 현재 버전을 2로 올렸습니다.
- 생성, 직렬화, 저장 색인 로더가 같은 버전 정책을 사용합니다.
- version 1 색인은 search, brief, chat에서 사용하지 않고 sb init 재실행을 안내합니다.
- setup은 기존 상태를 바꾸지 않은 채 version 1 색인을 허용하고, init은 설정·메모·소스를 보존하면서 version 2로 다시 만듭니다.
- bool, 미래 버전, 비표준 JSON은 기존처럼 거부합니다.
- 그래프와 검색 토큰의 의미가 달라질 때 색인 버전을 올리는 유지보수 규칙을 기록했습니다.

## 어떻게 확인했나요?

- v1.0.4 형식의 색인을 만든 뒤 search와 brief가 사용을 차단하는지 확인
- setup이 기존 파일을 건드리지 않고 init이 version 2로 재생성하는지 확인
- 초기화 실패와 소스 변경 시 이전 색인이 보존되는지 확인
- 독립 검토에서 생성·저장·로더·CLI 경로와 버전 경계 사례 점검
- python -m ruff check . --no-cache
- python -m ruff format --check . --no-cache
- python -m mypy --strict src tests --no-incremental
- python -m unittest discover -s tests -q — 256개 통과, 7개 skip

## 이번 수정에서 제외한 내용

오래된 색인을 자동 변환하지 않습니다. 색인 자체를 다시 계산해야 바뀐 Python 이름 해석 규칙이 정확히 반영되므로, 사용자가 sb init을 실행하도록 안내합니다.

Closes #202