### PR TITLE
fix(release): install test dependencies before publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install build tooling and package
         run: >-
           python -m pip install --disable-pip-version-check
-          "build>=1.2,<2" "setuptools>=77" .
+          "build>=1.2,<2" "setuptools>=77" ".[dev]"
 
       - name: Run release tests
         run: python -m unittest discover -s tests -q


### PR DESCRIPTION
## Why
The first 1.2.0 publishing run stopped before build because its test environment did not include Flask.

## What changed
Install the existing development extras before running the release test suite. Runtime package dependencies are unchanged.

## Checks
The fix PR passed the full Ubuntu and Windows matrix on Python 3.10 and 3.14.