### PR TITLE
fix(release): install test dependencies before publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install build tooling and package
         run: >-
           python -m pip install --disable-pip-version-check
-          "build>=1.2,<2" "setuptools>=77" .
+          "build>=1.2,<2" "setuptools>=77" ".[dev]"
 
       - name: Run release tests
         run: python -m unittest discover -s tests -q


### PR DESCRIPTION
## Why
The PyPI build ran the full test suite without installing its development dependencies. The Flask example test therefore failed before package build or upload.

## What changed
- install `.[dev]` in the release build job
- keep the published runtime dependencies unchanged

## Checks
- `python -m unittest discover -s tests -q`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy`

Refs #228