### PR TITLE
fix(package): include README-linked sdist assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Reject indexes built by older graph algorithms and tell users to run `sb init` (#202).
 - Make the frozen scope evaluator runnable from a clean clone with pinned corpus setup and clear
   missing-input errors (#204).
+- Include every repository asset linked from the packaged README files in the source distribution
+  (#203).
 
 ## [1.0.4] - 2026-08-19
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CODE_OF_CONDUCT.md
 include CONTRIBUTING.md
 include README.ko.md
 include SECURITY.md
+include .github/assets/silobrief-wordmark.svg
 include .github/workflows/publish-pypi.yml
 include tests/__init__.py
 recursive-include examples/parcel-sync-fixture *.md *.py
@@ -12,3 +13,5 @@ recursive-include validation/v0.7 *.md
 recursive-include validation/v0.8 *.md
 recursive-include validation/v0.9 *.md
 recursive-include validation/v1.0 *.md
+include validation/v1.0.1/RELEASE_VERIFICATION.md
+include validation/v1.0-scope-related-context/REPORT.md

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -5,12 +5,47 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from html.parser import HTMLParser
 from importlib.metadata import distribution
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
 import silobrief
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+README_PATHS = (REPOSITORY_ROOT / "README.md", REPOSITORY_ROOT / "README.ko.md")
+
+
+class _ImageSourceParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sources: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "img":
+            return
+        for name, value in attrs:
+            if name == "src" and value is not None:
+                self.sources.append(value)
+
+
+def _local_readme_targets() -> set[Path]:
+    targets: set[Path] = set()
+    for readme_path in README_PATHS:
+        text = readme_path.read_text(encoding="utf-8")
+        parser = _ImageSourceParser()
+        parser.feed(text)
+        values = parser.sources
+        values.extend(partition.split(")", 1)[0] for partition in text.split("](")[1:])
+        for value in values:
+            parsed = urlsplit(value)
+            if parsed.scheme or parsed.netloc or not parsed.path:
+                continue
+            target = Path(unquote(parsed.path))
+            if target.is_absolute() or ".." in target.parts:
+                raise AssertionError(f"README local link leaves the repository: {value}")
+            targets.add(target)
+    return targets
 
 
 class PackageMetadataTests(unittest.TestCase):
@@ -55,6 +90,11 @@ class SourceDistributionTests(unittest.TestCase):
                 members = set(archive.getnames())
 
         root = f"silobrief-{distribution('silobrief').version}"
+        readme_targets = _local_readme_targets()
+        missing_repository_targets = {
+            path for path in readme_targets if not (REPOSITORY_ROOT / path).is_file()
+        }
+        self.assertFalse(missing_repository_targets, missing_repository_targets)
         required = {
             f"{root}/.github/workflows/publish-pypi.yml",
             f"{root}/CHANGELOG.md",
@@ -71,6 +111,7 @@ class SourceDistributionTests(unittest.TestCase):
             f"{root}/validation/v0.9/FIELD_TRIAL.md",
             f"{root}/validation/v1.0/RELEASE_CANDIDATE.md",
         }
+        required.update(f"{root}/{path.as_posix()}" for path in readme_targets)
         forbidden = {
             f"{root}/validation/graph-retrieval/BASELINE.md",
             f"{root}/validation/graph-retrieval/COMPARISON.md",


### PR DESCRIPTION
## 왜 필요한가

v1.0.4 sdist에는 README와 README.ko.md가 상대 경로로 가리키는 로고와 검증 문서가 빠져 있었습니다. 저장소에서는 링크가 열리지만, PyPI에서 받은 소스 배포본만 보면 해당 파일을 찾을 수 없습니다.

## 무엇을 바꿨나

- 로고와 v1.0.1 검증 문서, 범위 기반 연관 코드 검증 보고서를 `MANIFEST.in`에 추가했습니다.
- 두 README의 Markdown 링크와 이미지 경로를 테스트에서 직접 수집하도록 했습니다.
- 로컬 링크가 저장소에 실제로 존재하는지, 빌드한 sdist에도 들어 있는지 함께 검사합니다.
- 변경 내용을 CHANGELOG의 Unreleased 항목에 기록했습니다.

## 확인

- `python -m unittest tests.test_package -v`
- `python -m unittest discover -s tests -q` — 263 passed, 7 skipped
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy --strict src tests --no-incremental`
- wheel과 sdist를 새로 빌드해 산출물이 정확히 두 개인지 확인
- 격리 venv에 wheel 설치 후 `siloBrief 1.0.4`, `pip check` 확인
- sdist에서 README가 가리키는 세 누락 파일 확인

## 이번 PR에서 제외한 내용

- 이미 배포된 v1.0.4 파일 교체
- validation 전체를 wheel에 포함하는 변경
- 문서 사이트 도입

Closes #203