### PR TITLE
fix(example): move JWT secret to environment

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -65,6 +65,8 @@ cd silobrief-practice
 ```
 
 생성된 프로젝트는 SQLite를 사용하는 최소 Flask 회원가입·로그인 API입니다.
+`private/jwt.py`에는 JWT 생성·검증 함수가 있고, 로컬 서명 키는 Git에서 제외되는 `.env`에
+저장됩니다. 로그인 함수에는 아직 연결되지 않은 상태입니다.
 
 같은 디렉터리에서 첫 번째 과제를 시작합니다.
 
@@ -73,7 +75,7 @@ sb setup .
 sb language --cli ko --brief ko
 sb ignore private --as "JWT 설정"
 sb init
-sb log app.py --comment "JWT 서명 키는 private.jwt의 JWT_SECRET을 사용합니다."
+sb log app.py --comment "JWT 발급은 private.jwt.create_access_token(user_id, username)을 사용합니다."
 sb search "로그인 성공 응답"
 sb brief
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ sb example ./silobrief-practice
 cd silobrief-practice
 ```
 
-The generated project is a minimal Flask signup/login API backed by SQLite.
+The generated project is a minimal Flask signup/login API backed by SQLite. JWT creation and
+verification helpers live in `private/jwt.py`, while the local signing key is stored in the
+gitignored `.env` file. The login route does not use them yet.
 
 Start the first task from the same directory:
 
@@ -73,7 +75,7 @@ sb setup .
 sb language --cli en --brief en
 sb ignore private --as "JWT settings"
 sb init
-sb log app.py --comment "Use private.jwt.JWT_SECRET to sign JWTs."
+sb log app.py --comment "Use private.jwt.create_access_token(user_id, username) to issue a JWT."
 sb search "successful login response"
 sb brief
 ```

--- a/src/silobrief/example_project.py
+++ b/src/silobrief/example_project.py
@@ -9,7 +9,10 @@ class ExampleProjectError(Exception):
     pass
 
 
-_LOG_COMMAND = 'sb log app.py --comment "JWT 서명 키는 private.jwt의 JWT_SECRET을 사용합니다."'
+_LOG_COMMAND = (
+    'sb log app.py --comment "JWT 발급은 '
+    'private.jwt.create_access_token(user_id, username)을 사용합니다."'
+)
 _SEARCH_COMMAND = 'sb search "로그인 성공 응답"'
 _BRIEF_COMMAND = "sb brief"
 _TASK_REQUEST = (
@@ -35,6 +38,8 @@ POST /login   {{"username": "minsu", "password": "1234"}}
 ```
 
 비밀번호는 해시로 저장하며, 로그인 성공 시 아직 JWT를 발급하지 않습니다.
+`private/jwt.py`에는 토큰 생성·검증 함수가 준비되어 있고 서명 키는 `.env`에서 읽습니다.
+아직 로그인 함수에는 연결되지 않았으며 `requirements.txt`에도 PyJWT가 없습니다.
 
 siloBrief 시연은 아래 명령만 순서대로 실행합니다.
 
@@ -57,8 +62,8 @@ sb init
 `정보 추가`에서 `/file`로 `requirements.txt`를 고르고, `/func`로 `app.py`의 `login`을
 고른 뒤 Enter를 누릅니다.
 
-생성된 `.silobrief/exports/brief.md`를 확인하면 됩니다. 이 예제의 데이터베이스와
-서명 키는 실습 전용입니다.
+생성된 `.silobrief/exports/brief.md`를 확인하면 됩니다. `.env`의 서명 키는 로컬 실습
+전용이며 `.gitignore`에 등록되어 있습니다.
 """
 
 _FILES = (
@@ -127,13 +132,41 @@ if __name__ == "__main__":
     app.run()
 """,
     ),
-    ("requirements.txt", "Flask\n"),
-    (".gitignore", "users.db\n"),
+    ("requirements.txt", "Flask\npython-dotenv\n"),
+    (".env", "JWT_SECRET=demo-only-change-me\n"),
+    (".gitignore", ".env\nusers.db\n"),
     (
         "private/jwt.py",
         """from __future__ import annotations
 
-JWT_SECRET = "demo-only-change-me"
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import jwt
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+_ALGORITHM = "HS256"
+
+
+def _jwt_secret() -> str:
+    return os.environ["JWT_SECRET"]
+
+
+def create_access_token(user_id: int, username: str) -> str:
+    payload = {
+        "user_id": user_id,
+        "username": username,
+        "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+    }
+    return jwt.encode(payload, _jwt_secret(), algorithm=_ALGORITHM)
+
+
+def decode_access_token(access_token: str) -> dict[str, Any]:
+    return jwt.decode(access_token, _jwt_secret(), algorithms=[_ALGORITHM])
 """,
     ),
 )

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -61,6 +61,7 @@ class ExampleCommandTests(unittest.TestCase):
             self.assertEqual(
                 {path for path, _digest in file_manifest(project)},
                 {
+                    ".env",
                     ".gitignore",
                     "README.md",
                     "app.py",
@@ -124,7 +125,25 @@ assert denied.status_code == 401
             self.assertIn("generate_password_hash(password)", app_source)
             self.assertIn("check_password_hash(user[1], password)", app_source)
             self.assertNotIn("jwt.encode", app_source)
-            self.assertEqual((project / ".gitignore").read_text(encoding="utf-8"), "users.db\n")
+            jwt_source = (project / "private/jwt.py").read_text(encoding="utf-8")
+            self.assertIn("def create_access_token(user_id: int, username: str)", jwt_source)
+            self.assertIn("def decode_access_token(access_token: str)", jwt_source)
+            self.assertIn('os.environ["JWT_SECRET"]', jwt_source)
+            self.assertIn("jwt.encode", jwt_source)
+            self.assertIn("jwt.decode", jwt_source)
+            self.assertNotIn("demo-only-change-me", jwt_source)
+            self.assertEqual(
+                (project / "requirements.txt").read_text(encoding="utf-8"),
+                "Flask\npython-dotenv\n",
+            )
+            self.assertEqual(
+                (project / ".env").read_text(encoding="utf-8"),
+                "JWT_SECRET=demo-only-change-me\n",
+            )
+            self.assertEqual(
+                (project / ".gitignore").read_text(encoding="utf-8"),
+                ".env\nusers.db\n",
+            )
 
     def test_generation_is_byte_identical_and_uses_lf(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -177,7 +196,8 @@ assert denied.status_code == 401
                             "log",
                             "app.py",
                             "--comment",
-                            "JWT 서명 키는 private.jwt의 JWT_SECRET을 사용합니다.",
+                            "JWT 발급은 "
+                            "private.jwt.create_access_token(user_id, username)을 사용합니다.",
                         ]
                     ),
                     0,


### PR DESCRIPTION
## 관련 Issue

없음 (direct fix)

## 변경 이유

`develop`에서 검증된 JWT 예제 수정 사항을 `main`에 반영합니다.

## 변경 내용

- JWT 비밀값을 Git에서 제외되는 `.env`로 이동
- `private/jwt.py`에 토큰 발급·검증 함수 추가
- 한·영 README와 회귀 테스트 갱신

## 검증

- [x] develop 대상 PR #231의 필수 CI 4개 통과
- [x] 로컬 전체 테스트 통과: 378 passed, 28 skipped
- [x] lint 통과
