### PR TITLE
chore(release): publish v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-23
+
+### Fixed
+
+- Store the Flask practice project's JWT signing key in a gitignored `.env` file and provide
+  working token creation and verification helpers in `private/jwt.py`.
+
 ## [1.2.0] - 2026-08-23
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI 상태"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.2.0"><img src="https://img.shields.io/badge/release-v1.2.0-4f46e5" alt="릴리스 v1.2.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.2.1"><img src="https://img.shields.io/badge/release-v1.2.1-4f46e5" alt="릴리스 v1.2.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 이상"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 라이선스"></a>
 </p>
@@ -52,7 +52,7 @@ sb --version
 다음과 같이 출력되면 설치가 끝난 것입니다.
 
 ```text
-siloBrief 1.2.0
+siloBrief 1.2.1
 ```
 
 ### Flask 실습 예제
@@ -228,7 +228,7 @@ Ubuntu에서 브리프를 안전하게 저장하려면 출력 파일시스템이
 
 ## 검증 현황
 
-최신 공개 버전은 v1.2.0이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
+최신 공개 버전은 v1.2.1이며 1.x 호환성 규칙을 따릅니다. 고정된 검색 벤치마크에서 `sb search`는
 12개 과제 중 11개의 기대 심볼을 찾았고 평균 역순위는 72.2%였습니다. 후보 검색은 단어 기반
 제안입니다. 원하는 코드를 찾지 못하면 검토 중 정확한 Python 파일 상대 경로를 입력할 수
 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml"><img src="https://github.com/d3vksy/silobrief/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
-  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.2.0"><img src="https://img.shields.io/badge/release-v1.2.0-4f46e5" alt="Release v1.2.0"></a>
+  <a href="https://github.com/d3vksy/silobrief/releases/tag/v1.2.1"><img src="https://img.shields.io/badge/release-v1.2.1-4f46e5" alt="Release v1.2.1"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-3776ab" alt="Python 3.10 or newer"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-0f766e" alt="Apache 2.0 license"></a>
 </p>
@@ -52,7 +52,7 @@ sb --version
 Expected output:
 
 ```text
-siloBrief 1.2.0
+siloBrief 1.2.1
 ```
 
 ### Flask practice project
@@ -231,7 +231,7 @@ project and output location to the WSL Linux filesystem.
 
 ## Validation status
 
-The latest public release is v1.2.0 and follows the supported 1.x compatibility contract. In the
+The latest public release is v1.2.1 and follows the supported 1.x compatibility contract. In the
 frozen retrieval benchmark, `sb search` reaches an expected symbol for 11 of 12 tasks, with a mean
 reciprocal rank of 72.2%. Candidate search is lexical and advisory. When it misses, use the exact
 indexed Python file path during review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "silobrief"
-version = "1.2.0"
+version = "1.2.1"
 description = "Create reviewed research briefs from Python project context"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,6 +30,8 @@ dev = [
     "build>=1.2",
     "Flask",
     "mypy>=1.15",
+    "PyJWT",
+    "python-dotenv",
     "ruff>=0.11",
     "setuptools>=77",
 ]

--- a/src/silobrief/example_project.py
+++ b/src/silobrief/example_project.py
@@ -73,6 +73,7 @@ _FILES = (
         """from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 from flask import Flask, request
@@ -83,13 +84,14 @@ DATABASE_PATH = Path(__file__).with_name("users.db")
 
 
 def init_db() -> None:
-    with sqlite3.connect(DATABASE_PATH) as database:
+    with closing(sqlite3.connect(DATABASE_PATH)) as database:
         database.execute(
             "CREATE TABLE IF NOT EXISTS users ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
             "username TEXT UNIQUE NOT NULL, "
             "password_hash TEXT NOT NULL)"
         )
+        database.commit()
 
 
 @app.post("/signup")
@@ -101,11 +103,12 @@ def signup():
         return {"error": "아이디와 비밀번호가 필요합니다."}, 400
 
     try:
-        with sqlite3.connect(DATABASE_PATH) as database:
+        with closing(sqlite3.connect(DATABASE_PATH)) as database:
             database.execute(
                 "INSERT INTO users (username, password_hash) VALUES (?, ?)",
                 (username, generate_password_hash(password)),
             )
+            database.commit()
     except sqlite3.IntegrityError:
         return {"error": "이미 존재하는 아이디입니다."}, 409
     return {"message": "회원가입 성공"}, 201
@@ -113,11 +116,12 @@ def signup():
 
 @app.post("/login")
 def login():
+    '''아이디와 비밀번호를 확인해 로그인 성공 응답을 반환합니다.'''
     data = request.get_json(silent=True) or {}
     username = str(data.get("username", "")).strip()
     password = str(data.get("password", ""))
 
-    with sqlite3.connect(DATABASE_PATH) as database:
+    with closing(sqlite3.connect(DATABASE_PATH)) as database:
         user = database.execute(
             "SELECT id, password_hash FROM users WHERE username = ?",
             (username,),
@@ -133,7 +137,7 @@ if __name__ == "__main__":
 """,
     ),
     ("requirements.txt", "Flask\npython-dotenv\n"),
