### PR TITLE
fix(ci): restore cross-platform release checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.0.5] - 2026-08-19
+## [1.0.5] - 2026-08-21
 
 ### Fixed
 
@@ -27,6 +27,9 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   missing-input errors (#204).
 - Resume a recognized partial state after an interrupted `sb setup`, while leaving unknown or
   invalid entries untouched (#214).
+- Restore cross-platform release checks by detecting rapid Linux approval-state replacements,
+  serializing empty Windows config-lock initialization, and accepting stable Windows workspace
+  drive aliases for source and output paths (#216).
 
 ### Security
 

--- a/src/silobrief/boundaries.py
+++ b/src/silobrief/boundaries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import stat
+import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -113,7 +114,7 @@ def unregister_boundary(selector: str, *, start: Path) -> BoundaryData:
 
 @contextmanager
 def _config_update_lock(state: Path, state_descriptor: int | None) -> Iterator[None]:
-    if os.name != "nt":
+    if sys.platform != "win32":
         if state_descriptor is None:
             raise SetupError("state directory descriptor is unavailable")
         _lock_descriptor(state_descriptor)
@@ -144,9 +145,9 @@ def _config_update_lock(state: Path, state_descriptor: int | None) -> Iterator[N
             or not os.path.samestat(metadata, current)
         ):
             raise SetupError("config lock must be a real file")
-        _ensure_lock_byte(descriptor)
         _lock_descriptor(descriptor)
         acquired = True
+        _ensure_lock_byte(descriptor)
         try:
             current = path.stat(follow_symlinks=False)
         except OSError as error:
@@ -176,7 +177,7 @@ def _ensure_lock_byte(descriptor: int) -> None:
 
 
 def _lock_descriptor(descriptor: int) -> None:
-    if os.name != "nt":
+    if sys.platform != "win32":
         file_locks = cast(_FileLockModule, importlib.import_module("fcntl"))
 
         try:
@@ -201,7 +202,7 @@ def _lock_descriptor(descriptor: int) -> None:
 
 def _unlock_descriptor(descriptor: int) -> None:
     try:
-        if os.name == "nt":
+        if sys.platform == "win32":
             import msvcrt
 
             os.lseek(descriptor, 0, os.SEEK_SET)

--- a/src/silobrief/current_index.py
+++ b/src/silobrief/current_index.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
+import threading
 from dataclasses import dataclass, field
 from io import FileIO
 from pathlib import Path
@@ -61,6 +63,7 @@ class _ApprovalResources:
     state_fd: int
     config_fd: int
     index_fd: int
+    watch_fd: int | None
     root_generation: _FileGeneration
     state_generation: _FileGeneration
     config_generation: _FileGeneration
@@ -68,10 +71,12 @@ class _ApprovalResources:
     config_content: bytes
     index_content: bytes
     root_identity: SourceRootIdentity
+    watch_changed: bool = False
+    watch_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     status: int = 0
 
     def revalidate(self) -> None:
-        if self.status or has_link_like_component(self.root):
+        if self.status or self._watch_changed() or has_link_like_component(self.root):
             raise CurrentIndexError("project settings changed during approval; run sb init")
         state = self.root / STATE_DIRECTORY
         try:
@@ -96,6 +101,7 @@ class _ApprovalResources:
             if (
                 _read_descriptor(self.config_fd) != self.config_content
                 or _read_descriptor(self.index_fd) != self.index_content
+                or self._watch_changed()
             ):
                 raise CurrentIndexError("project settings changed during approval; run sb init")
         except OSError as error:
@@ -103,11 +109,19 @@ class _ApprovalResources:
                 "project settings changed during approval; run sb init"
             ) from error
 
+    def _watch_changed(self) -> bool:
+        with self.watch_lock:
+            self.watch_changed = self.watch_changed or _approval_watch_changed(self.watch_fd)
+            return self.watch_changed
+
     def close(self) -> None:
         if self.status == 2:
             return
         self.status = 2
-        _close_descriptors(self.root_fd, self.state_fd, self.config_fd, self.index_fd)
+        descriptors = [self.root_fd, self.state_fd, self.config_fd, self.index_fd]
+        if self.watch_fd is not None:
+            descriptors.append(self.watch_fd)
+        _close_descriptors(*descriptors)
 
 
 def load_current_index(root: Path) -> tuple[IndexData, SourceSnapshot]:
@@ -189,9 +203,14 @@ def _open_approval_resources(root: Path) -> _ApprovalResources:
         return opened
 
     try:
+        watch_descriptor = _open_approval_watch()
+        if watch_descriptor is not None:
+            descriptors.append(watch_descriptor)
         root_descriptor, root_generation = hold(root, root.name, None, True)
+        _add_approval_watch(watch_descriptor, f"/proc/self/fd/{root_descriptor}")
         state = root / STATE_DIRECTORY
         state_descriptor, state_generation = hold(state, STATE_DIRECTORY, root_descriptor, True)
+        _add_approval_watch(watch_descriptor, f"/proc/self/fd/{state_descriptor}")
         config_descriptor, config_generation = hold(
             state / "config.json", "config.json", state_descriptor, False
         )
@@ -204,6 +223,7 @@ def _open_approval_resources(root: Path) -> _ApprovalResources:
             state_fd=state_descriptor,
             config_fd=config_descriptor,
             index_fd=index_descriptor,
+            watch_fd=watch_descriptor,
             root_generation=root_generation,
             state_generation=state_generation,
             config_generation=config_generation,
@@ -299,6 +319,43 @@ def _read_descriptor(descriptor: int) -> bytes:
         return FileIO(descriptor, closefd=False).read()
     finally:
         os.lseek(descriptor, position, os.SEEK_SET)
+
+
+def _open_approval_watch() -> int | None:
+    if sys.platform != "linux":
+        return None
+    import ctypes
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    initialize = libc.inotify_init1
+    initialize.argtypes = (ctypes.c_int,)
+    initialize.restype = ctypes.c_int
+    descriptor = int(initialize(os.O_NONBLOCK | int(getattr(os, "O_CLOEXEC", 0))))
+    if descriptor < 0:
+        raise OSError(ctypes.get_errno(), "cannot monitor approval state")
+    return descriptor
+
+
+def _add_approval_watch(descriptor: int | None, path: str) -> None:
+    if descriptor is None:
+        return
+    import ctypes
+
+    add_watch = ctypes.CDLL(None, use_errno=True).inotify_add_watch
+    add_watch.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_uint32)
+    add_watch.restype = ctypes.c_int
+    change_mask = 0x2 | 0x4 | 0x8 | 0x40 | 0x80 | 0x100 | 0x200 | 0x400 | 0x800 | 0x2000
+    if add_watch(descriptor, os.fsencode(path), change_mask) < 0:
+        raise OSError(ctypes.get_errno(), "cannot monitor approval state")
+
+
+def _approval_watch_changed(descriptor: int | None) -> bool:
+    if descriptor is None:
+        return False
+    try:
+        return bool(os.read(descriptor, 65536))
+    except BlockingIOError:
+        return False
 
 
 def _close_descriptors(*descriptors: int) -> None:

--- a/src/silobrief/output.py
+++ b/src/silobrief/output.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import os
 import stat
+import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -265,10 +266,6 @@ def _protected_output_directory(
         write_descriptor = parent_descriptor
 
     try:
-        if os.name == "nt" and _normalized_windows_path(
-            _windows_handle_path(parent_descriptor)
-        ) != _normalized_windows_path(path):
-            raise OutputBlockedError("output parent must remain a real directory")
         if not _same_directory(path, parent_descriptor):
             raise OutputBlockedError("output parent must remain a real directory")
         guard = _OutputDirectoryGuard(
@@ -368,6 +365,8 @@ def _same_path_identity(path: Path, identity: tuple[int, int]) -> bool:
 
 
 def _open_windows_directory(path: Path) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows output handles are unavailable")
     import ctypes
     import msvcrt
 
@@ -409,6 +408,8 @@ def _open_windows_directory(path: Path) -> int:
 
 
 def _windows_handle_path(descriptor: int) -> Path:
+    if sys.platform != "win32":
+        raise OSError("Windows output handles are unavailable")
     import ctypes
     import msvcrt
 
@@ -435,15 +436,6 @@ def _windows_handle_path(descriptor: int) -> Path:
     elif value.startswith("\\\\?\\"):
         value = value[4:]
     return Path(value)
-
-
-def _normalized_windows_path(path: Path) -> str:
-    value = str(path.absolute())
-    if value.startswith("\\\\?\\UNC\\"):
-        value = f"\\\\{value[8:]}"
-    elif value.startswith("\\\\?\\"):
-        value = value[4:]
-    return os.path.normcase(os.path.normpath(value))
 
 
 def _require_allowed_location(destination: Path, root: Path) -> None:
@@ -599,6 +591,8 @@ def _open_new_file(path: Path, directory_descriptor: int | None) -> tuple[int, b
 
 
 def _open_windows_output_file(path: Path) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows output handles are unavailable")
     import ctypes
     import msvcrt
 
@@ -775,7 +769,7 @@ def _abort_created_file(guard: _OutputDirectoryGuard) -> None:
 
 
 def _mark_windows_file_for_deletion(created: _CreatedFile) -> bool:
-    if created.descriptor < 0:
+    if sys.platform != "win32" or created.descriptor < 0:
         return False
     try:
         import ctypes

--- a/src/silobrief/sources.py
+++ b/src/silobrief/sources.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import stat
+import sys
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
@@ -100,7 +101,9 @@ def load_source_config(
 ) -> tuple[ConfigData, SourceRootIdentity]:
     with _validated_root(root, expected_root_identity, protected_root_descriptor) as project:
         config_root = (
-            root if project.descriptor is None else Path("/proc/self/fd") / str(project.descriptor)
+            project.expected_path
+            if project.descriptor is None
+            else Path("/proc/self/fd") / str(project.descriptor)
         )
         config = load_config(config_root)
         _require_current_root(project)
@@ -512,7 +515,7 @@ def _capture_boundary_tree(
             raise SourceCollectionError(
                 f"registered boundary has no stable file ID: {child.relative_path}"
             )
-        path = project.path / Path(child.relative_path)
+        path = project.expected_path / Path(child.relative_path)
         access = 0x00000080 | (0x00000001 if child.children else 0)
         try:
             handle = _open_windows_handle(
@@ -563,13 +566,12 @@ def _verify_boundary_handle(
     expected_directory: bool | None,
     handle: int,
 ) -> tuple[int, bool]:
-    path = project.path / Path(relative)
     expected_path = project.expected_path / Path(relative)
     try:
         attributes = _windows_handle_attributes(handle)
         actual_path = _windows_handle_path(handle)
         entry_id = _windows_handle_file_id(handle)
-        observed = path.stat(follow_symlinks=False)
+        observed = expected_path.stat(follow_symlinks=False)
     except OSError as error:
         raise SourceCollectionError(
             f"cannot protect registered boundary {relative}: {_error_reason(error)}"
@@ -623,7 +625,11 @@ def _read_regular_source(
                 raise SourceCollectionError(
                     f"source entry changed location before read: {relative_path}"
                 )
-            locked_path_state = path.stat(follow_symlinks=False) if os.name == "nt" else opened
+            locked_path_state = (
+                (parent.expected_path / path.name).stat(follow_symlinks=False)
+                if os.name == "nt"
+                else opened
+            )
             if not _same_file_state(locked_path_state, opened) or not _same_entry_observation(
                 expected,
                 locked_path_state,
@@ -682,7 +688,7 @@ def _scan_directory(
     directory: _SourceDirectory,
 ) -> AbstractContextManager[Iterator[os.DirEntry[str]]]:
     target: int | Path = (
-        directory.descriptor if directory.descriptor is not None else directory.path
+        directory.descriptor if directory.descriptor is not None else directory.expected_path
     )
     return os.scandir(target)
 
@@ -690,7 +696,7 @@ def _scan_directory(
 def _directory_metadata(directory: _SourceDirectory) -> os.stat_result:
     if directory.descriptor is not None:
         return os.fstat(directory.descriptor)
-    return directory.path.stat(follow_symlinks=False)
+    return directory.expected_path.stat(follow_symlinks=False)
 
 
 @contextmanager
@@ -699,29 +705,32 @@ def _open_root_directory(
     expected_identity: SourceRootIdentity,
     protected_root_descriptor: int | None = None,
 ) -> Iterator[_SourceDirectory]:
-    if os.name == "nt":
+    if sys.platform == "win32":
         import msvcrt
 
         handles: list[int] = []
         borrowed_descriptor: int | None = None
-        current = Path(path.anchor)
+        requested = Path(path.anchor)
+        canonical: Path | None = None
         try:
             for component in (path.anchor, *path.parts[1:]):
                 if component != path.anchor:
-                    current /= component
-                if current == path and protected_root_descriptor is not None:
+                    requested /= component
+                current = requested if canonical is None else canonical / component
+                if requested == path and protected_root_descriptor is not None:
                     borrowed_descriptor = os.dup(protected_root_descriptor)
                     handle = msvcrt.get_osfhandle(borrowed_descriptor)
                 else:
                     handle = _open_windows_directory(
                         current,
-                        lock_delete=current == path,
-                        list_entries=current == path,
+                        lock_delete=requested == path,
+                        list_entries=requested == path,
                     )
                     handles.append(handle)
                 actual = _windows_handle_path(handle)
-                if not _paths_match(current, actual):
+                if not (_paths_match(current, actual) or os.path.samefile(current, actual)):
                     raise OSError("project root component changed while opening")
+                canonical = actual
             opened = path.stat(follow_symlinks=False)
             if _source_root_identity(opened) != expected_identity:
                 raise OSError("project root changed while opening")
@@ -786,10 +795,10 @@ def _open_child_directory(
             os.close(descriptor)
         return
 
-    handle = _open_windows_directory(path)
+    handle = _open_windows_directory(wanted_path)
     try:
         actual = _windows_handle_path(handle)
-        after_open = path.stat(follow_symlinks=False)
+        after_open = wanted_path.stat(follow_symlinks=False)
         if not _same_entry_observation(
             expected, after_open, expected_inode, False
         ) or not _paths_match(wanted_path, actual):
@@ -831,7 +840,7 @@ def _open_source_descriptor(parent: _SourceDirectory, name: str, path: Path) -> 
         flags = os.O_RDONLY | int(getattr(os, "O_CLOEXEC", 0))
         flags |= int(getattr(os, "O_NOFOLLOW", 0))
         return os.open(name, flags, dir_fd=parent.descriptor)
-    return _open_windows_source(path)
+    return _open_windows_source(parent.expected_path / name)
 
 
 def _opened_file_path(file_descriptor: int) -> Path:
@@ -856,7 +865,7 @@ def _open_windows_directory(
     lock_delete: bool = True,
     list_entries: bool = True,
 ) -> int:
-    cwd_outside = not Path.cwd().is_relative_to(path)
+    cwd_outside = not _windows_directory_contains_cwd(path)
     access = 0x00010080 if lock_delete and cwd_outside else 0x00000080
     if list_entries:
         access |= 0x00000001
@@ -872,7 +881,22 @@ def _open_windows_directory(
     return handle
 
 
+def _windows_directory_contains_cwd(path: Path) -> bool:
+    cwd = Path.cwd()
+    if cwd.is_relative_to(path):
+        return True
+    for candidate in (cwd, *cwd.parents):
+        try:
+            if os.path.samefile(candidate, path):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _open_windows_source(path: Path) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import msvcrt
 
     handle = _open_windows_handle(path, 0x80010000, 0x00200000 | 0x08000000)
@@ -898,6 +922,8 @@ def _open_windows_handle(
     *,
     share: int = 0x1 | 0x2,
 ) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -920,6 +946,8 @@ def _open_windows_handle(
 
 
 def _windows_directory_entry_ids(handle: int) -> dict[str, int]:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     class FileIdBothDirectoryInfo(ctypes.Structure):
@@ -982,6 +1010,8 @@ def _windows_directory_entry_ids(handle: int) -> dict[str, int]:
 
 
 def _windows_handle_attributes(handle: int) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     class FileAttributeTagInfo(ctypes.Structure):
@@ -998,6 +1028,8 @@ def _windows_handle_attributes(handle: int) -> int:
 
 
 def _windows_handle_file_id(handle: int) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     class ByHandleFileInformation(ctypes.Structure):
@@ -1028,6 +1060,8 @@ def _windows_handle_file_id(handle: int) -> int:
 
 
 def _windows_handle_path(handle: int) -> Path:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -1058,6 +1092,8 @@ def _windows_handle_path(handle: int) -> Path:
 
 
 def _windows_opened_file_path(file_descriptor: int) -> Path:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import msvcrt
 
     return _windows_handle_path(msvcrt.get_osfhandle(file_descriptor))
@@ -1077,6 +1113,8 @@ def _normalized_windows_relative(path: str) -> str:
 
 
 def _close_windows_handle(handle: int) -> None:
+    if sys.platform != "win32":
+        raise OSError("Windows source handles are unavailable")
     import ctypes
 
     kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)

--- a/src/silobrief/state.py
+++ b/src/silobrief/state.py
@@ -6,6 +6,7 @@ import os
 import re
 import secrets
 import stat
+import sys
 import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, contextmanager
@@ -1069,6 +1070,8 @@ def _open_windows_handle(
     share_mode: int,
     flags: int,
 ) -> int:
+    if sys.platform != "win32":
+        raise OSError("Windows state handles are unavailable")
     import ctypes
     import msvcrt
 

--- a/tests/test_current_index.py
+++ b/tests/test_current_index.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 import unittest
 from dataclasses import replace
@@ -20,7 +21,7 @@ from silobrief.current_index import (
 from silobrief.index import config_digest
 from silobrief.initialization import initialize_index
 from silobrief.sources import SourceCollectionError, SourceWarning, snapshot_sources
-from silobrief.state import SetupError, load_config, setup_project
+from silobrief.state import STATE_DIRECTORY, SetupError, load_config, setup_project
 from silobrief.stored_index import StoredIndexError, load_stored_index
 
 V1_0_4_INDEX = Path(__file__).with_name("fixtures") / "index-v1.0.4-minimal.json"
@@ -182,6 +183,85 @@ class CurrentIndexTests(unittest.TestCase):
             self.assertTrue(result.changed)
             self.assertNotEqual(config_path.read_bytes(), config_before[0])
             self.assertTrue(load_stored_index(project).stale)
+
+    @unittest.skipUnless(sys.platform == "linux", "inotify requires Linux")
+    def test_approval_watch_remembers_rapid_root_and_state_replacements(self) -> None:
+        original_generation = current_index._file_generation
+        for target_name in ("root", "state"):
+            with self.subTest(target=target_name), tempfile.TemporaryDirectory() as directory:
+                base = Path(directory)
+                project = base / "project"
+                project.mkdir()
+                create_project(project)
+                target = project if target_name == "root" else project / STATE_DIRECTORY
+                backup = base / f"{target.name}-backup"
+                replacement = base / f"{target.name}-replacement"
+                replacement.mkdir()
+
+                def coarse_generation(
+                    metadata: os.stat_result,
+                ) -> current_index._FileGeneration:
+                    return replace(
+                        original_generation(metadata),
+                        modified_time_ns=0,
+                        changed_time_ns=0,
+                    )
+
+                with mock.patch.object(
+                    current_index,
+                    "_file_generation",
+                    side_effect=coarse_generation,
+                ):
+                    _, _, approval = load_current_index_for_approval(project)
+                    try:
+                        target.rename(backup)
+                        replacement.rename(target)
+                        target.rename(replacement)
+                        backup.rename(target)
+                        for _ in range(2):
+                            with self.assertRaisesRegex(
+                                CurrentIndexError,
+                                "settings changed during approval",
+                            ):
+                                revalidate_current_index_approval(project, approval)
+                    finally:
+                        approval.close()
+
+    @unittest.skipUnless(sys.platform == "linux", "inotify requires Linux")
+    def test_approval_watch_covers_state_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "project"
+            project.mkdir()
+            create_project(project)
+            state = project / STATE_DIRECTORY
+            backup = project / f"{STATE_DIRECTORY}-backup"
+            replacement = project / f"{STATE_DIRECTORY}-replacement"
+            replacement.mkdir()
+            original_open = current_index._open_entry
+
+            def open_then_replace(
+                path: Path,
+                name: str,
+                parent_descriptor: int | None,
+                is_directory: bool,
+            ) -> tuple[int, current_index._FileGeneration]:
+                opened = original_open(path, name, parent_descriptor, is_directory)
+                if name == STATE_DIRECTORY:
+                    state.rename(backup)
+                    replacement.rename(state)
+                    state.rename(replacement)
+                    backup.rename(state)
+                return opened
+
+            with (
+                mock.patch.object(
+                    current_index,
+                    "_open_entry",
+                    side_effect=open_then_replace,
+                ),
+                self.assertRaisesRegex(CurrentIndexError, "settings changed during approval"),
+            ):
+                load_current_index_for_approval(project)
 
     def test_v1_0_4_index_requires_init_before_it_can_be_used(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -178,7 +178,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
-        self.assertIn("## [1.0.5] - 2026-08-19", changelog)
+        self.assertIn("## [1.0.5] - 2026-08-21", changelog)
         self.assertIn("## [1.0.4] - 2026-08-19", changelog)
         self.assertIn("## [1.0.3] - 2026-08-18", changelog)
         self.assertIn("## [1.0.2] - 2026-08-17", changelog)

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import json
 import os
+import sys
 import tempfile
 import threading
 import unittest
@@ -510,6 +511,8 @@ class IgnoreCommandTests(unittest.TestCase):
             replacement.mkdir()
             self.assertTrue(state_module.setup_project(project))
             self.assertTrue(state_module.setup_project(replacement))
+            project = project.resolve(strict=True)
+            replacement = replacement.resolve(strict=True)
             state = project / ".silobrief"
             original_state = state.resolve(strict=True)
             replacement_state = replacement / ".silobrief"
@@ -614,6 +617,7 @@ class IgnoreCommandTests(unittest.TestCase):
             project = root / "project"
             project.mkdir()
             self.assertTrue(state_module.setup_project(project))
+            project = project.resolve(strict=True)
             target = project / ".silobrief" / "config.json"
             before = target.read_bytes()
             canary = root / "outside.json"
@@ -704,6 +708,7 @@ class IgnoreCommandTests(unittest.TestCase):
                 project = root / "project"
                 project.mkdir()
                 self.assertTrue(state_module.setup_project(project))
+                project = project.resolve(strict=True)
                 original_replace = state_module._replace_temporary_entry
                 mutation_kept_identity = False
 
@@ -917,6 +922,70 @@ class IgnoreCommandTests(unittest.TestCase):
                 {item["alias"] for item in items},
                 {"boundary-1", "boundary-2"},
             )
+
+    @unittest.skipUnless(os.name == "nt", "Windows byte-range lock test")
+    def test_initializes_an_empty_config_lock_only_after_acquiring_it(self) -> None:
+        if sys.platform != "win32":
+            return
+        import msvcrt
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            self.assertEqual(main(["setup", str(project)]), 0)
+            state = project / ".silobrief"
+            lock_path = state / ".config.lock"
+            lock_path.touch()
+            blocker = os.open(lock_path, os.O_RDWR)
+            lock_attempted = threading.Event()
+            initialized = threading.Event()
+            original_lock = boundary_commands._lock_descriptor
+            original_initialize = boundary_commands._ensure_lock_byte
+
+            def observed_lock(descriptor: int) -> None:
+                lock_attempted.set()
+                original_lock(descriptor)
+
+            def observed_initialize(descriptor: int) -> None:
+                initialized.set()
+                original_initialize(descriptor)
+
+            def acquire_lock() -> None:
+                with boundary_commands._config_update_lock(state, None):
+                    pass
+
+            os.lseek(blocker, 0, os.SEEK_SET)
+            msvcrt.locking(blocker, msvcrt.LK_NBLCK, 1)
+            locked = True
+            try:
+                with (
+                    mock.patch.object(
+                        boundary_commands,
+                        "_lock_descriptor",
+                        side_effect=observed_lock,
+                    ),
+                    mock.patch.object(
+                        boundary_commands,
+                        "_ensure_lock_byte",
+                        side_effect=observed_initialize,
+                    ),
+                    ThreadPoolExecutor(max_workers=1) as executor,
+                ):
+                    future = executor.submit(acquire_lock)
+                    reached_lock = lock_attempted.wait(timeout=2)
+                    initialized_while_locked = initialized.wait(timeout=0.1)
+                    os.lseek(blocker, 0, os.SEEK_SET)
+                    msvcrt.locking(blocker, msvcrt.LK_UNLCK, 1)
+                    locked = False
+                    future.result(timeout=5)
+                self.assertTrue(reached_lock)
+                self.assertFalse(initialized_while_locked)
+                self.assertTrue(initialized.is_set())
+                self.assertEqual(lock_path.read_bytes(), b"\0")
+            finally:
+                if locked:
+                    os.lseek(blocker, 0, os.SEEK_SET)
+                    msvcrt.locking(blocker, msvcrt.LK_UNLCK, 1)
+                os.close(blocker)
 
     @unittest.skipIf(os.name == "nt", "Windows prevents renaming an open lock file")
     def test_replacing_the_lock_file_does_not_bypass_posix_serialization(self) -> None:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -36,7 +36,7 @@ from silobrief.sources import (
     snapshot_sources,
 )
 from silobrief.state import ConfigData, SetupError, load_config, mark_index_stale, setup_project
-from tests.windows_junctions import directory_junction
+from tests.windows_junctions import directory_junction, short_windows_path, substituted_drive
 
 
 class TtyBuffer(io.StringIO):
@@ -443,7 +443,7 @@ class ApprovedOutputTests(unittest.TestCase):
 
             def write_then_change_policy(descriptor: int, content: bytes) -> None:
                 original_write(descriptor, content)
-                mark_index_stale(project)
+                mark_index_stale(project.resolve(strict=True))
 
             _, snapshot, approval_state = load_current_index_for_approval(project)
             try:
@@ -939,6 +939,48 @@ class ApprovedOutputTests(unittest.TestCase):
 
             self.assertTrue(swap_blocked)
             self.assertTrue((parent / "result.md").is_file())
+
+    @unittest.skipUnless(os.name == "nt", "substituted drives require Windows")
+    def test_accepts_a_stable_substituted_output_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            project = project_in(str(workspace))
+            outside = workspace / "external"
+            outside.mkdir()
+
+            with substituted_drive(workspace) as drive:
+                approve_and_write(
+                    project,
+                    str(drive / outside.name / "result.md"),
+                    rendered_brief(),
+                    start=project,
+                    input_stream=TtyBuffer("WRITE\n"),
+                    output_stream=TtyBuffer(),
+                )
+
+            self.assertTrue((outside / "result.md").is_file())
+
+    @unittest.skipUnless(os.name == "nt", "short paths require Windows")
+    def test_accepts_a_stable_short_output_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            project = project_in(str(workspace))
+            outside = workspace / "External Output With A Long Name"
+            outside.mkdir()
+            short_outside = short_windows_path(outside)
+            if os.path.normcase(str(short_outside)) == os.path.normcase(str(outside)):
+                self.skipTest("8.3 path aliases are disabled on this volume")
+
+            approve_and_write(
+                project,
+                str(short_outside / "result.md"),
+                rendered_brief(),
+                start=project,
+                input_stream=TtyBuffer("WRITE\n"),
+                output_stream=TtyBuffer(),
+            )
+
+            self.assertTrue((outside / "result.md").is_file())
 
     @unittest.skipIf(os.name == "nt", "POSIX permits renaming an open directory")
     def test_rejects_a_real_parent_replacement_after_protection(self) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -263,7 +263,7 @@ class SetupCommandTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
     def test_setup_locks_project_root_before_creating_state(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve(strict=True)
             project = root / "project"
             project.mkdir()
             state = project / ".silobrief"
@@ -312,7 +312,7 @@ class SetupCommandTests(unittest.TestCase):
 
     def test_setup_does_not_clean_a_replaced_real_state_directory(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve(strict=True)
             project = root / "project"
             replacement = root / "replacement"
             project.mkdir()
@@ -719,7 +719,7 @@ class SetupCommandTests(unittest.TestCase):
 
     def test_setup_binds_incomplete_exports_validation_to_one_directory(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            project = Path(directory)
+            project = Path(directory).resolve(strict=True)
             state = project / ".silobrief"
             exports = state / "exports"
             exports.mkdir(parents=True)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sys
 import tempfile
 import unittest
 from collections.abc import Iterator
@@ -20,7 +21,7 @@ from silobrief.sources import (
     snapshot_sources,
 )
 from silobrief.state import ConfigData, load_config, setup_project
-from tests.windows_junctions import directory_junction
+from tests.windows_junctions import directory_junction, short_windows_path, substituted_drive
 
 
 def file_digest(path: Path) -> str:
@@ -303,7 +304,7 @@ class SourceSnapshotTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "directory junctions require Windows")
     def test_snapshot_rejects_a_directory_replaced_during_scan(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve(strict=True)
             project = root / "project"
             project.mkdir()
             package = project / "package"
@@ -525,7 +526,7 @@ class SourceSnapshotTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "Windows boundary handles are required")
     def test_snapshot_binds_every_boundary_before_opening_the_first_handle(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            project = Path(directory)
+            project = Path(directory).resolve(strict=True)
             first = project / "boundary-a"
             first.mkdir()
             (first / "first.py").write_bytes(b"FIRST_BOUNDARY\n")
@@ -655,7 +656,7 @@ class SourceSnapshotTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "Windows boundary handles are required")
     def test_snapshot_binds_nested_boundary_ancestors_before_handles(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            project = Path(directory)
+            project = Path(directory).resolve(strict=True)
             private = project / "private"
             nested = private / "nested"
             nested.mkdir(parents=True)
@@ -978,7 +979,7 @@ class SourceSnapshotTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "Windows boundary handles are required")
     def test_snapshot_rejects_a_boundary_swap_while_binding_its_handle(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            project = Path(directory)
+            project = Path(directory).resolve(strict=True)
             package = project / "package"
             package.mkdir()
             (package / "safe.py").write_bytes(b"SAFE_SOURCE\n")
@@ -1040,7 +1041,7 @@ class SourceSnapshotTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "Windows boundary handles are required")
     def test_snapshot_rejects_a_boundary_removed_before_its_handle_opens(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            project = Path(directory)
+            project = Path(directory).resolve(strict=True)
             package = project / "package"
             package.mkdir()
             (package / "safe.py").write_bytes(b"SAFE_SOURCE\n")
@@ -1121,6 +1122,8 @@ class SourceSnapshotTests(unittest.TestCase):
 
     @unittest.skipUnless(os.name == "nt", "Windows handles are required")
     def test_windows_entry_enumeration_does_not_leak_handles(self) -> None:
+        if sys.platform != "win32":
+            return
         import ctypes
 
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
@@ -1180,6 +1183,54 @@ class SourceSnapshotTests(unittest.TestCase):
             snapshot = snapshot_sources(extended_project, config)
 
             self.assertEqual([source.path for source in snapshot.files], ["visible.py"])
+
+    @unittest.skipUnless(os.name == "nt", "substituted drives require Windows")
+    def test_snapshot_accepts_a_stable_substituted_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            project = workspace / "project"
+            project.mkdir()
+            private = project / "private"
+            private.mkdir()
+            (private / "secret.py").write_bytes(b"BOUNDARY_CANARY\n")
+            (project / "visible.py").write_bytes(b"VISIBLE\n")
+            setup_project(project)
+            register_boundary("private", "Private implementation", "private", start=project)
+            config = load_config(project)
+
+            with substituted_drive(workspace) as drive:
+                drive_snapshot = snapshot_sources(drive / project.name, config)
+
+            self.assertEqual([source.path for source in drive_snapshot.files], ["visible.py"])
+
+    @unittest.skipUnless(os.name == "nt", "short paths require Windows")
+    def test_snapshot_accepts_a_stable_short_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            project = workspace / "Project With A Long Name"
+            project.mkdir()
+            package = project / "package"
+            package.mkdir()
+            (package / "visible.py").write_bytes(b"VISIBLE\n")
+            setup_project(project)
+            config = load_config(project)
+            short_project = short_windows_path(project)
+            if os.path.normcase(str(short_project)) == os.path.normcase(str(project)):
+                self.skipTest("8.3 path aliases are disabled on this volume")
+
+            short_snapshot = snapshot_sources(short_project, config)
+            previous = Path.cwd()
+            os.chdir(short_project / package.name)
+            try:
+                cwd_snapshot = snapshot_sources(project.resolve(strict=True), config)
+            finally:
+                os.chdir(previous)
+
+            for snapshot in (short_snapshot, cwd_snapshot):
+                self.assertEqual(
+                    [source.path for source in snapshot.files],
+                    ["package/visible.py"],
+                )
 
     @unittest.skipUnless(os.name == "nt", "Windows UNC paths are required")
     def test_snapshot_accepts_an_extended_unc_project_path(self) -> None:

--- a/tests/windows_junctions.py
+++ b/tests/windows_junctions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -26,3 +27,43 @@ def directory_junction(link: Path, target: Path) -> Iterator[Path]:
             os.rmdir(link)
         except FileNotFoundError:
             pass
+
+
+@contextmanager
+def substituted_drive(target: Path) -> Iterator[Path]:
+    if os.name != "nt":
+        raise OSError("substituted drives require Windows")
+    drive: str | None = None
+    for letter in "ZYXWVUTSRQP":
+        candidate = f"{letter}:"
+        result = subprocess.run(
+            ["subst", candidate, str(target.resolve(strict=True))],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            drive = candidate
+            break
+    if drive is None:
+        raise OSError("cannot reserve a substituted drive for this test")
+    try:
+        yield Path(f"{drive}\\")
+    finally:
+        subprocess.run(["subst", drive, "/D"], check=True, capture_output=True, text=True)
+
+
+def short_windows_path(path: Path) -> Path:
+    if sys.platform != "win32":
+        raise OSError("short paths require Windows")
+    import ctypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    get_short_path = kernel32.GetShortPathNameW
+    get_short_path.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+    get_short_path.restype = ctypes.c_uint32
+    buffer = ctypes.create_unicode_buffer(32768)
+    length = get_short_path(str(path), buffer, len(buffer))
+    if length == 0 or length >= len(buffer):
+        raise OSError(ctypes.get_last_error(), "cannot resolve a short Windows path")
+    return Path(buffer.value)


### PR DESCRIPTION
## 변경 내용

v1.0.5 병합 직후 CI에서 확인된 플랫폼별 실패를 한 번에 정리했습니다.

- Linux strict mypy가 Windows 전용 API 본문을 검사하지 않도록 플랫폼 분기를 명확히 했습니다.
- Windows Actions의 8.3 경로와 SUBST 드라이브를 실제 디렉터리 핸들에 안전하게 연결합니다.
- 빈 Windows config lock은 byte lock을 얻은 뒤 초기화해 병렬 등록 경쟁을 막습니다.
- Linux 승인 과정은 root와 state 디렉터리를 FD 기준으로 감시해 빠른 교체도 놓치지 않습니다.
- v1.0.5 릴리스 날짜와 회귀 테스트를 현재 배포일에 맞췄습니다.

실패 기준: https://github.com/d3vksy/silobrief/actions/runs/32389220395

## 검증

- Ruff lint/format, strict mypy(host/Linux/Win32) 통과
- Windows Python 3.10 및 3.14: 각각 368 tests 통과
- WSL Python 3.12: 368 tests 통과
- Linux root/state ABA 핵심 회귀 100회 반복 통과
- Windows lock 및 경로 별칭 핵심 회귀 20회 반복 통과
- wheel/sdist 빌드 통과

Closes #216