-    (".env", "JWT_SECRET=demo-only-change-me\n"),
+    (".env", "JWT_SECRET=demo-only-change-me-use-at-least-32-bytes\n"),
     (".gitignore", ".env\nusers.db\n"),
     (
         "private/jwt.py",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,4 +185,4 @@ class VersionCommandTests(unittest.TestCase):
             main(["--version"])
 
         self.assertEqual(caught.exception.code, 0)
-        self.assertEqual(stdout.getvalue(), "siloBrief 1.2.0\n")
+        self.assertEqual(stdout.getvalue(), "siloBrief 1.2.1\n")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -88,8 +88,8 @@ SAFETY_EXPECTATIONS = {
     ),
 }
 VALIDATION_EXPECTATIONS = {
-    "README.md": ("v1.2.0", "1.x", "11 of 12", "72.2%"),
-    "README.ko.md": ("v1.2.0", "1.x", "12개 과제 중 11개", "72.2%"),
+    "README.md": ("v1.2.1", "1.x", "11 of 12", "72.2%"),
+    "README.ko.md": ("v1.2.1", "1.x", "12개 과제 중 11개", "72.2%"),
 }
 VALIDATION_PROJECTS = ("Django Ninja", "pytest", "Jinja")
 VALIDATION_LINKS = (
@@ -194,6 +194,7 @@ class ReleaseDocumentationTests(unittest.TestCase):
     def test_v1_release_metadata_is_current(self) -> None:
         changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         self.assertIn("## [Unreleased]", changelog)
+        self.assertIn("## [1.2.1] - 2026-08-23", changelog)
         self.assertIn("## [1.2.0] - 2026-08-23", changelog)
         self.assertIn("## [1.0.5] - 2026-08-21", changelog)
         self.assertIn("## [1.0.4] - 2026-08-19", changelog)
@@ -235,8 +236,8 @@ class ReleaseDocumentationTests(unittest.TestCase):
         self.assertNotIn("public GitHub profile", conduct)
 
         pyproject = (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-        self.assertEqual(pyproject.count('version = "1.2.0"'), 1)
-        self.assertEqual(version("silobrief"), "1.2.0")
+        self.assertEqual(pyproject.count('version = "1.2.1"'), 1)
+        self.assertEqual(version("silobrief"), "1.2.1")
 
     def test_public_fixture_link_points_to_an_existing_file(self) -> None:
         self.assertTrue((REPOSITORY_ROOT / FIXTURE_README).is_file())

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -95,11 +95,13 @@ assert denied.status_code == 401
             behavior = subprocess.run(
                 [sys.executable, "-c", behavior_script],
                 cwd=project,
+                env={**os.environ, "PYTHONWARNINGS": "error"},
                 check=False,
                 capture_output=True,
                 text=True,
             )
             self.assertEqual(behavior.returncode, 0, behavior.stdout + behavior.stderr)
+            self.assertNotIn("ResourceWarning", behavior.stderr)
 
             readme = (project / "README.md").read_text(encoding="utf-8")
             for expected in (
@@ -121,7 +123,9 @@ assert denied.status_code == 401
             app_source = (project / "app.py").read_text(encoding="utf-8")
             self.assertIn('@app.post("/signup")', app_source)
             self.assertIn('@app.post("/login")', app_source)
+            self.assertIn("로그인 성공 응답을 반환합니다.", app_source)
             self.assertIn("sqlite3.connect(DATABASE_PATH)", app_source)
+            self.assertIn("closing(sqlite3.connect(DATABASE_PATH))", app_source)
             self.assertIn("generate_password_hash(password)", app_source)
             self.assertIn("check_password_hash(user[1], password)", app_source)
             self.assertNotIn("jwt.encode", app_source)
@@ -132,13 +136,44 @@ assert denied.status_code == 401
             self.assertIn("jwt.encode", jwt_source)
             self.assertIn("jwt.decode", jwt_source)
             self.assertNotIn("demo-only-change-me", jwt_source)
+
+            jwt_environment = os.environ.copy()
+            jwt_environment.pop("JWT_SECRET", None)
+            jwt_environment["PYTHONWARNINGS"] = "error"
+            jwt_behavior_script = """
+from datetime import datetime, timezone
+
+from private.jwt import create_access_token, decode_access_token
+
+token = create_access_token(7, "minsu")
+payload = decode_access_token(token)
+remaining_seconds = payload["exp"] - datetime.now(timezone.utc).timestamp()
+assert isinstance(token, str)
+assert set(payload) == {"user_id", "username", "exp"}
+assert payload["user_id"] == 7
+assert payload["username"] == "minsu"
+assert 3500 <= remaining_seconds <= 3600
+"""
+            jwt_behavior = subprocess.run(
+                [sys.executable, "-c", jwt_behavior_script],
+                cwd=project,
+                env=jwt_environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                jwt_behavior.returncode,
+                0,
+                jwt_behavior.stdout + jwt_behavior.stderr,
+            )
             self.assertEqual(
                 (project / "requirements.txt").read_text(encoding="utf-8"),
                 "Flask\npython-dotenv\n",
             )
             self.assertEqual(
                 (project / ".env").read_text(encoding="utf-8"),
-                "JWT_SECRET=demo-only-change-me\n",
+                "JWT_SECRET=demo-only-change-me-use-at-least-32-bytes\n",
             )
             self.assertEqual(
                 (project / ".gitignore").read_text(encoding="utf-8"),
@@ -188,20 +223,34 @@ assert denied.status_code == 401
 
             with working_directory(project):
                 self.assertEqual(main(["setup", "."]), 0)
-                self.assertEqual(main(["ignore", "private", "--as", "JWT 설정"]), 0)
-                self.assertEqual(main(["init"]), 0)
-                self.assertEqual(
-                    main(
-                        [
-                            "log",
-                            "app.py",
-                            "--comment",
-                            "JWT 발급은 "
-                            "private.jwt.create_access_token(user_id, username)을 사용합니다.",
-                        ]
-                    ),
-                    0,
-                )
+                workflow_stdout = io.StringIO()
+                with contextlib.redirect_stdout(workflow_stdout):
+                    self.assertEqual(
+                        main(["language", "--cli", "ko", "--brief", "ko"]),
+                        0,
+                    )
+                    self.assertEqual(
+                        main(["ignore", "private", "--as", "JWT 설정"]),
+                        0,
+                    )
+                    self.assertEqual(main(["init"]), 0)
+                search_stdout = io.StringIO()
+                with contextlib.redirect_stdout(search_stdout):
+                    self.assertEqual(main(["search", "로그인 성공 응답"]), 0)
+                self.assertIn("login", search_stdout.getvalue())
+                with contextlib.redirect_stdout(workflow_stdout):
+                    self.assertEqual(
+                        main(
+                            [
+                                "log",
+                                "app.py",
+                                "--comment",
+                                "JWT 발급은 "
+                                "private.jwt.create_access_token(user_id, username)을 사용합니다.",
+                            ]
+                        ),
+                        0,
+                    )
                 stdin = TtyBuffer(review_input)
                 stdout = TtyBuffer()
                 stderr = io.StringIO()
@@ -223,9 +272,11 @@ assert denied.status_code == 401
             self.assertTrue(brief.is_file())
             content = brief.read_text(encoding="utf-8")
             self.assertIn(prompt, content)
-            self.assertIn("function: login", content)
+            self.assertIn("함수: login", content)
             self.assertIn("def login(", content)
             self.assertIn("source_delivery: embedded", content)
+            self.assertIn("private.jwt.create_access_token", content)
+            self.assertNotIn("def create_access_token", content)
             self.assertNotIn("demo-only-change-me", content)
             self.assertFalse(brief.with_name("brief.sources.md").exists())
 


### PR DESCRIPTION
siloBrief 1.2.1 릴리스 반영. 로컬 전체 테스트와 Ubuntu/Windows Python 3.10/3.14 CI를 통과했습니다.